### PR TITLE
fix: add MESSAGE_SIZE_LIMIT env var required by webmail

### DIFF
--- a/ansible/roles/mailu/templates/mailu.env.j2
+++ b/ansible/roles/mailu/templates/mailu.env.j2
@@ -21,7 +21,8 @@ AUTH_RATELIMIT_IP=60/hour
 AUTH_RATELIMIT_USER=100/day
 DISABLE_STATISTICS=True
 
-# Message rate limiting
+# Message settings
+MESSAGE_SIZE_LIMIT={{ mailu_message_size_limit | default('50000000') }}
 MESSAGE_RATELIMIT={{ mailu_message_ratelimit }}
 {% if mailu_message_ratelimit_exemption %}
 MESSAGE_RATELIMIT_EXEMPTION={{ mailu_message_ratelimit_exemption }}


### PR DESCRIPTION
Webmail container crashes without this env var in Mailu 2024.06