### PR TITLE
fix: rename droplet for PTR record

### DIFF
--- a/terraform/jasonernst-com.tf
+++ b/terraform/jasonernst-com.tf
@@ -5,6 +5,10 @@ resource "digitalocean_vpc" "www-jasonernst-vpc" {
 }
 
 # size chart: https://developers.digitalocean.com/documentation/changelog/api-v2/new-size-slugs-for-droplet-plan-changes/
+# Note: The Terraform resource identifier remains "www-jasonernst-com" for historical reasons
+# and because this droplet also serves the main site (www.jasonernst.com). The droplet's
+# display name is set to "mail.jasonernst.com" to enable automatic PTR record creation
+# by DigitalOcean for mail deliverability.
 resource "digitalocean_droplet" "www-jasonernst-com" {
   image    = "ubuntu-24-04-x64"
   name     = "mail.jasonernst.com"

--- a/terraform/jasonernst-com.tf
+++ b/terraform/jasonernst-com.tf
@@ -7,7 +7,7 @@ resource "digitalocean_vpc" "www-jasonernst-vpc" {
 # size chart: https://developers.digitalocean.com/documentation/changelog/api-v2/new-size-slugs-for-droplet-plan-changes/
 resource "digitalocean_droplet" "www-jasonernst-com" {
   image    = "ubuntu-24-04-x64"
-  name     = "www-jasonernst-com"
+  name     = "mail.jasonernst.com"
   region   = "sfo2"
   size     = "s-1vcpu-2gb"
   ipv6     = true


### PR DESCRIPTION
Renames droplet to mail.jasonernst.com so DigitalOcean auto-creates the PTR record for mail deliverability.