### PR TITLE
chore: update Slack to 4.47.69

### DIFF
--- a/ansible/roles/common_gui/tasks/main.yml
+++ b/ansible/roles/common_gui/tasks/main.yml
@@ -181,7 +181,7 @@
   tags: slack
   become: true
   ansible.builtin.apt:
-    deb: https://downloads.slack-edge.com/desktop-releases/linux/x64/4.43.51/slack-desktop-4.43.51-amd64.deb
+    deb: https://downloads.slack-edge.com/desktop-releases/linux/x64/4.47.69/slack-desktop-4.47.69-amd64.deb
   when: ansible_os_family == "Debian"
 
 - name: Install slack (macOS)


### PR DESCRIPTION
Updates the hardcoded Slack version from 4.43.51 to 4.47.69.