### PR TITLE
fix(stalwart): make binaries executable after extraction

### DIFF
--- a/ansible/roles/stalwart/tasks/main.yml
+++ b/ansible/roles/stalwart/tasks/main.yml
@@ -73,6 +73,14 @@
         dest: "{{ stalwart_data_dir }}/bin"
         remote_src: true
 
+    - name: Make binaries executable
+      ansible.builtin.file:
+        path: "{{ item }}"
+        mode: '0755'
+      loop:
+        - "{{ stalwart_data_dir }}/bin/stalwart"
+        - "{{ stalwart_data_dir }}/bin/stalwart-cli"
+
     - name: Create symlink for stalwart-mail
       ansible.builtin.file:
         src: "{{ stalwart_data_dir }}/bin/stalwart"


### PR DESCRIPTION
Extracted binaries don't have execute permission. Adds a task to chmod +x them.