### PR TITLE
feat: enable shared media network for container name resolution

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -26,7 +26,7 @@ collections:
   - name: community.docker
     version: "5.0.5"
   - name: compscidr.media_server
-    version: "1.2.0"
+    version: "1.3.0"
   - name: compscidr.github_runner
     version: "0.1.2"
   - name: compscidr.rust_gameserver

--- a/ansible/roles/media_server/defaults/main.yml
+++ b/ansible/roles/media_server/defaults/main.yml
@@ -7,3 +7,7 @@ media_user_group: admin
 # Base storage path for all media directories
 # The media_storage role will create subdirectories (downloads, tv, movies, music)
 media_storage_base_path: /volume1/storage
+
+# Enable shared Docker network for container name resolution
+# Allows containers to reach each other by name (e.g., http://sonarr:8989)
+media_storage_network_enabled: true


### PR DESCRIPTION
- Bump compscidr.media_server to **1.3.0**
- Enable `media_storage_network_enabled: true`

Containers can now reach each other by name:
- `http://sonarr:8989`
- `http://radarr:7878`
- `http://prowlarr:9696`
- etc.