### PR TITLE
fix: remove recursive vars block

### DIFF
--- a/ansible/roles/media_server/tasks/main.yml
+++ b/ansible/roles/media_server/tasks/main.yml
@@ -14,9 +14,6 @@
     name: compscidr.media_server.media_storage
     apply:
       become: true
-  vars:
-    media_storage_network_enabled: "{{ media_storage_network_enabled | default(true) }}"
-    media_storage_network_name: "{{ media_storage_network_name | default('media') }}"
 
 # Nginx reverse proxy + LetsEncrypt for SSL certs
 - name: Create nginx config directory


### PR DESCRIPTION
Removes the recursive vars block from include_role. The set_fact already sets the variables.