### PR TITLE
feat: replace apt npm with fnm (Fast Node Manager)

### DIFF
--- a/ansible/group_vars/dev.yml
+++ b/ansible/group_vars/dev.yml
@@ -4,3 +4,6 @@
 
 # Password enables normal sudo (prompts for password)
 bootstrap_user_password: "{{ lookup('community.general.onepassword', 'System Account', field='password', vault=onepassword_vault, account_id=onepassword_account_id) }}"
+
+# fnm: don't modify shell configs (managed by dotfiles repo)
+fnm_configure_shell: false

--- a/ansible/roles/common_cli/tasks/main.yml
+++ b/ansible/roles/common_cli/tasks/main.yml
@@ -628,8 +628,8 @@
   ansible.builtin.git:
     repo: git@github.com:compscidr/dotfiles.git
     dest: ~/dotfiles
-    # Pinned commit adds service account token switching + npm-global PATH
-    version: b93601386e1ee952d46a6cb8d55124e31c48ca0a
+    # Pinned commit adds fnm (Fast Node Manager) shell integration
+    version: fbad7a24d01ffed7d70138d42b50be3c1c6c5db6
 
 - name: Test .bashrc file to see if its a symlink
   tags: dotfile

--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -81,36 +81,69 @@
     pkg:
       - golang
 
-- name: Install node development tools
-  become: true
+# Node.js via fnm (Fast Node Manager)
+- name: Install fnm and Node.js
   tags:
     - node
     - npm
-  ansible.builtin.apt:
-    pkg:
-      - npm
+    - fnm
+  ansible.builtin.include_role:
+    name: fnm
 
 # yarn: https://www.itzgeek.com/how-tos/linux/ubuntu-how-tos/how-to-install-yarn-on-ubuntu-22-04-ubuntu-20-04.html
-# https://docs.ansible.com/ansible/latest/collections/community/general/npm_module.html
-- name: Install yarn node.js package
+- name: Check if yarn is installed
   become: true
+  become_user: "{{ username }}"
+  ansible.builtin.shell: |
+    export PATH="{{ ansible_env.HOME }}/.local/share/fnm:/opt/homebrew/bin:$PATH"
+    eval "$(fnm env)" 2>/dev/null || true
+    which yarn || echo "not found"
+  register: yarn_check
+  changed_when: false
   tags:
     - yarn
     - node
     - npm
-  community.general.npm:
-    name: yarn
-    global: true
 
-- name: Install tldr node package # https://tldr.sh/
+- name: Install yarn via fnm npm
   become: true
+  become_user: "{{ username }}"
+  tags:
+    - yarn
+    - node
+    - npm
+  ansible.builtin.shell: |
+    export PATH="{{ ansible_env.HOME }}/.local/share/fnm:/opt/homebrew/bin:$PATH"
+    eval "$(fnm env)"
+    npm install -g yarn
+  when: "'not found' in yarn_check.stdout"
+
+- name: Check if tldr is installed
+  become: true
+  become_user: "{{ username }}"
+  ansible.builtin.shell: |
+    export PATH="{{ ansible_env.HOME }}/.local/share/fnm:/opt/homebrew/bin:$PATH"
+    eval "$(fnm env)" 2>/dev/null || true
+    which tldr || echo "not found"
+  register: tldr_check
+  changed_when: false
   tags:
     - tldr
     - node
     - npm
-  community.general.npm:
-    name: tldr
-    global: true
+
+- name: Install tldr via fnm npm # https://tldr.sh/
+  become: true
+  become_user: "{{ username }}"
+  tags:
+    - tldr
+    - node
+    - npm
+  ansible.builtin.shell: |
+    export PATH="{{ ansible_env.HOME }}/.local/share/fnm:/opt/homebrew/bin:$PATH"
+    eval "$(fnm env)"
+    npm install -g tldr
+  when: "'not found' in tldr_check.stdout"
 
 - name: Check if php ppa repository exists
   tags: php

--- a/ansible/roles/fnm/defaults/main.yml
+++ b/ansible/roles/fnm/defaults/main.yml
@@ -1,0 +1,5 @@
+# fnm role defaults
+fnm_node_version: "22"  # LTS version to install
+fnm_set_default: true   # Set as default version
+fnm_cleanup_apt: true   # Remove apt nodejs/npm packages
+fnm_configure_shell: true  # Add shell integration to bashrc/zshrc (disable if using dotfiles)

--- a/ansible/roles/fnm/tasks/main.yml
+++ b/ansible/roles/fnm/tasks/main.yml
@@ -1,0 +1,148 @@
+---
+# fnm - Fast Node Manager
+# https://github.com/Schniz/fnm
+
+- name: Remove apt nodejs/npm packages (cleanup old installs)
+  become: true
+  tags:
+    - fnm
+    - node
+    - cleanup
+  ansible.builtin.apt:
+    pkg:
+      - nodejs
+      - npm
+    state: absent
+    autoremove: true
+  when:
+    - fnm_cleanup_apt | default(true)
+    - ansible_os_family == "Debian"
+
+- name: Check if fnm is installed
+  become: true
+  become_user: "{{ username }}"
+  ansible.builtin.shell: which fnm || echo "not found"
+  register: fnm_check
+  changed_when: false
+  tags:
+    - fnm
+    - node
+
+- name: Install fnm via install script (Linux)
+  become: true
+  become_user: "{{ username }}"
+  ansible.builtin.shell: |
+    curl -fsSL https://fnm.vercel.app/install | bash -s -- --skip-shell
+  args:
+    creates: "{{ ansible_env.HOME }}/.local/share/fnm/fnm"
+  when:
+    - ansible_system == "Linux"
+    - "'not found' in fnm_check.stdout"
+  tags:
+    - fnm
+    - node
+
+- name: Install fnm via Homebrew (macOS)
+  community.general.homebrew:
+    name: fnm
+    state: present
+  when:
+    - ansible_os_family == "Darwin"
+    - "'not found' in fnm_check.stdout"
+  tags:
+    - fnm
+    - node
+
+- name: Add fnm to bashrc (Linux)
+  become: true
+  become_user: "{{ username }}"
+  ansible.builtin.blockinfile:
+    path: "{{ ansible_env.HOME }}/.bashrc"
+    marker: "# {mark} ANSIBLE MANAGED - fnm"
+    block: |
+      # fnm (Fast Node Manager)
+      FNM_PATH="{{ ansible_env.HOME }}/.local/share/fnm"
+      if [ -d "$FNM_PATH" ]; then
+        export PATH="$FNM_PATH:$PATH"
+        eval "$(fnm env --use-on-cd --shell bash)"
+      fi
+    create: true
+  when:
+    - ansible_system == "Linux"
+    - fnm_configure_shell | default(true)
+  tags:
+    - fnm
+    - node
+
+- name: Add fnm to zshrc (Linux)
+  become: true
+  become_user: "{{ username }}"
+  ansible.builtin.blockinfile:
+    path: "{{ ansible_env.HOME }}/.zshrc"
+    marker: "# {mark} ANSIBLE MANAGED - fnm"
+    block: |
+      # fnm (Fast Node Manager)
+      FNM_PATH="{{ ansible_env.HOME }}/.local/share/fnm"
+      if [ -d "$FNM_PATH" ]; then
+        export PATH="$FNM_PATH:$PATH"
+        eval "$(fnm env --use-on-cd --shell zsh)"
+      fi
+    create: true
+  when:
+    - ansible_system == "Linux"
+    - fnm_configure_shell | default(true)
+  tags:
+    - fnm
+    - node
+
+- name: Add fnm to zshrc (macOS)
+  ansible.builtin.blockinfile:
+    path: "{{ ansible_env.HOME }}/.zshrc"
+    marker: "# {mark} ANSIBLE MANAGED - fnm"
+    block: |
+      # fnm (Fast Node Manager) - installed via Homebrew
+      eval "$(fnm env --use-on-cd --shell zsh)"
+    create: true
+  when:
+    - ansible_os_family == "Darwin"
+    - fnm_configure_shell | default(true)
+  tags:
+    - fnm
+    - node
+
+- name: Check installed Node versions
+  become: true
+  become_user: "{{ username }}"
+  ansible.builtin.shell: |
+    export PATH="{{ ansible_env.HOME }}/.local/share/fnm:/opt/homebrew/bin:$PATH"
+    fnm list 2>/dev/null | grep -q "{{ fnm_node_version }}" && echo "installed" || echo "not installed"
+  register: node_version_check
+  changed_when: false
+  tags:
+    - fnm
+    - node
+
+- name: Install Node.js version via fnm
+  become: true
+  become_user: "{{ username }}"
+  ansible.builtin.shell: |
+    export PATH="{{ ansible_env.HOME }}/.local/share/fnm:/opt/homebrew/bin:$PATH"
+    eval "$(fnm env)"
+    fnm install {{ fnm_node_version }}
+  when: "'not installed' in node_version_check.stdout"
+  tags:
+    - fnm
+    - node
+
+- name: Set default Node.js version
+  become: true
+  become_user: "{{ username }}"
+  ansible.builtin.shell: |
+    export PATH="{{ ansible_env.HOME }}/.local/share/fnm:/opt/homebrew/bin:$PATH"
+    eval "$(fnm env)"
+    fnm default {{ fnm_node_version }}
+  when: fnm_set_default | default(true)
+  changed_when: false
+  tags:
+    - fnm
+    - node


### PR DESCRIPTION
## What
Replaces the apt-based npm installation with fnm (Fast Node Manager).

## Why
The apt npm package has many dependencies that conflict with Node.js installed from other sources (nvm, NodeSource, etc.), causing `held broken packages` errors.

## Changes
- **New `fnm` role** that:
  - Removes old apt nodejs/npm packages (cleanup)
  - Installs fnm via official script (Linux) or Homebrew (macOS)
  - Adds shell integration to `.bashrc`/`.zshrc`
  - Installs Node.js 22 LTS (configurable via `fnm_node_version`)

- **Updated `dev` role**:
  - Uses fnm instead of apt npm
  - yarn and tldr installed via fnm's npm (user-local, no sudo needed)

## Usage
After running, start a new shell or `source ~/.bashrc` to use:
```bash
fnm list        # see installed versions
fnm install 20  # install another version
fnm use 20      # switch versions
```

Closes the npm dependency conflict issue.