### PR TITLE
fix: skip docker-compose.override.yml in production

### DIFF
--- a/ansible/roles/projects/tasks/main.yml
+++ b/ansible/roles/projects/tasks/main.yml
@@ -82,6 +82,8 @@
   become: true
   community.docker.docker_compose_v2:
     project_src: "{{ projects_base_path }}/network-tools"
+    files:
+      - docker-compose.yml  # Exclude override file (sets external: false for local dev)
     state: present
     pull: always
   environment:
@@ -104,6 +106,8 @@
   become: true
   community.docker.docker_compose_v2:
     project_src: "{{ projects_base_path }}/darksearch"
+    files:
+      - docker-compose.yml  # Exclude override file (sets external: false for local dev)
     state: present
     pull: always
   environment:


### PR DESCRIPTION
The override files set `external: false` for local dev, causing compose to create project-prefixed networks (`darksearch_nginx-proxy`, `network-tools_nginx-proxy`) instead of joining the shared `nginx-proxy` network.

This broke the reverse proxy routing (503 errors).

**Fix:** Explicitly specify `files: [docker-compose.yml]` to skip the override file in production.