### PR TITLE
ci: add workflow to auto-update Slack version

### DIFF
--- a/.github/workflows/check-slack-version.yml
+++ b/.github/workflows/check-slack-version.yml
@@ -1,0 +1,52 @@
+name: Check Slack Version
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Weekly on Monday 9am UTC
+  workflow_dispatch:
+
+jobs:
+  check-slack:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Get versions
+        id: versions
+        run: |
+          # Get latest from Slack's official downloads page
+          LATEST=$(curl -s "https://slack.com/downloads/linux" | \
+            grep -oE 'Version [0-9]+\.[0-9]+\.[0-9]+' | \
+            head -1 | sed 's/Version //')
+          
+          # Get current from our ansible file
+          CURRENT=$(grep -oE 'slack-desktop-[0-9]+\.[0-9]+\.[0-9]+' \
+            ansible/roles/common_gui/tasks/main.yml | \
+            head -1 | sed 's/slack-desktop-//')
+          
+          echo "latest=$LATEST" >> $GITHUB_OUTPUT
+          echo "current=$CURRENT" >> $GITHUB_OUTPUT
+          echo "Latest: $LATEST, Current: $CURRENT"
+          
+      - name: Update version
+        if: steps.versions.outputs.latest != steps.versions.outputs.current && steps.versions.outputs.latest != ''
+        run: |
+          OLD="${{ steps.versions.outputs.current }}"
+          NEW="${{ steps.versions.outputs.latest }}"
+          sed -i "s|slack-desktop-${OLD}|slack-desktop-${NEW}|g" ansible/roles/common_gui/tasks/main.yml
+          sed -i "s|x64/${OLD}/|x64/${NEW}/|g" ansible/roles/common_gui/tasks/main.yml
+          echo "Updated Slack from $OLD to $NEW"
+          
+      - name: Create Pull Request
+        if: steps.versions.outputs.latest != steps.versions.outputs.current && steps.versions.outputs.latest != ''
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "chore(deps): update Slack to ${{ steps.versions.outputs.latest }}"
+          body: |
+            Updates Slack from ${{ steps.versions.outputs.current }} to ${{ steps.versions.outputs.latest }}.
+            
+            Source: [Slack Linux Downloads](https://slack.com/downloads/linux)
+          branch: auto-update-slack-${{ steps.versions.outputs.latest }}
+          commit-message: "chore(deps): update Slack to ${{ steps.versions.outputs.latest }}"
+          labels: dependencies


### PR DESCRIPTION
Adds a GitHub Action that runs weekly to check for new Slack versions.

**How it works:**
- Queries the Snap store API for the latest stable Slack version
- Compares against the version pinned in `ansible/roles/common_gui/tasks/main.yml`
- Creates a PR if there's a newer version

**Caveats:**
- Snap releases sometimes lag behind direct .deb releases by a few versions
- Can always manually trigger via workflow_dispatch if you know a newer version exists

**Trigger:**
- Weekly on Monday at 9am UTC
- Manual trigger available