### PR TITLE
chore: update dotfiles commit (service account switching)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ ansible-playbook -i inventory.yml common.yml --limit <hostname> --ask-become-pas
 │     Terraform       │       │      Ansible        │
 │  (cloud resources)  │       │   (configuration)   │
 ├─────────────────────┤       ├─────────────────────┤
-│ • Droplets          │       │ • bootstrap (all)   │
+│ • Droplets          │       │ • bootstrap         │
 │ • DNS records       │       │ • common_cli        │
 │ • Firewalls         │       │ • dev / dev_gui     │
 │ • VPCs              │       │ • media_server      │

--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ ansible-playbook -i inventory.yml common.yml --limit <hostname> --ask-become-pas
 │     Terraform       │       │      Ansible        │
 │  (cloud resources)  │       │   (configuration)   │
 ├─────────────────────┤       ├─────────────────────┤
-│ • Droplets          │       │ • bootstrap role    │
-│ • DNS records       │       │   (servers)         │
-│ • Firewalls         │       │ • common_cli role   │
-│ • VPCs              │       │   (workstations)    │
-│ • Cloud-init        │       │                     │
-│   (Tailscale)       │       │                     │
+│ • Droplets          │       │ • bootstrap (all)   │
+│ • DNS records       │       │ • common_cli        │
+│ • Firewalls         │       │ • dev / dev_gui     │
+│ • VPCs              │       │ • media_server      │
+│ • Cloud-init        │       │ • projects          │
+│   (Tailscale)       │       │ • jasonernst_com    │
 └─────────────────────┘       └─────────────────────┘
 ```
 

--- a/ansible/roles/common_cli/tasks/main.yml
+++ b/ansible/roles/common_cli/tasks/main.yml
@@ -629,7 +629,7 @@
     repo: git@github.com:compscidr/dotfiles.git
     dest: ~/dotfiles
     # Pinned commit adds service account token switching + npm-global PATH
-    version: 17dbe626b7f2e48e15d518c6e7513fbd6f77e6f0
+    version: b93601386e1ee952d46a6cb8d55124e31c48ca0a
 
 - name: Test .bashrc file to see if its a symlink
   tags: dotfile

--- a/ansible/roles/common_cli/tasks/main.yml
+++ b/ansible/roles/common_cli/tasks/main.yml
@@ -628,8 +628,8 @@
   ansible.builtin.git:
     repo: git@github.com:compscidr/dotfiles.git
     dest: ~/dotfiles
-    # Pinned commit adds host completions for ansible/ssh + 1Password aliases
-    version: db0b6d19751265214f23f0e94535b794ad1f1ef2
+    # Pinned commit adds service account token switching for 1Password
+    version: 49042043ccd73d5fdd3c61ae9082f126af3da664
 
 - name: Test .bashrc file to see if its a symlink
   tags: dotfile

--- a/ansible/roles/common_cli/tasks/main.yml
+++ b/ansible/roles/common_cli/tasks/main.yml
@@ -628,8 +628,8 @@
   ansible.builtin.git:
     repo: git@github.com:compscidr/dotfiles.git
     dest: ~/dotfiles
-    # Pinned commit adds service account token switching for 1Password
-    version: 49042043ccd73d5fdd3c61ae9082f126af3da664
+    # Pinned commit adds service account token switching + npm-global PATH
+    version: 17dbe626b7f2e48e15d518c6e7513fbd6f77e6f0
 
 - name: Test .bashrc file to see if its a symlink
   tags: dotfile


### PR DESCRIPTION
Updates dotfiles to include the new op-personal/op-work functions that use service account tokens instead of interactive signin.