### PR TITLE
fix: use explicit A record for jasonernst.com

### DIFF
--- a/terraform/jasonernst-com.tf
+++ b/terraform/jasonernst-com.tf
@@ -21,8 +21,16 @@ resource "digitalocean_droplet" "www-jasonernst-com" {
 }
 
 resource "digitalocean_domain" "default" {
-  name       = "jasonernst.com"
-  ip_address = digitalocean_droplet.www-jasonernst-com.ipv4_address
+  name = "jasonernst.com"
+  # Note: Don't use ip_address here - it only sets A record at creation time
+  # and won't update if the droplet IP changes. Use explicit records instead.
+}
+
+resource "digitalocean_record" "A" {
+  domain = digitalocean_domain.default.name
+  type   = "A"
+  name   = "@"
+  value  = digitalocean_droplet.www-jasonernst-com.ipv4_address
 }
 
 resource "digitalocean_record" "AAAA" {


### PR DESCRIPTION
Same fix as #315 - use explicit `digitalocean_record` for the A record instead of `digitalocean_domain.ip_address`.

Prevents DNS from going stale if the www droplet is recreated.