### PR TITLE
docs(stalwart): update CLI instructions and add DKIM DNS

### DIFF
--- a/ansible/roles/stalwart/tasks/main.yml
+++ b/ansible/roles/stalwart/tasks/main.yml
@@ -187,11 +187,14 @@
       Next steps:
       1. SSH tunnel to access admin: ssh -L 8080:localhost:8080 root@{{ stalwart_hostname }}
       2. Open http://localhost:8080 in browser (login with 1Password credentials)
-      3. Generate DKIM key via admin UI or CLI:
-         stalwart-cli -u http://localhost:8080 -c {{ stalwart_admin_user }}:<password> domain create {{ stalwart_domain }}
-      4. Update the DKIM DNS record in Terraform with the generated public key
-      5. Create user accounts (e.g., kai@{{ stalwart_domain }}, jason@{{ stalwart_domain }})
+      3. Generate DKIM key via CLI:
+         stalwart-cli -u http://localhost:8080 -c {{ stalwart_admin_user }}:<password> dkim create ed25519 {{ stalwart_domain }}
+      4. Get the public key for DNS:
+         stalwart-cli -u http://localhost:8080 -c {{ stalwart_admin_user }}:<password> dkim get-public-key ed25519-{{ stalwart_domain }}
+      5. Add DNS TXT record: ed25519._domainkey.{{ stalwart_domain }} with value "v=DKIM1; k=ed25519; p=<public_key>"
+      6. Create user accounts in the web UI (Settings -> Accounts)
       
       Test commands:
       - Check SMTP: telnet {{ stalwart_hostname }} 25
       - Check IMAP: openssl s_client -connect {{ stalwart_hostname }}:993
+      - Verify DKIM DNS: dig TXT ed25519._domainkey.{{ stalwart_domain }}

--- a/terraform/mail.tf
+++ b/terraform/mail.tf
@@ -60,15 +60,14 @@ resource "digitalocean_record" "TXT-DMARC" {
   value  = "v=DMARC1; p=quarantine; rua=mailto:postmaster@jasonernst.com; ruf=mailto:postmaster@jasonernst.com; fo=1"
 }
 
-# DKIM record - placeholder, update after Stalwart generates the key
-# Stalwart uses ed25519 by default for better security
-# Run: stalwart-cli -u http://localhost:8080 domain create jasonernst.com
-# Then update this value with the generated public key
+# DKIM record for ed25519 signature
+# Generated with: stalwart-cli -u http://localhost:8080 -c admin:<password> dkim create ed25519 jasonernst.com
+# Get public key: stalwart-cli -u http://localhost:8080 -c admin:<password> dkim get-public-key ed25519-jasonernst.com
 resource "digitalocean_record" "TXT-DKIM" {
   domain = digitalocean_domain.default.name
   type   = "TXT"
-  name   = "stalwart._domainkey"
-  value  = "v=DKIM1; k=ed25519; p=REPLACE_WITH_GENERATED_PUBLIC_KEY"
+  name   = "ed25519._domainkey"
+  value  = "v=DKIM1; k=ed25519; p=BTSzGlAVg1po2Q9pbhqszjeuswH1RuyY30leO/u8VuQ="
 }
 
 # Reverse DNS (PTR) - set via DigitalOcean console or API


### PR DESCRIPTION
## Changes

### Ansible post-install instructions
- Fixed DKIM CLI commands:
  - `dkim create ed25519 jasonernst.com` (not `domain create`)
  - `dkim get-public-key ed25519-jasonernst.com` to retrieve the key
- Added DNS verification command

### Terraform
- Updated DKIM selector from `stalwart._domainkey` to `ed25519._domainkey`
- Added actual DKIM public key

After merging, run `terraform apply` to update DNS.