### PR TITLE
fix: set explicit Tailscale hostnames to match domains

### DIFF
--- a/terraform/cloud-init/tailscale.yml
+++ b/terraform/cloud-init/tailscale.yml
@@ -6,4 +6,4 @@ package_update: true
 
 runcmd:
   - curl -fsSL https://tailscale.com/install.sh | sh
-  - tailscale up --authkey=${tailscale_authkey} --ssh
+  - tailscale up --authkey=${tailscale_authkey} --hostname=${hostname} --ssh

--- a/terraform/jasonernst-com.tf
+++ b/terraform/jasonernst-com.tf
@@ -16,6 +16,7 @@ resource "digitalocean_droplet" "www-jasonernst-com" {
 
   user_data = templatefile("${path.module}/cloud-init/tailscale.yml", {
     tailscale_authkey = data.onepassword_item.tailscale.credential
+    hostname          = "www.jasonernst.com"
   })
 }
 

--- a/terraform/mail.tf
+++ b/terraform/mail.tf
@@ -14,6 +14,7 @@ resource "digitalocean_droplet" "mail-jasonernst-com" {
 
   user_data = templatefile("${path.module}/cloud-init/tailscale.yml", {
     tailscale_authkey = data.onepassword_item.tailscale.credential
+    hostname          = "mail.jasonernst.com"
   })
 }
 

--- a/terraform/projects.tf
+++ b/terraform/projects.tf
@@ -24,6 +24,7 @@ resource "digitalocean_droplet" "projects" {
 
   user_data = templatefile("${path.module}/cloud-init/tailscale.yml", {
     tailscale_authkey = data.onepassword_item.tailscale.credential
+    hostname          = "projects.jasonernst.com"
   })
 }
 


### PR DESCRIPTION
Sets Tailscale hostname via cloud-init so machines show up as:
- www.jasonernst.com
- mail.jasonernst.com  
- projects.jasonernst.com

Instead of www-jasonernst-com, mail-jasonernst-com, projects