### PR TITLE
fix: create cert symlinks for Mailu to use nginx-proxy letsencrypt certs

### DIFF
--- a/ansible/roles/mailu/tasks/main.yml
+++ b/ansible/roles/mailu/tasks/main.yml
@@ -45,6 +45,24 @@
     mode: '644'
   notify: Restart Mailu
 
+# nginx-proxy stores certs as <domain>.crt/<domain>.key
+# Mailu expects cert.pem/key.pem - create symlinks
+- name: Create cert.pem symlink for Mailu
+  become: true
+  ansible.builtin.file:
+    src: "{{ mailu_hostname }}.crt"
+    dest: /var/lib/docker/volumes/certs/_data/cert.pem
+    state: link
+    force: true
+
+- name: Create key.pem symlink for Mailu
+  become: true
+  ansible.builtin.file:
+    src: "{{ mailu_hostname }}.key"
+    dest: /var/lib/docker/volumes/certs/_data/key.pem
+    state: link
+    force: true
+
 - name: Start Mailu stack
   become: true
   community.docker.docker_compose_v2:


### PR DESCRIPTION
nginx-proxy/letsencrypt-companion stores certs as `<domain>.crt` and `<domain>.key`.
Mailu expects `cert.pem` and `key.pem`.

This creates symlinks so Mailu can use the existing certs for mail protocol TLS.