### PR TITLE
feat: add ombi.jasonernst.com CNAME pointing to nas

### DIFF
--- a/terraform/jasonernst-com.tf
+++ b/terraform/jasonernst-com.tf
@@ -53,6 +53,14 @@ resource "digitalocean_record" "CNAME-dev" {
   value  = "@"
 }
 
+# ombi.jasonernst.com -> nas (same dynamic IP, managed by dyndns container)
+resource "digitalocean_record" "CNAME-ombi" {
+  domain = digitalocean_domain.default.name
+  type   = "CNAME"
+  name   = "ombi"
+  value  = "nas.jasonernst.com."
+}
+
 # projects.jasonernst.com -> projects droplet
 resource "digitalocean_record" "A-projects" {
   domain = digitalocean_domain.default.name


### PR DESCRIPTION
Adds a CNAME record for `ombi.jasonernst.com` pointing to `nas.jasonernst.com`.

Both services run on the NAS:
- `nas.jasonernst.com` — A record managed by dyndns container (dynamic IP)
- `ombi.jasonernst.com` — CNAME → nas.jasonernst.com

nginx-proxy on the NAS routes requests by hostname to the appropriate backend container.

After merging, run:
```bash
cd terraform && terraform apply
```