### PR TITLE
fix: run git clone as user with SSH keys

### DIFF
--- a/ansible/roles/projects/defaults/main.yml
+++ b/ansible/roles/projects/defaults/main.yml
@@ -3,6 +3,7 @@
 
 projects_base_path: /opt/projects
 projects_letsencrypt_email: "ernstjason1@gmail.com"
+projects_git_user: jason  # User with SSH keys for cloning private repos
 
 # Project repos
 projects_repos:

--- a/ansible/roles/projects/tasks/main.yml
+++ b/ansible/roles/projects/tasks/main.yml
@@ -54,11 +54,14 @@
     path: "{{ projects_base_path }}"
     state: directory
     mode: '755'
+    owner: "{{ projects_git_user }}"
+    group: "{{ projects_git_user }}"
 
 # Clone and deploy network-tools (ping4, ping6, dumpers)
 - name: Clone network-tools repo
   tags: [projects, network-tools]
   become: true
+  become_user: "{{ projects_git_user }}"
   ansible.builtin.git:
     repo: git@github.com:compscidr/network-tools.git
     dest: "{{ projects_base_path }}/network-tools"
@@ -80,6 +83,7 @@
 - name: Clone darksearch repo
   tags: [projects, darksearch]
   become: true
+  become_user: "{{ projects_git_user }}"
   ansible.builtin.git:
     repo: git@github.com:compscidr/darksearch.xyz.git
     dest: "{{ projects_base_path }}/darksearch"


### PR DESCRIPTION
The bootstrap role deploys SSH keys to the user's home (`/home/jason/.ssh/id_rsa`), but the git clone tasks were running as root (`become: true`), which doesn't have access to those keys.

**Changes:**
- Added `projects_git_user` variable (defaults to `jason`)
- Git clone tasks now use `become_user: {{ projects_git_user }}`
- Projects base directory ownership set to the git user

This ensures git operations use the SSH keys deployed by the bootstrap role.