### PR TITLE
fix: use bash as default shell for ansible

### DIFF
--- a/ansible/group_vars/linux.yml
+++ b/ansible/group_vars/linux.yml
@@ -1,0 +1,4 @@
+# Linux-specific settings
+# Use bash explicitly to support bash-specific features like 'set -o pipefail'
+# (Ubuntu's /bin/sh is dash which doesn't support this)
+ansible_shell_executable: /bin/bash

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -47,3 +47,13 @@ java_runner:
     ubuntu-silverstone.local:
     ubuntu-cube.local:
 
+linux:
+  hosts:
+    ubuntu-beast.local:
+    ubuntu-silverstone.local:
+    ubuntu-cube.local:
+    ubuntu-work-laptop.local:
+    ubuntu-asus-laptop.local:
+    ubuntu-toshiba-laptop.local:
+    ubuntu-toshiba-mini-laptop.local:
+


### PR DESCRIPTION
Fixes compatibility with roles that use bash-specific features like `set -o pipefail` which fail on Ubuntu where `/bin/sh` is dash.

Specifically fixes the `luizgavalda.gnome_extensions` role failure:
```
/bin/sh: 1: set: Illegal option -o pipefail
```