### PR TITLE
fix: use short Tailscale hostnames

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -1,13 +1,13 @@
 # Local hosts use .local (mDNS) - works on LAN even if Tailscale is down
-# Cloud hosts use FQDN
+# Cloud hosts use Tailscale short names (www, mail, projects)
 # Use --limit 'ubuntu-beast*' to match by prefix
 
 ungrouped:
   hosts:
-    jasonernst.com:
+    www:
     nas.local:
-    mail.jasonernst.com:
-    projects.jasonernst.com:
+    mail:
+    projects:
 
 academic_gui:
   hosts:

--- a/ansible/jasonernst_com.yml
+++ b/ansible/jasonernst_com.yml
@@ -1,6 +1,6 @@
 ---
 - name: Services for www.jasonernst.com
-  hosts: jasonernst.com
+  hosts: www
   vars_files:
     - vars/deb_arch.yml
     - vars/user.yml

--- a/ansible/mail.yml
+++ b/ansible/mail.yml
@@ -6,7 +6,7 @@
 # with fields: username, password
 
 - name: Deploy Stalwart Mail Server
-  hosts: mail.jasonernst.com
+  hosts: mail
   become: true
   vars:
     stalwart_domain: jasonernst.com

--- a/ansible/projects.yml
+++ b/ansible/projects.yml
@@ -3,7 +3,7 @@
 # Usage: ansible-playbook -i inventory.yml projects.yml
 
 - name: Deploy projects
-  hosts: projects.jasonernst.com
+  hosts: projects
   vars_files:
     - vars/user.yml
   roles:

--- a/terraform/jasonernst-com.tf
+++ b/terraform/jasonernst-com.tf
@@ -16,7 +16,7 @@ resource "digitalocean_droplet" "www-jasonernst-com" {
 
   user_data = templatefile("${path.module}/cloud-init/tailscale.yml", {
     tailscale_authkey = data.onepassword_item.tailscale.credential
-    hostname          = "www.jasonernst.com"
+    hostname          = "www"
   })
 }
 

--- a/terraform/mail.tf
+++ b/terraform/mail.tf
@@ -14,7 +14,7 @@ resource "digitalocean_droplet" "mail-jasonernst-com" {
 
   user_data = templatefile("${path.module}/cloud-init/tailscale.yml", {
     tailscale_authkey = data.onepassword_item.tailscale.credential
-    hostname          = "mail.jasonernst.com"
+    hostname          = "mail"
   })
 }
 

--- a/terraform/projects.tf
+++ b/terraform/projects.tf
@@ -24,7 +24,7 @@ resource "digitalocean_droplet" "projects" {
 
   user_data = templatefile("${path.module}/cloud-init/tailscale.yml", {
     tailscale_authkey = data.onepassword_item.tailscale.credential
-    hostname          = "projects.jasonernst.com"
+    hostname          = "projects"
   })
 }
 


### PR DESCRIPTION
Use short names (www, mail, projects) instead of FQDNs since Tailscale converts dots to dashes.