### PR TITLE
fix: remove recreate:true now that network migration is complete

### DIFF
--- a/ansible/roles/jasonernst_com/tasks/main.yml
+++ b/ansible/roles/jasonernst_com/tasks/main.yml
@@ -46,9 +46,6 @@
   community.docker.docker_container:
     name: nginx-proxy
     image: jwilder/nginx-proxy
-    # recreate: true ensures containers move to nginx-proxy network
-    # Can be removed after migration is complete
-    recreate: true
     published_ports:
       - "80:80"
       - "443:443"
@@ -73,7 +70,6 @@
   community.docker.docker_container:
     name: letsencrypt
     image: jrcs/letsencrypt-nginx-proxy-companion
-    recreate: true
     volumes:
       - certs:/etc/nginx/certs:rw
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -194,7 +190,6 @@
   community.docker.docker_container:
     name: www.jasonernst.com
     image: compscidr/goblog:v0.1.44
-    recreate: true
     volumes:
       - /opt/goblog/prod/uploads:/go/src/github.com/compscidr/goblog/www/uploads
     mounts:
@@ -220,7 +215,6 @@
   community.docker.docker_container:
     name: staging.jasonernst.com
     image: compscidr/goblog:v0.1.46
-    recreate: true
     volumes:
       - /opt/goblog/staging/uploads:/go/src/github.com/compscidr/goblog/www/uploads
     mounts:


### PR DESCRIPTION
The recreate:true was only needed for the one-time migration to move containers to the nginx-proxy network. Now that's done, remove it to avoid unnecessary container restarts on every ansible run.