### PR TITLE
fix: Rename duplicate TXT record resources

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -65,7 +65,7 @@ resource "digitalocean_record" "CNAME-dev" {
   value = "@"
 }
 
-resource "digitalocean_record" "txt" {
+resource "digitalocean_record" "TXT-keybase" {
   domain = digitalocean_domain.default.name
   type = "TXT"
   name = "@"
@@ -73,7 +73,7 @@ resource "digitalocean_record" "txt" {
 }
 
 # maven verification record
-resource "digitalocean_record" "txt" {
+resource "digitalocean_record" "TXT-maven" {
   domain = digitalocean_domain.default.name
   type = "TXT"
   name = "@"


### PR DESCRIPTION
Pre-existing bug: two `digitalocean_record` resources were both named `txt`, causing Terraform to fail.

**Fix:** Renamed to unique names:
- `txt` → `TXT-keybase` (keybase verification)
- `txt` → `TXT-maven` (maven verification)

**Note:** After merging, you'll need to import the existing state or let Terraform recreate them:
```bash
terraform state mv digitalocean_record.txt digitalocean_record.TXT-keybase
# Or just let terraform apply recreate them (brief DNS blip)
```