### PR TITLE
fix: use TLS_FLAVOR=mail since nginx-proxy handles web TLS

### DIFF
--- a/ansible/roles/mailu/templates/mailu.env.j2
+++ b/ansible/roles/mailu/templates/mailu.env.j2
@@ -13,8 +13,8 @@ REAL_IP_HEADER=X-Forwarded-For
 REAL_IP_FROM={{ mailu_nginx_proxy_subnet | default('172.18.0.0/16') }}
 
 # TLS configuration
-# Using certs from shared letsencrypt volume (managed by nginx-proxy companion)
-TLS_FLAVOR=cert
+# mail = Mailu handles TLS for mail protocols only (nginx-proxy handles web TLS)
+TLS_FLAVOR=mail
 
 # Authentication settings
 AUTH_RATELIMIT_IP=60/hour


### PR DESCRIPTION
TLS_FLAVOR=cert was causing issues because certs weren't in the expected location. Since nginx-proxy handles SSL termination for web traffic, use TLS_FLAVOR=mail which only enables TLS for mail protocols (SMTP/IMAP).