### PR TITLE
feat: Add Stalwart mail server for jasonernst.com

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -54,3 +54,7 @@ java_runner:
 nas:
   hosts:
     nas.local:
+mail:
+  hosts:
+    # Add mail.jasonernst.com after terraform apply creates the droplet
+    # mail.jasonernst.com:

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -56,5 +56,4 @@ nas:
     nas.local:
 mail:
   hosts:
-    # Add mail.jasonernst.com after terraform apply creates the droplet
-    # mail.jasonernst.com:
+    mail.jasonernst.com:

--- a/ansible/mail.yml
+++ b/ansible/mail.yml
@@ -1,6 +1,9 @@
 ---
 # Mail server deployment playbook
 # Usage: ansible-playbook -i inventory.yml mail.yml
+#
+# Requires 1Password CLI (op) authenticated and item 'stalwart-admin' in Infrastructure vault
+# with fields: username, password
 
 - name: Deploy Stalwart Mail Server
   hosts: mail
@@ -8,8 +11,9 @@
   vars:
     stalwart_domain: jasonernst.com
     stalwart_hostname: mail.jasonernst.com
-    # Admin password - retrieve from 1Password
-    # stalwart_admin_password: "{{ lookup('community.general.onepassword', 'stalwart-admin', field='password') }}"
+    # Admin credentials from 1Password (Infrastructure vault)
+    stalwart_admin_user: "{{ lookup('community.general.onepassword', 'stalwart-admin', field='username', vault='Infrastructure') }}"
+    stalwart_admin_password: "{{ lookup('community.general.onepassword', 'stalwart-admin', field='password', vault='Infrastructure') }}"
   roles:
     - common_cli
     - stalwart

--- a/ansible/mail.yml
+++ b/ansible/mail.yml
@@ -1,0 +1,15 @@
+---
+# Mail server deployment playbook
+# Usage: ansible-playbook -i inventory.yml mail.yml
+
+- name: Deploy Stalwart Mail Server
+  hosts: mail
+  become: true
+  vars:
+    stalwart_domain: jasonernst.com
+    stalwart_hostname: mail.jasonernst.com
+    # Admin password - retrieve from 1Password
+    # stalwart_admin_password: "{{ lookup('community.general.onepassword', 'stalwart-admin', field='password') }}"
+  roles:
+    - common_cli
+    - stalwart

--- a/ansible/roles/stalwart/README.md
+++ b/ansible/roles/stalwart/README.md
@@ -4,19 +4,26 @@ Installs and configures [Stalwart Mail Server](https://stalw.art/) - a modern, f
 
 ## Features
 
-- SMTP (port 25, 587, 465)
-- IMAP (port 143, 993)
-- Web admin interface
+- SMTP (port 25, 587 with STARTTLS, 465 implicit TLS)
+- IMAP (port 143 with STARTTLS, 993 implicit TLS)
+- Web interface on HTTPS (443)
 - Let's Encrypt TLS via ACME
-- DKIM signing
+- DKIM signing (ed25519)
 - Spam filtering via Sieve
 - Fail2ban integration
+- Runs as dedicated `stalwart` user (not root)
 
 ## Requirements
 
 - Ubuntu 20.04+ (22.04 or 24.04 recommended)
-- Open ports: 25, 587, 465, 143, 993, 443, 8080
+- Open ports: 22, 25, 587, 465, 143, 993, 80, 443
 - Valid DNS records (MX, SPF, DKIM, DMARC)
+
+## Security
+
+- Runs as unprivileged `stalwart` user with `CAP_NET_BIND_SERVICE`
+- Management interface bound to localhost only (access via SSH tunnel)
+- Systemd hardening: `NoNewPrivileges`, `ProtectSystem`, `PrivateTmp`
 
 ## Role Variables
 
@@ -25,22 +32,26 @@ See `defaults/main.yml` for all available variables.
 Key variables:
 - `stalwart_domain`: Your mail domain (e.g., `jasonernst.com`)
 - `stalwart_hostname`: Mail server FQDN (e.g., `mail.jasonernst.com`)
-- `stalwart_admin_password`: Admin password (store in 1Password)
 
 ## Post-Installation
 
-1. Access admin panel at `https://mail.jasonernst.com:8080`
-
-2. Generate DKIM key:
+1. SSH tunnel to access admin panel:
    ```bash
-   stalwart-cli -u https://localhost:8080 dkim generate stalwart jasonernst.com
+   ssh -L 8080:localhost:8080 root@mail.jasonernst.com
    ```
 
-3. Update DKIM DNS record with the generated public key
+2. Open http://localhost:8080 in your browser
 
-4. Create user accounts:
+3. Create domain and generate DKIM key:
    ```bash
-   stalwart-cli -u https://localhost:8080 account create kai@jasonernst.com
+   stalwart-cli -u http://localhost:8080 domain create jasonernst.com
+   ```
+
+4. Update DKIM DNS record in Terraform with the generated public key
+
+5. Create user accounts:
+   ```bash
+   stalwart-cli -u http://localhost:8080 account create kai@jasonernst.com
    ```
 
 ## Testing
@@ -52,10 +63,18 @@ telnet mail.jasonernst.com 25
 # Test IMAP with TLS
 openssl s_client -connect mail.jasonernst.com:993
 
+# Test STARTTLS on submission
+openssl s_client -starttls smtp -connect mail.jasonernst.com:587
+
 # Send test email
 swaks --to test@example.com --from kai@jasonernst.com --server mail.jasonernst.com:587 --tls
 ```
 
 ## DNS Records Required
 
-See `terraform/mail.tf` for the DNS records that need to be configured.
+See `terraform/mail.tf` for the DNS records that need to be configured:
+- A/AAAA records for mail.jasonernst.com
+- MX record pointing to mail subdomain
+- SPF record (`v=spf1 mx -all`)
+- DMARC record
+- DKIM record (update after key generation)

--- a/ansible/roles/stalwart/README.md
+++ b/ansible/roles/stalwart/README.md
@@ -42,23 +42,25 @@ Key variables:
 
 ## Post-Installation
 
+Admin account is pre-configured from 1Password (`stalwart-admin` item in Infrastructure vault).
+
 1. SSH tunnel to access admin panel:
    ```bash
    ssh -L 8080:localhost:8080 root@mail.jasonernst.com
    ```
 
-2. Open http://localhost:8080 in your browser
+2. Open http://localhost:8080 and login with your 1Password credentials
 
 3. Create domain and generate DKIM key:
    ```bash
-   stalwart-cli -u http://localhost:8080 domain create jasonernst.com
+   stalwart-cli -u http://localhost:8080 -c admin:<password> domain create jasonernst.com
    ```
 
 4. Update DKIM DNS record in Terraform with the generated public key
 
 5. Create user accounts:
    ```bash
-   stalwart-cli -u http://localhost:8080 account create kai@jasonernst.com
+   stalwart-cli -u http://localhost:8080 -c admin:<password> account create kai@jasonernst.com
    ```
 
 ## Testing

--- a/ansible/roles/stalwart/README.md
+++ b/ansible/roles/stalwart/README.md
@@ -1,0 +1,61 @@
+# Stalwart Mail Server Role
+
+Installs and configures [Stalwart Mail Server](https://stalw.art/) - a modern, fast, and secure all-in-one mail server.
+
+## Features
+
+- SMTP (port 25, 587, 465)
+- IMAP (port 143, 993)
+- Web admin interface
+- Let's Encrypt TLS via ACME
+- DKIM signing
+- Spam filtering via Sieve
+- Fail2ban integration
+
+## Requirements
+
+- Ubuntu 20.04+ (22.04 or 24.04 recommended)
+- Open ports: 25, 587, 465, 143, 993, 443, 8080
+- Valid DNS records (MX, SPF, DKIM, DMARC)
+
+## Role Variables
+
+See `defaults/main.yml` for all available variables.
+
+Key variables:
+- `stalwart_domain`: Your mail domain (e.g., `jasonernst.com`)
+- `stalwart_hostname`: Mail server FQDN (e.g., `mail.jasonernst.com`)
+- `stalwart_admin_password`: Admin password (store in 1Password)
+
+## Post-Installation
+
+1. Access admin panel at `https://mail.jasonernst.com:8080`
+
+2. Generate DKIM key:
+   ```bash
+   stalwart-cli -u https://localhost:8080 dkim generate stalwart jasonernst.com
+   ```
+
+3. Update DKIM DNS record with the generated public key
+
+4. Create user accounts:
+   ```bash
+   stalwart-cli -u https://localhost:8080 account create kai@jasonernst.com
+   ```
+
+## Testing
+
+```bash
+# Test SMTP
+telnet mail.jasonernst.com 25
+
+# Test IMAP with TLS
+openssl s_client -connect mail.jasonernst.com:993
+
+# Send test email
+swaks --to test@example.com --from kai@jasonernst.com --server mail.jasonernst.com:587 --tls
+```
+
+## DNS Records Required
+
+See `terraform/mail.tf` for the DNS records that need to be configured.

--- a/ansible/roles/stalwart/README.md
+++ b/ansible/roles/stalwart/README.md
@@ -2,6 +2,13 @@
 
 Installs and configures [Stalwart Mail Server](https://stalw.art/) - a modern, fast, and secure all-in-one mail server.
 
+## Version
+
+Currently pinned to **v0.15.4** with SHA256 checksum verification.
+
+To update: change `stalwart_version` and checksums in `defaults/main.yml`.
+Get checksums from [GitHub releases](https://github.com/stalwartlabs/mail-server/releases).
+
 ## Features
 
 - SMTP (port 25, 587 with STARTTLS, 465 implicit TLS)

--- a/ansible/roles/stalwart/defaults/main.yml
+++ b/ansible/roles/stalwart/defaults/main.yml
@@ -16,9 +16,10 @@ stalwart_hostname: "mail.jasonernst.com"
 # Data directory
 stalwart_data_dir: "/opt/stalwart-mail"
 
-# Admin credentials - override in vault/1password
+# Admin credentials - MUST be set via 1Password lookup in playbook
+# These are configured in [authentication.fallback-admin] section
 stalwart_admin_user: "admin"
-# stalwart_admin_password: set via 1password
+stalwart_admin_password: ""  # Required - set in mail.yml from 1Password
 
 # DKIM selector
 stalwart_dkim_selector: "stalwart"

--- a/ansible/roles/stalwart/defaults/main.yml
+++ b/ansible/roles/stalwart/defaults/main.yml
@@ -1,7 +1,15 @@
 ---
 # Stalwart Mail Server defaults
 
-stalwart_version: "latest"
+# Version pinning for reproducible builds
+stalwart_version: "0.15.4"
+stalwart_server_checksum: "sha256:6e4bd106b36554fa461f831fc477b55888f8b8b30b5a509bcdbd62dcf633a4ba"
+stalwart_cli_checksum: "sha256:6b66782a1862121e94e1956f35d0dae70ca90203c8843eed1945971a7ec45c29"
+
+# Download URLs (GitHub releases)
+stalwart_server_url: "https://github.com/stalwartlabs/stalwart/releases/download/v{{ stalwart_version }}/stalwart-x86_64-unknown-linux-gnu.tar.gz"
+stalwart_cli_url: "https://github.com/stalwartlabs/stalwart/releases/download/v{{ stalwart_version }}/stalwart-cli-x86_64-unknown-linux-gnu.tar.gz"
+
 stalwart_domain: "jasonernst.com"
 stalwart_hostname: "mail.jasonernst.com"
 

--- a/ansible/roles/stalwart/defaults/main.yml
+++ b/ansible/roles/stalwart/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+# Stalwart Mail Server defaults
+
+stalwart_version: "latest"
+stalwart_domain: "jasonernst.com"
+stalwart_hostname: "mail.jasonernst.com"
+
+# Data directory
+stalwart_data_dir: "/opt/stalwart-mail"
+
+# Admin credentials - override in vault/1password
+stalwart_admin_user: "admin"
+# stalwart_admin_password: set via 1password
+
+# DKIM selector
+stalwart_dkim_selector: "stalwart"
+
+# TLS - use Let's Encrypt via ACME
+stalwart_acme_enabled: true
+stalwart_acme_contact: "postmaster@{{ stalwart_domain }}"
+
+# Ports
+stalwart_smtp_port: 25
+stalwart_submission_port: 587
+stalwart_submissions_port: 465
+stalwart_imap_port: 143
+stalwart_imaps_port: 993
+stalwart_http_port: 443
+stalwart_http_management_port: 8080

--- a/ansible/roles/stalwart/handlers/main.yml
+++ b/ansible/roles/stalwart/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Reload systemd
+  become: true
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Restart stalwart
+  become: true
+  ansible.builtin.systemd:
+    name: stalwart-mail
+    state: restarted

--- a/ansible/roles/stalwart/meta/main.yml
+++ b/ansible/roles/stalwart/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: Kai (via compscidr/iac)
+  description: Install and configure Stalwart Mail Server
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+        - noble
+
+dependencies:
+  - common_cli

--- a/ansible/roles/stalwart/tasks/main.yml
+++ b/ansible/roles/stalwart/tasks/main.yml
@@ -30,6 +30,7 @@
     group: stalwart
   loop:
     - "{{ stalwart_data_dir }}"
+    - "{{ stalwart_data_dir }}/bin"
     - "{{ stalwart_data_dir }}/etc"
     - "{{ stalwart_data_dir }}/etc/dkim"
     - "{{ stalwart_data_dir }}/etc/certs"
@@ -37,30 +38,62 @@
     - "{{ stalwart_data_dir }}/queue"
     - "{{ stalwart_data_dir }}/reports"
 
-- name: Check if Stalwart is already installed
+- name: Check if Stalwart server is already installed
   ansible.builtin.stat:
     path: /usr/local/bin/stalwart-mail
   register: stalwart_binary
 
-- name: Download and install Stalwart
+- name: Download and install Stalwart (with checksum verification)
   become: true
   when: not stalwart_binary.stat.exists
   block:
-    - name: Download Stalwart install script
+    - name: Download Stalwart server tarball
       ansible.builtin.get_url:
-        url: https://get.stalw.art/install.sh
-        dest: /tmp/stalwart-install.sh
-        mode: '0755'
-      # Note: Checksum verification recommended for production
-      # checksum: "sha256:{{ stalwart_install_checksum }}"
+        url: "{{ stalwart_server_url }}"
+        dest: /tmp/stalwart-server.tar.gz
+        mode: '0644'
+        checksum: "{{ stalwart_server_checksum }}"
 
-    - name: Run Stalwart installer
-      ansible.builtin.shell: |
-        /tmp/stalwart-install.sh --prefix {{ stalwart_data_dir }} --component all-in-one
-      args:
-        creates: /usr/local/bin/stalwart-mail
+    - name: Download Stalwart CLI tarball
+      ansible.builtin.get_url:
+        url: "{{ stalwart_cli_url }}"
+        dest: /tmp/stalwart-cli.tar.gz
+        mode: '0644'
+        checksum: "{{ stalwart_cli_checksum }}"
 
-    - name: Fix ownership after install
+    - name: Extract Stalwart server
+      ansible.builtin.unarchive:
+        src: /tmp/stalwart-server.tar.gz
+        dest: "{{ stalwart_data_dir }}/bin"
+        remote_src: true
+
+    - name: Extract Stalwart CLI
+      ansible.builtin.unarchive:
+        src: /tmp/stalwart-cli.tar.gz
+        dest: "{{ stalwart_data_dir }}/bin"
+        remote_src: true
+
+    - name: Create symlink for stalwart-mail
+      ansible.builtin.file:
+        src: "{{ stalwart_data_dir }}/bin/stalwart-mail"
+        dest: /usr/local/bin/stalwart-mail
+        state: link
+
+    - name: Create symlink for stalwart-cli
+      ansible.builtin.file:
+        src: "{{ stalwart_data_dir }}/bin/stalwart-cli"
+        dest: /usr/local/bin/stalwart-cli
+        state: link
+
+    - name: Clean up downloaded tarballs
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /tmp/stalwart-server.tar.gz
+        - /tmp/stalwart-cli.tar.gz
+
+    - name: Fix ownership
       ansible.builtin.file:
         path: "{{ stalwart_data_dir }}"
         state: directory
@@ -128,7 +161,9 @@
 - name: Display post-install instructions
   ansible.builtin.debug:
     msg: |
-      Stalwart Mail Server installed successfully!
+      Stalwart Mail Server v{{ stalwart_version }} installed successfully!
+      
+      Binaries verified with SHA256 checksum.
       
       Next steps:
       1. SSH tunnel to access admin: ssh -L 8080:localhost:8080 root@{{ stalwart_hostname }}

--- a/ansible/roles/stalwart/tasks/main.yml
+++ b/ansible/roles/stalwart/tasks/main.yml
@@ -1,0 +1,112 @@
+---
+# Stalwart Mail Server installation and configuration
+
+- name: Install required packages
+  become: true
+  ansible.builtin.apt:
+    name:
+      - curl
+      - ca-certificates
+      - ufw
+    state: present
+    update_cache: true
+
+- name: Create stalwart data directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ stalwart_data_dir }}"
+    state: directory
+    mode: '0755'
+    owner: root
+    group: root
+
+- name: Check if Stalwart is already installed
+  ansible.builtin.stat:
+    path: /usr/local/bin/stalwart-mail
+  register: stalwart_binary
+
+- name: Download and install Stalwart
+  become: true
+  when: not stalwart_binary.stat.exists
+  block:
+    - name: Download Stalwart install script
+      ansible.builtin.get_url:
+        url: https://get.stalw.art/install.sh
+        dest: /tmp/stalwart-install.sh
+        mode: '0755'
+
+    - name: Run Stalwart installer
+      ansible.builtin.shell: |
+        /tmp/stalwart-install.sh --prefix {{ stalwart_data_dir }} --component all-in-one
+      args:
+        creates: /usr/local/bin/stalwart-mail
+
+- name: Configure UFW for mail services
+  become: true
+  community.general.ufw:
+    rule: allow
+    port: "{{ item }}"
+    proto: tcp
+  loop:
+    - "{{ stalwart_smtp_port }}"
+    - "{{ stalwart_submission_port }}"
+    - "{{ stalwart_submissions_port }}"
+    - "{{ stalwart_imap_port }}"
+    - "{{ stalwart_imaps_port }}"
+    - "{{ stalwart_http_port }}"
+    - "{{ stalwart_http_management_port }}"
+    - "22"  # SSH
+
+- name: Enable UFW
+  become: true
+  community.general.ufw:
+    state: enabled
+    policy: deny
+
+- name: Deploy Stalwart configuration
+  become: true
+  ansible.builtin.template:
+    src: config.toml.j2
+    dest: "{{ stalwart_data_dir }}/etc/config.toml"
+    mode: '0640'
+    owner: root
+    group: root
+  notify: Restart stalwart
+
+- name: Create systemd service file
+  become: true
+  ansible.builtin.template:
+    src: stalwart-mail.service.j2
+    dest: /etc/systemd/system/stalwart-mail.service
+    mode: '0644'
+  notify:
+    - Reload systemd
+    - Restart stalwart
+
+- name: Enable and start Stalwart service
+  become: true
+  ansible.builtin.systemd:
+    name: stalwart-mail
+    enabled: true
+    state: started
+    daemon_reload: true
+
+- name: Wait for Stalwart to be ready
+  ansible.builtin.wait_for:
+    port: "{{ stalwart_http_management_port }}"
+    timeout: 60
+
+- name: Display post-install instructions
+  ansible.builtin.debug:
+    msg: |
+      Stalwart Mail Server installed successfully!
+      
+      Next steps:
+      1. Access admin panel: https://{{ stalwart_hostname }}:{{ stalwart_http_management_port }}
+      2. Generate DKIM key: stalwart-cli -u https://localhost:{{ stalwart_http_management_port }} dkim generate {{ stalwart_dkim_selector }} {{ stalwart_domain }}
+      3. Update the DKIM DNS record in Terraform with the generated public key
+      4. Create user accounts via admin panel or CLI
+      
+      Test commands:
+      - Check SMTP: telnet {{ stalwart_hostname }} 25
+      - Check IMAP: openssl s_client -connect {{ stalwart_hostname }}:993

--- a/ansible/roles/stalwart/tasks/main.yml
+++ b/ansible/roles/stalwart/tasks/main.yml
@@ -164,12 +164,13 @@
       Stalwart Mail Server v{{ stalwart_version }} installed successfully!
       
       Binaries verified with SHA256 checksum.
+      Admin account pre-configured from 1Password (user: {{ stalwart_admin_user }})
       
       Next steps:
       1. SSH tunnel to access admin: ssh -L 8080:localhost:8080 root@{{ stalwart_hostname }}
-      2. Open http://localhost:8080 in browser
+      2. Open http://localhost:8080 in browser (login with 1Password credentials)
       3. Generate DKIM key via admin UI or CLI:
-         stalwart-cli -u http://localhost:8080 domain create {{ stalwart_domain }}
+         stalwart-cli -u http://localhost:8080 -c {{ stalwart_admin_user }}:<password> domain create {{ stalwart_domain }}
       4. Update the DKIM DNS record in Terraform with the generated public key
       5. Create user accounts (e.g., kai@{{ stalwart_domain }}, jason@{{ stalwart_domain }})
       

--- a/ansible/roles/stalwart/tasks/main.yml
+++ b/ansible/roles/stalwart/tasks/main.yml
@@ -171,7 +171,7 @@
       3. Generate DKIM key via admin UI or CLI:
          stalwart-cli -u http://localhost:8080 domain create {{ stalwart_domain }}
       4. Update the DKIM DNS record in Terraform with the generated public key
-      5. Create user accounts (e.g., kai@{{ stalwart_domain }})
+      5. Create user accounts (e.g., kai@{{ stalwart_domain }}, jason@{{ stalwart_domain }})
       
       Test commands:
       - Check SMTP: telnet {{ stalwart_hostname }} 25

--- a/ansible/roles/stalwart/tasks/main.yml
+++ b/ansible/roles/stalwart/tasks/main.yml
@@ -11,14 +11,31 @@
     state: present
     update_cache: true
 
-- name: Create stalwart data directory
+- name: Create stalwart system user
+  become: true
+  ansible.builtin.user:
+    name: stalwart
+    system: true
+    shell: /usr/sbin/nologin
+    home: "{{ stalwart_data_dir }}"
+    create_home: false
+
+- name: Create stalwart directories
   become: true
   ansible.builtin.file:
-    path: "{{ stalwart_data_dir }}"
+    path: "{{ item }}"
     state: directory
     mode: '0755'
-    owner: root
-    group: root
+    owner: stalwart
+    group: stalwart
+  loop:
+    - "{{ stalwart_data_dir }}"
+    - "{{ stalwart_data_dir }}/etc"
+    - "{{ stalwart_data_dir }}/etc/dkim"
+    - "{{ stalwart_data_dir }}/etc/certs"
+    - "{{ stalwart_data_dir }}/data"
+    - "{{ stalwart_data_dir }}/queue"
+    - "{{ stalwart_data_dir }}/reports"
 
 - name: Check if Stalwart is already installed
   ansible.builtin.stat:
@@ -34,12 +51,22 @@
         url: https://get.stalw.art/install.sh
         dest: /tmp/stalwart-install.sh
         mode: '0755'
+      # Note: Checksum verification recommended for production
+      # checksum: "sha256:{{ stalwart_install_checksum }}"
 
     - name: Run Stalwart installer
       ansible.builtin.shell: |
         /tmp/stalwart-install.sh --prefix {{ stalwart_data_dir }} --component all-in-one
       args:
         creates: /usr/local/bin/stalwart-mail
+
+    - name: Fix ownership after install
+      ansible.builtin.file:
+        path: "{{ stalwart_data_dir }}"
+        state: directory
+        recurse: true
+        owner: stalwart
+        group: stalwart
 
 - name: Configure UFW for mail services
   become: true
@@ -54,8 +81,10 @@
     - "{{ stalwart_imap_port }}"
     - "{{ stalwart_imaps_port }}"
     - "{{ stalwart_http_port }}"
-    - "{{ stalwart_http_management_port }}"
-    - "22"  # SSH
+    - "80"   # HTTP for ACME challenges
+    - "22"   # SSH
+
+# Management port (8080) intentionally NOT opened - use SSH tunnel
 
 - name: Enable UFW
   become: true
@@ -69,8 +98,8 @@
     src: config.toml.j2
     dest: "{{ stalwart_data_dir }}/etc/config.toml"
     mode: '0640'
-    owner: root
-    group: root
+    owner: stalwart
+    group: stalwart
   notify: Restart stalwart
 
 - name: Create systemd service file
@@ -93,7 +122,7 @@
 
 - name: Wait for Stalwart to be ready
   ansible.builtin.wait_for:
-    port: "{{ stalwart_http_management_port }}"
+    port: "{{ stalwart_smtp_port }}"
     timeout: 60
 
 - name: Display post-install instructions
@@ -102,10 +131,12 @@
       Stalwart Mail Server installed successfully!
       
       Next steps:
-      1. Access admin panel: https://{{ stalwart_hostname }}:{{ stalwart_http_management_port }}
-      2. Generate DKIM key: stalwart-cli -u https://localhost:{{ stalwart_http_management_port }} dkim generate {{ stalwart_dkim_selector }} {{ stalwart_domain }}
-      3. Update the DKIM DNS record in Terraform with the generated public key
-      4. Create user accounts via admin panel or CLI
+      1. SSH tunnel to access admin: ssh -L 8080:localhost:8080 root@{{ stalwart_hostname }}
+      2. Open http://localhost:8080 in browser
+      3. Generate DKIM key via admin UI or CLI:
+         stalwart-cli -u http://localhost:8080 domain create {{ stalwart_domain }}
+      4. Update the DKIM DNS record in Terraform with the generated public key
+      5. Create user accounts (e.g., kai@{{ stalwart_domain }})
       
       Test commands:
       - Check SMTP: telnet {{ stalwart_hostname }} 25

--- a/ansible/roles/stalwart/templates/config.toml.j2
+++ b/ansible/roles/stalwart/templates/config.toml.j2
@@ -1,0 +1,143 @@
+# Stalwart Mail Server Configuration
+# Managed by Ansible - do not edit directly
+
+[server]
+hostname = "{{ stalwart_hostname }}"
+max-connections = 8192
+
+[server.listener.smtp]
+bind = ["[::]:{{ stalwart_smtp_port }}"]
+protocol = "smtp"
+
+[server.listener.submission]
+bind = ["[::]:{{ stalwart_submission_port }}"]
+protocol = "smtp"
+
+[server.listener.submissions]
+bind = ["[::]:{{ stalwart_submissions_port }}"]
+protocol = "smtp"
+tls.implicit = true
+
+[server.listener.imap]
+bind = ["[::]:{{ stalwart_imap_port }}"]
+protocol = "imap"
+
+[server.listener.imaps]
+bind = ["[::]:{{ stalwart_imaps_port }}"]
+protocol = "imap"
+tls.implicit = true
+
+[server.listener.https]
+bind = ["[::]:{{ stalwart_http_port }}"]
+protocol = "http"
+tls.implicit = true
+
+[server.listener.management]
+bind = ["[::]:{{ stalwart_http_management_port }}"]
+protocol = "http"
+
+# Storage configuration
+[store."rocksdb"]
+type = "rocksdb"
+path = "{{ stalwart_data_dir }}/data"
+
+[storage]
+data = "rocksdb"
+fts = "rocksdb"
+blob = "rocksdb"
+lookup = "rocksdb"
+directory = "internal"
+
+# Internal directory for user management
+[directory."internal"]
+type = "internal"
+store = "rocksdb"
+
+# ACME (Let's Encrypt) for TLS certificates
+{% if stalwart_acme_enabled %}
+[acme."letsencrypt"]
+directory = "https://acme-v02.api.letsencrypt.org/directory"
+contact = ["mailto:{{ stalwart_acme_contact }}"]
+domains = ["{{ stalwart_hostname }}"]
+challenge = "tls-alpn-01"
+
+[certificate."default"]
+cert = "%{file:{{ stalwart_data_dir }}/etc/certs/{{ stalwart_hostname }}.crt}%"
+private-key = "%{file:{{ stalwart_data_dir }}/etc/certs/{{ stalwart_hostname }}.key}%"
+default = true
+{% endif %}
+
+# Authentication
+[authentication]
+fail2ban = "101/1d"
+
+[session.auth]
+mechanisms = ["PLAIN", "LOGIN"]
+directory = "internal"
+
+# DKIM signing
+[signature."{{ stalwart_dkim_selector }}"]
+private-key = "%{file:{{ stalwart_data_dir }}/etc/dkim/{{ stalwart_domain }}.key}%"
+domain = "{{ stalwart_domain }}"
+selector = "{{ stalwart_dkim_selector }}"
+headers = ["From", "To", "Date", "Subject", "Message-ID"]
+algorithm = "ed25519-sha256"
+canonicalization = "relaxed/relaxed"
+set-body-length = false
+report = true
+
+# Spam filtering with Sieve
+[sieve.trusted]
+from-name = "Sieve Daemon"
+from-addr = "sieve@{{ stalwart_domain }}"
+return-path = ""
+hostname = "{{ stalwart_hostname }}"
+no-capability-check = false
+
+[sieve.trusted.limits]
+name-length = 512
+max-scripts = 256
+script-size = 102400
+string-length = 4096
+variable-name-length = 32
+variable-size = 4096
+nested-blocks = 15
+nested-tests = 15
+nested-foreverypart = 3
+match-variables = 30
+local-variables = 128
+header-size = 1024
+includes = 3
+nested-includes = 3
+cpu = 5000
+redirects = 1
+received-headers = 10
+outgoing-messages = 3
+
+# Queue configuration
+[queue]
+path = "{{ stalwart_data_dir }}/queue"
+
+[queue.schedule]
+retry = "[2m, 5m, 10m, 15m, 30m, 1h, 2h]"
+notify = "[1d, 3d]"
+expire = "5d"
+
+# Reporting
+[report]
+path = "{{ stalwart_data_dir }}/reports"
+
+[report.analysis]
+addresses = ["postmaster@{{ stalwart_domain }}"]
+
+# Logging
+[tracing."stdout"]
+type = "stdout"
+level = "info"
+ansi = false
+enable = true
+
+[tracing."journal"]
+type = "journal"
+level = "info"
+enable = true

--- a/ansible/roles/stalwart/templates/config.toml.j2
+++ b/ansible/roles/stalwart/templates/config.toml.j2
@@ -12,6 +12,7 @@ protocol = "smtp"
 [server.listener.submission]
 bind = ["[::]:{{ stalwart_submission_port }}"]
 protocol = "smtp"
+tls.implicit = false  # STARTTLS required for secure auth
 
 [server.listener.submissions]
 bind = ["[::]:{{ stalwart_submissions_port }}"]
@@ -32,8 +33,10 @@ bind = ["[::]:{{ stalwart_http_port }}"]
 protocol = "http"
 tls.implicit = true
 
+# Management interface - localhost only for security
+# Access via SSH tunnel: ssh -L 8080:localhost:8080 root@mail.jasonernst.com
 [server.listener.management]
-bind = ["[::]:{{ stalwart_http_management_port }}"]
+bind = ["127.0.0.1:{{ stalwart_http_management_port }}"]
 protocol = "http"
 
 # Storage configuration
@@ -60,10 +63,11 @@ directory = "https://acme-v02.api.letsencrypt.org/directory"
 contact = ["mailto:{{ stalwart_acme_contact }}"]
 domains = ["{{ stalwart_hostname }}"]
 challenge = "tls-alpn-01"
+renew-before = "30d"
 
 [certificate."default"]
-cert = "%{file:{{ stalwart_data_dir }}/etc/certs/{{ stalwart_hostname }}.crt}%"
-private-key = "%{file:{{ stalwart_data_dir }}/etc/certs/{{ stalwart_hostname }}.key}%"
+acme = "letsencrypt"
+domains = ["{{ stalwart_hostname }}"]
 default = true
 {% endif %}
 
@@ -75,7 +79,8 @@ fail2ban = "101/1d"
 mechanisms = ["PLAIN", "LOGIN"]
 directory = "internal"
 
-# DKIM signing
+# DKIM signing - key generated post-install via stalwart-cli
+# Run: stalwart-cli -u http://localhost:8080 domain create jasonernst.com
 [signature."{{ stalwart_dkim_selector }}"]
 private-key = "%{file:{{ stalwart_data_dir }}/etc/dkim/{{ stalwart_domain }}.key}%"
 domain = "{{ stalwart_domain }}"

--- a/ansible/roles/stalwart/templates/config.toml.j2
+++ b/ansible/roles/stalwart/templates/config.toml.j2
@@ -3,7 +3,7 @@
 
 [server]
 hostname = "{{ stalwart_hostname }}"
-max-connections = 8192
+max-connections = 1024  # Conservative for 512MB RAM
 
 [server.listener.smtp]
 bind = ["[::]:{{ stalwart_smtp_port }}"]

--- a/ansible/roles/stalwart/templates/config.toml.j2
+++ b/ansible/roles/stalwart/templates/config.toml.j2
@@ -75,6 +75,11 @@ default = true
 [authentication]
 fail2ban = "101/1d"
 
+# Fallback admin account - configured via Ansible from 1Password
+[authentication.fallback-admin]
+user = "{{ stalwart_admin_user }}"
+secret = "{{ stalwart_admin_password }}"
+
 [session.auth]
 mechanisms = ["PLAIN", "LOGIN"]
 directory = "internal"

--- a/ansible/roles/stalwart/templates/stalwart-mail.service.j2
+++ b/ansible/roles/stalwart/templates/stalwart-mail.service.j2
@@ -1,0 +1,22 @@
+[Unit]
+Description=Stalwart Mail Server
+After=network.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+ExecStart=/usr/local/bin/stalwart-mail --config {{ stalwart_data_dir }}/etc/config.toml
+Restart=always
+RestartSec=5
+LimitNOFILE=65535
+
+# Security hardening
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+ReadWritePaths={{ stalwart_data_dir }}
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/stalwart/templates/stalwart-mail.service.j2
+++ b/ansible/roles/stalwart/templates/stalwart-mail.service.j2
@@ -4,12 +4,16 @@ After=network.target
 
 [Service]
 Type=simple
-User=root
-Group=root
+User=stalwart
+Group=stalwart
 ExecStart=/usr/local/bin/stalwart-mail --config {{ stalwart_data_dir }}/etc/config.toml
 Restart=always
 RestartSec=5
 LimitNOFILE=65535
+
+# Allow binding to privileged ports without root
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
 # Security hardening
 NoNewPrivileges=yes

--- a/terraform/mail.tf
+++ b/terraform/mail.tf
@@ -5,7 +5,7 @@ resource "digitalocean_droplet" "mail-jasonernst-com" {
   image    = "ubuntu-24-04-x64"
   name     = "mail-jasonernst-com"
   region   = "sfo2"
-  size     = "s-1vcpu-2gb"
+  size     = "s-1vcpu-512mb-10gb"  # $4/mo - sufficient for Stalwart with 2 users
   ipv6     = true
   vpc_uuid = digitalocean_vpc.www-jasonernst-vpc.id
   ssh_keys = [28506911]

--- a/terraform/mail.tf
+++ b/terraform/mail.tf
@@ -68,6 +68,94 @@ resource "digitalocean_record" "TXT-DKIM" {
 # This is critical for email deliverability
 # Note: DigitalOcean automatically sets PTR to droplet name if it matches a domain you own
 
+# DigitalOcean Cloud Firewall for mail server
+resource "digitalocean_firewall" "mail" {
+  name = "mail-jasonernst-com-fw"
+
+  droplet_ids = [digitalocean_droplet.mail-jasonernst-com.id]
+
+  # SSH
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "22"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  # SMTP (inbound mail from other servers)
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "25"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  # Submission (client mail submission)
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "587"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  # SMTPS (implicit TLS submission)
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "465"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  # IMAP
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "143"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  # IMAPS (implicit TLS)
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "993"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  # HTTPS (webmail/admin)
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "443"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  # HTTP (ACME challenges)
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "80"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  # Management UI (consider restricting to your IP)
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "8080"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  # Allow all outbound
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "icmp"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+}
+
 output "mail_droplet_ip" {
   value = digitalocean_droplet.mail-jasonernst-com.ipv4_address
 }

--- a/terraform/mail.tf
+++ b/terraform/mail.tf
@@ -1,0 +1,77 @@
+# Mail server infrastructure for jasonernst.com
+# Uses Stalwart Mail Server
+
+resource "digitalocean_droplet" "mail-jasonernst-com" {
+  image    = "ubuntu-24-04-x64"
+  name     = "mail-jasonernst-com"
+  region   = "sfo2"
+  size     = "s-1vcpu-2gb"
+  ipv6     = true
+  vpc_uuid = digitalocean_vpc.www-jasonernst-vpc.id
+  ssh_keys = [28506911]
+
+  tags = ["mail", "jasonernst-com"]
+}
+
+# A record for mail.jasonernst.com
+resource "digitalocean_record" "A-mail" {
+  domain = digitalocean_domain.default.name
+  type   = "A"
+  name   = "mail"
+  value  = digitalocean_droplet.mail-jasonernst-com.ipv4_address
+}
+
+# AAAA record for mail.jasonernst.com (IPv6)
+resource "digitalocean_record" "AAAA-mail" {
+  domain = digitalocean_domain.default.name
+  type   = "AAAA"
+  name   = "mail"
+  value  = digitalocean_droplet.mail-jasonernst-com.ipv6_address
+}
+
+# MX record - mail.jasonernst.com handles mail for jasonernst.com
+resource "digitalocean_record" "MX" {
+  domain   = digitalocean_domain.default.name
+  type     = "MX"
+  name     = "@"
+  value    = "mail.jasonernst.com."
+  priority = 10
+}
+
+# SPF record - authorize mail server to send on behalf of domain
+resource "digitalocean_record" "TXT-SPF" {
+  domain = digitalocean_domain.default.name
+  type   = "TXT"
+  name   = "@"
+  value  = "v=spf1 mx a:mail.jasonernst.com -all"
+}
+
+# DMARC record - policy for handling failed authentication
+resource "digitalocean_record" "TXT-DMARC" {
+  domain = digitalocean_domain.default.name
+  type   = "TXT"
+  name   = "_dmarc"
+  value  = "v=DMARC1; p=quarantine; rua=mailto:postmaster@jasonernst.com; ruf=mailto:postmaster@jasonernst.com; fo=1"
+}
+
+# DKIM record - placeholder, update after Stalwart generates the key
+# Run: stalwart-cli dkim generate <selector> jasonernst.com
+# Then update this value with the generated public key
+resource "digitalocean_record" "TXT-DKIM" {
+  domain = digitalocean_domain.default.name
+  type   = "TXT"
+  name   = "stalwart._domainkey"
+  value  = "v=DKIM1; k=rsa; p=REPLACE_WITH_GENERATED_PUBLIC_KEY"
+}
+
+# Reverse DNS (PTR) - set via DigitalOcean console or API
+# This is critical for email deliverability
+# Note: DigitalOcean automatically sets PTR to droplet name if it matches a domain you own
+
+output "mail_droplet_ip" {
+  value = digitalocean_droplet.mail-jasonernst-com.ipv4_address
+}
+
+output "mail_droplet_ipv6" {
+  value = digitalocean_droplet.mail-jasonernst-com.ipv6_address
+}


### PR DESCRIPTION
## Summary
Adds infrastructure for self-hosted email at `mail.jasonernst.com` using [Stalwart Mail Server](https://stalw.art/).

## Changes

### Terraform (`terraform/mail.tf`)
- New DigitalOcean droplet: `mail-jasonernst-com` (s-1vcpu-2gb, sfo2)
- DNS records:
  - A/AAAA for `mail.jasonernst.com`
  - MX record pointing to mail subdomain
  - SPF record authorizing mail server
  - DMARC policy (quarantine mode)
  - DKIM placeholder (update after key generation)

### Ansible
- New `stalwart` role with:
  - Automated installation via official script
  - Systemd service with security hardening
  - ACME/Let's Encrypt TLS
  - UFW firewall configuration
  - DKIM signing setup
- New `mail.yml` playbook
- Updated `inventory.yml` with mail group

## Deployment Steps

1. `terraform apply` to create droplet and DNS records
2. Update `inventory.yml` with the new droplet IP
3. `ansible-playbook -i inventory.yml mail.yml`
4. Generate DKIM key and update Terraform
5. Create user accounts (e.g., `kai@jasonernst.com`)

## Post-Deployment
See `ansible/roles/stalwart/README.md` for detailed instructions.

---
*PR created by Kai 🌊*