### PR TITLE
fix(stalwart): ensure binaries are executable outside install block

### DIFF
--- a/ansible/roles/stalwart/tasks/main.yml
+++ b/ansible/roles/stalwart/tasks/main.yml
@@ -109,6 +109,16 @@
         owner: stalwart
         group: stalwart
 
+# Always ensure binaries are executable (runs even if install was skipped)
+- name: Ensure Stalwart binaries are executable
+  become: true
+  ansible.builtin.file:
+    path: "{{ item }}"
+    mode: '0755'
+  loop:
+    - "{{ stalwart_data_dir }}/bin/stalwart"
+    - "{{ stalwart_data_dir }}/bin/stalwart-cli"
+
 - name: Configure UFW for mail services
   become: true
   community.general.ufw:


### PR DESCRIPTION
The chmod task was inside the 'when: not installed' block, so it was skipped on subsequent runs when the symlink already existed.

Adds a separate task outside the block that always ensures the binaries are executable.