### PR TITLE
fix: jasonernst_com ansible role issues

### DIFF
--- a/ansible/roles/jasonernst_com/tasks/main.yml
+++ b/ansible/roles/jasonernst_com/tasks/main.yml
@@ -14,12 +14,12 @@
   become: true
   ansible.builtin.copy:
     content: "client_max_body_size 100m;"
-    dest: /etc/nginx/conf.d
+    dest: /etc/nginx/conf.d/client_max_body_size.conf
     mode: '644'
     owner: root
     group: root
 
-- name: Enable IPv6 for docker daemon
+- name: Configure docker daemon logging
   become: true
   tags: docker
   ansible.builtin.copy:
@@ -39,8 +39,9 @@
   community.docker.docker_container:
     name: nginx-proxy
     image: jwilder/nginx-proxy
-    default_host_ip: ""
-    published_ports: 80:80,443:443
+    published_ports:
+      - "80:80"
+      - "443:443"
     volumes:
       - /etc/nginx/conf.d:/etc/nginx/conf.d
       - vhost:/etc/nginx/vhost.d
@@ -71,7 +72,7 @@
       ENABLE_IPV6: "true"
 
 
-- name: Create prodcuction /opt/goblog directory on host
+- name: Create production /opt/goblog directory on host
   tags: website
   become: true
   ansible.builtin.file:
@@ -98,7 +99,6 @@
     src: /opt/goblog/prod/
     dest: /opt/goblog/staging
     remote_src: true
-    mode: '644'
     owner: root
     group: root
 
@@ -132,6 +132,8 @@
 
 - name: Deploy www.jasonernst.com
   tags: website
+  vars:
+    ansible_python_interpreter: "/usr/bin/env python3-docker"
   community.docker.docker_container:
     name: www.jasonernst.com
     image: compscidr/goblog:v0.1.46
@@ -154,6 +156,8 @@
 
 - name: Deploy staging.jasonernst.com
   tags: website
+  vars:
+    ansible_python_interpreter: "/usr/bin/env python3-docker"
   community.docker.docker_container:
     name: staging.jasonernst.com
     image: compscidr/goblog:v0.1.46


### PR DESCRIPTION
## Summary
Fixes several issues in the jasonernst_com Ansible role that were preventing successful deployment.

## Changes
- **Fix nginx config dest**: Changed from directory (`/etc/nginx/conf.d`) to file path (`/etc/nginx/conf.d/client_max_body_size.conf`) - this was the breaking error
- **Rename misleading task**: 'Enable IPv6 for docker daemon' → 'Configure docker daemon logging' (the task only sets log-driver, not IPv6)
- **Fix published_ports format**: Changed from comma-separated string to proper YAML list
- **Remove invalid param**: Removed `default_host_ip: ""` which isn't a valid docker_container parameter
- **Fix typo**: 'prodcuction' → 'production'
- **Fix directory copy mode**: Removed `mode: '644'` from prod→staging copy (was forcing 644 on all copied items including directories)
- **Add missing python interpreter**: Added `ansible_python_interpreter` vars to www and staging container deploy tasks for consistency

## Testing
Ready to test with: `ansible-playbook -i inventory.yml jasonernst_com.yml --limit www`