### PR TITLE
feat(stalwart): Add SendGrid SMTP relay and fix DKIM signing

### DIFF
--- a/ansible/mail.yml
+++ b/ansible/mail.yml
@@ -14,5 +14,9 @@
     # Admin credentials from 1Password (Infrastructure vault)
     stalwart_admin_user: "{{ lookup('community.general.onepassword', 'stalwart-admin', field='username', vault=onepassword_vault) }}"
     stalwart_admin_password: "{{ lookup('community.general.onepassword', 'stalwart-admin', field='password', vault=onepassword_vault) }}"
+    # SendGrid SMTP relay credentials from 1Password
+    stalwart_sendgrid_enabled: true
+    stalwart_sendgrid_username: "{{ lookup('community.general.onepassword', 'SendGrid', field='username', vault=onepassword_vault) }}"
+    stalwart_sendgrid_api_key: "{{ lookup('community.general.onepassword', 'SendGrid', field='credential', vault=onepassword_vault) }}"
   roles:
     - stalwart

--- a/ansible/roles/stalwart/defaults/main.yml
+++ b/ansible/roles/stalwart/defaults/main.yml
@@ -21,8 +21,8 @@ stalwart_data_dir: "/opt/stalwart-mail"
 stalwart_admin_user: "admin"
 stalwart_admin_password: ""  # Required - set in mail.yml from 1Password
 
-# DKIM selector
-stalwart_dkim_selector: "stalwart"
+# DKIM selector - must match DNS record (ed25519._domainkey.domain.com)
+stalwart_dkim_selector: "ed25519"
 
 # TLS - use Let's Encrypt via ACME
 stalwart_acme_enabled: true

--- a/ansible/roles/stalwart/defaults/main.yml
+++ b/ansible/roles/stalwart/defaults/main.yml
@@ -28,6 +28,11 @@ stalwart_dkim_selector: "ed25519"
 stalwart_acme_enabled: true
 stalwart_acme_contact: "postmaster@{{ stalwart_domain }}"
 
+# SendGrid SMTP relay (for outbound mail delivery)
+stalwart_sendgrid_enabled: false
+stalwart_sendgrid_username: "apikey"
+stalwart_sendgrid_api_key: ""
+
 # Ports
 stalwart_smtp_port: 25
 stalwart_submission_port: 587

--- a/ansible/roles/stalwart/tasks/main.yml
+++ b/ansible/roles/stalwart/tasks/main.yml
@@ -185,16 +185,27 @@
       Admin account pre-configured from 1Password (user: {{ stalwart_admin_user }})
       
       Next steps:
-      1. SSH tunnel to access admin: ssh -L 8080:localhost:8080 root@{{ stalwart_hostname }}
-      2. Open http://localhost:8080 in browser (login with 1Password credentials)
-      3. Generate DKIM key via CLI:
-         stalwart-cli -u http://localhost:8080 -c {{ stalwart_admin_user }}:<password> dkim create ed25519 {{ stalwart_domain }}
-      4. Get the public key for DNS:
-         stalwart-cli -u http://localhost:8080 -c {{ stalwart_admin_user }}:<password> dkim get-public-key ed25519-{{ stalwart_domain }}
-      5. Add DNS TXT record: ed25519._domainkey.{{ stalwart_domain }} with value "v=DKIM1; k=ed25519; p=<public_key>"
-      6. Create user accounts in the web UI (Settings -> Accounts)
+      1. Generate DKIM key:
+         sudo openssl genpkey -algorithm ed25519 -out {{ stalwart_data_dir }}/etc/dkim/{{ stalwart_domain }}.key
+         sudo chown stalwart:stalwart {{ stalwart_data_dir }}/etc/dkim/{{ stalwart_domain }}.key
+         sudo chmod 600 {{ stalwart_data_dir }}/etc/dkim/{{ stalwart_domain }}.key
+      
+      2. Get public key for DNS:
+         sudo openssl pkey -in {{ stalwart_data_dir }}/etc/dkim/{{ stalwart_domain }}.key -pubout 2>/dev/null | openssl asn1parse -offset 12 -noout -out /dev/stdout | base64
+      
+      3. Update Terraform with the public key in mail.tf (ed25519._domainkey.{{ stalwart_domain }})
+         Then run: terraform apply
+      
+      4. Restart Stalwart to pick up the key:
+         sudo systemctl restart stalwart-mail
+      
+      5. Access admin UI via SSH tunnel:
+         ssh -L 8080:localhost:8080 root@{{ stalwart_hostname }}
+         Then open http://localhost:8080 (login with 1Password credentials)
+      
+      6. Create user accounts (e.g., kai@{{ stalwart_domain }}, jason@{{ stalwart_domain }})
       
       Test commands:
       - Check SMTP: telnet {{ stalwart_hostname }} 25
       - Check IMAP: openssl s_client -connect {{ stalwart_hostname }}:993
-      - Verify DKIM DNS: dig TXT ed25519._domainkey.{{ stalwart_domain }}
+      - Test DKIM: dig TXT {{ stalwart_dkim_selector }}._domainkey.{{ stalwart_domain }} +short

--- a/ansible/roles/stalwart/templates/config.toml.j2
+++ b/ansible/roles/stalwart/templates/config.toml.j2
@@ -84,8 +84,9 @@ secret = "{{ stalwart_admin_password }}"
 mechanisms = ["PLAIN", "LOGIN"]
 directory = "internal"
 
-# DKIM signing - key generated post-install via stalwart-cli
-# Run: stalwart-cli -u http://localhost:8080 domain create jasonernst.com
+# DKIM signing - key generated via openssl post-install
+# Generate key: openssl genpkey -algorithm ed25519 -out {{ stalwart_data_dir }}/etc/dkim/{{ stalwart_domain }}.key
+# Get public key: openssl pkey -in {{ stalwart_data_dir }}/etc/dkim/{{ stalwart_domain }}.key -pubout 2>/dev/null | openssl asn1parse -offset 12 -noout -out /dev/stdout | base64
 [signature."{{ stalwart_dkim_selector }}"]
 private-key = "%{file:{{ stalwart_data_dir }}/etc/dkim/{{ stalwart_domain }}.key}%"
 domain = "{{ stalwart_domain }}"
@@ -95,6 +96,11 @@ algorithm = "ed25519-sha256"
 canonicalization = "relaxed/relaxed"
 set-body-length = false
 report = true
+
+# Enable DKIM signing for outbound mail (not from external SMTP relay)
+[auth.dkim]
+sign = [ { if = "listener != 'smtp'", then = "['{{ stalwart_dkim_selector }}']" },
+         { else = false } ]
 
 # Spam filtering with Sieve
 [sieve.trusted]

--- a/ansible/roles/stalwart/templates/config.toml.j2
+++ b/ansible/roles/stalwart/templates/config.toml.j2
@@ -139,6 +139,26 @@ retry = "[2m, 5m, 10m, 15m, 30m, 1h, 2h]"
 notify = "[1d, 3d]"
 expire = "5d"
 
+{% if stalwart_sendgrid_enabled %}
+# SendGrid SMTP relay for outbound mail delivery
+# Improves deliverability by using SendGrid's trusted IP reputation
+[remote."sendgrid"]
+address = "smtp.sendgrid.net"
+port = 587
+protocol = "smtp"
+tls.implicit = false
+tls.starttls = "require"
+
+[remote."sendgrid".auth]
+username = "{{ stalwart_sendgrid_username }}"
+secret = "{{ stalwart_sendgrid_api_key }}"
+
+# Route non-local outbound mail through SendGrid
+[queue.outbound]
+next-hop = [ { if = "!is_local_domain('', rcpt_domain)", then = "'sendgrid'" },
+             { else = false } ]
+{% endif %}
+
 # Reporting
 [report]
 path = "{{ stalwart_data_dir }}/reports"

--- a/terraform/mail.tf
+++ b/terraform/mail.tf
@@ -43,13 +43,12 @@ resource "digitalocean_record" "MX" {
   priority = 10
 }
 
-# SPF record - authorize mail server to send on behalf of domain
-# Using 'mx' mechanism which covers mail.jasonernst.com
+# SPF record - authorize mail server and SendGrid to send on behalf of domain
 resource "digitalocean_record" "TXT-SPF" {
   domain = digitalocean_domain.default.name
   type   = "TXT"
   name   = "@"
-  value  = "v=spf1 mx -all"
+  value  = "v=spf1 mx include:sendgrid.net -all"
 }
 
 # DMARC record - policy for handling failed authentication
@@ -70,6 +69,43 @@ resource "digitalocean_record" "TXT-DKIM" {
   type   = "TXT"
   name   = "ed25519._domainkey"
   value  = "v=DKIM1; k=ed25519; p=fUU6C7whZBmzcatZ6PyeOUHQcaDTHzs/jSl2uubePKI="
+}
+
+# SendGrid DNS records for domain authentication and link branding
+resource "digitalocean_record" "CNAME-sendgrid-url" {
+  domain = digitalocean_domain.default.name
+  type   = "CNAME"
+  name   = "url8795"
+  value  = "sendgrid.net."
+}
+
+resource "digitalocean_record" "CNAME-sendgrid-59516169" {
+  domain = digitalocean_domain.default.name
+  type   = "CNAME"
+  name   = "59516169"
+  value  = "sendgrid.net."
+}
+
+resource "digitalocean_record" "CNAME-sendgrid-em" {
+  domain = digitalocean_domain.default.name
+  type   = "CNAME"
+  name   = "em3384"
+  value  = "u59516169.wl170.sendgrid.net."
+}
+
+# SendGrid DKIM records
+resource "digitalocean_record" "CNAME-sendgrid-dkim-s1" {
+  domain = digitalocean_domain.default.name
+  type   = "CNAME"
+  name   = "s1._domainkey"
+  value  = "s1.domainkey.u59516169.wl170.sendgrid.net."
+}
+
+resource "digitalocean_record" "CNAME-sendgrid-dkim-s2" {
+  domain = digitalocean_domain.default.name
+  type   = "CNAME"
+  name   = "s2._domainkey"
+  value  = "s2.domainkey.u59516169.wl170.sendgrid.net."
 }
 
 # Reverse DNS (PTR) - set via DigitalOcean console or API

--- a/terraform/mail.tf
+++ b/terraform/mail.tf
@@ -60,14 +60,16 @@ resource "digitalocean_record" "TXT-DMARC" {
   value  = "v=DMARC1; p=quarantine; rua=mailto:postmaster@jasonernst.com; ruf=mailto:postmaster@jasonernst.com; fo=1"
 }
 
-# DKIM record for ed25519 signature
-# Generated with: stalwart-cli -u http://localhost:8080 -c admin:<password> dkim create ed25519 jasonernst.com
-# Get public key: stalwart-cli -u http://localhost:8080 -c admin:<password> dkim get-public-key ed25519-jasonernst.com
+# DKIM record for ed25519 signing
+# The private key is generated via openssl on the mail server:
+#   openssl genpkey -algorithm ed25519 -out /opt/stalwart-mail/etc/dkim/jasonernst.com.key
+# Extract public key for DNS with:
+#   openssl pkey -in /opt/stalwart-mail/etc/dkim/jasonernst.com.key -pubout 2>/dev/null | openssl asn1parse -offset 12 -noout -out /dev/stdout | base64
 resource "digitalocean_record" "TXT-DKIM" {
   domain = digitalocean_domain.default.name
   type   = "TXT"
   name   = "ed25519._domainkey"
-  value  = "v=DKIM1; k=ed25519; p=BTSzGlAVg1po2Q9pbhqszjeuswH1RuyY30leO/u8VuQ="
+  value  = "v=DKIM1; k=ed25519; p=fUU6C7whZBmzcatZ6PyeOUHQcaDTHzs/jSl2uubePKI="
 }
 
 # Reverse DNS (PTR) - set via DigitalOcean console or API


### PR DESCRIPTION
## Changes

### DKIM Signing Fix
- Change DKIM selector from 'stalwart' to 'ed25519' to match DNS convention
- Add `[auth.dkim]` section to actually enable DKIM signing (was missing!)
- Update post-install instructions with openssl key generation steps

### SendGrid SMTP Relay
- Add SendGrid DNS records (CNAME for domain auth + DKIM)
- Update SPF to include sendgrid.net
- Add `stalwart_sendgrid_enabled` toggle with 1Password credential lookup
- Route non-local outbound mail through SendGrid for better deliverability

### Why
Gmail (and other providers) block DigitalOcean VPS IPs for direct mail delivery. SendGrid relay solves this with trusted IP reputation.