### PR TITLE
fix: set media_user vars via set_fact

### DIFF
--- a/ansible/roles/media_server/defaults/main.yml
+++ b/ansible/roles/media_server/defaults/main.yml
@@ -1,13 +1,4 @@
 ---
-# Media user/group for UID/GID auto-detection
-# These must exist on the target system
-media_user_user: jason
-media_user_group: admin
-
-# Base storage path for all media directories
-# The media_storage role will create subdirectories (downloads, tv, movies, music)
-media_storage_base_path: /volume1/storage
-
-# Enable shared Docker network for container name resolution
-# Allows containers to reach each other by name (e.g., http://sonarr:8989)
-media_storage_network_enabled: true
+# Note: Variables for included collection roles are set via set_fact
+# in tasks/main.yml because role defaults don't pass through to
+# included collection roles. See the "Set media defaults" task.

--- a/ansible/roles/media_server/tasks/main.yml
+++ b/ansible/roles/media_server/tasks/main.yml
@@ -1,8 +1,12 @@
 ---
-# Ensure network variables are set before including roles
-- name: Set media network defaults
+# Ensure variables are set before including roles
+# (Role defaults don't pass through to included collection roles)
+- name: Set media defaults
   tags: always
   ansible.builtin.set_fact:
+    media_user_user: jason
+    media_user_group: admin
+    media_storage_base_path: /volume1/storage
     media_storage_network_enabled: true
     media_storage_network_name: "media"
 


### PR DESCRIPTION
Role defaults don't pass through to included collection roles.

Adds `media_user_user`, `media_user_group`, and `media_storage_base_path` to the set_fact task so they're available when the media_user role runs.

Fixes PUID/PGID being set to 65534 (nobody) instead of 999 (jason).