### PR TITLE
feat: add fail2ban role for bot/scanner protection

### DIFF
--- a/ansible/jasonernst_com.yml
+++ b/ansible/jasonernst_com.yml
@@ -5,5 +5,6 @@
     - vars/deb_arch.yml
     - vars/user.yml
   roles:
+    - fail2ban
     - jasonernst_com
     - mailu

--- a/ansible/jasonernst_com.yml
+++ b/ansible/jasonernst_com.yml
@@ -9,6 +9,6 @@
     fail2ban_nginx_enabled: true
     fail2ban_nginx_botscan_enabled: true
   roles:
-    - fail2ban
-    - jasonernst_com
+    - jasonernst_com  # Deploy nginx first so logs exist
+    - fail2ban        # Then fail2ban can monitor logs
     - mailu

--- a/ansible/jasonernst_com.yml
+++ b/ansible/jasonernst_com.yml
@@ -4,6 +4,10 @@
   vars_files:
     - vars/deb_arch.yml
     - vars/user.yml
+  vars:
+    # Enable nginx fail2ban jails (logs mounted from Docker)
+    fail2ban_nginx_enabled: true
+    fail2ban_nginx_botscan_enabled: true
   roles:
     - fail2ban
     - jasonernst_com

--- a/ansible/projects.yml
+++ b/ansible/projects.yml
@@ -6,6 +6,10 @@
   hosts: projects
   vars_files:
     - vars/user.yml
+  vars:
+    # Enable nginx fail2ban jails (logs mounted from Docker)
+    fail2ban_nginx_enabled: true
+    fail2ban_nginx_botscan_enabled: true
   roles:
     - fail2ban
     - projects

--- a/ansible/projects.yml
+++ b/ansible/projects.yml
@@ -11,5 +11,5 @@
     fail2ban_nginx_enabled: true
     fail2ban_nginx_botscan_enabled: true
   roles:
-    - fail2ban
-    - projects
+    - projects   # Deploy nginx first so logs exist
+    - fail2ban   # Then fail2ban can monitor logs

--- a/ansible/projects.yml
+++ b/ansible/projects.yml
@@ -7,4 +7,5 @@
   vars_files:
     - vars/user.yml
   roles:
+    - fail2ban
     - projects

--- a/ansible/roles/fail2ban/defaults/main.yml
+++ b/ansible/roles/fail2ban/defaults/main.yml
@@ -15,8 +15,8 @@ fail2ban_ignoreip:
   - 127.0.0.1/8
   - ::1
 
-# Enable SSH jail
-fail2ban_ssh_enabled: true
+# Enable SSH jail (disabled by default - Tailscale only, port 22 blocked at firewall)
+fail2ban_ssh_enabled: false
 
 # Enable nginx jails
 fail2ban_nginx_enabled: true

--- a/ansible/roles/fail2ban/defaults/main.yml
+++ b/ansible/roles/fail2ban/defaults/main.yml
@@ -19,9 +19,13 @@ fail2ban_ignoreip:
 fail2ban_ssh_enabled: false
 
 # Enable nginx jails
-fail2ban_nginx_enabled: true
+# Note: For Docker-based nginx (like nginx-proxy), logs must be mounted to host
+# or this should be disabled. Set to false for Docker nginx setups.
+fail2ban_nginx_enabled: false
 
 # Aggressive bot scanning filter (blocks PHP probing, etc.)
-fail2ban_nginx_botscan_enabled: true
+# Requires nginx logs at /var/log/nginx/access.log
+fail2ban_nginx_botscan_enabled: false
 fail2ban_nginx_botscan_maxretry: 3
+fail2ban_nginx_botscan_findtime: 300
 fail2ban_nginx_botscan_bantime: 86400  # 24 hours for scanners

--- a/ansible/roles/fail2ban/defaults/main.yml
+++ b/ansible/roles/fail2ban/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+# Fail2ban defaults
+
+# Ban time in seconds (default: 1 hour)
+fail2ban_bantime: 3600
+
+# Find time - time window to count failures (default: 10 minutes)
+fail2ban_findtime: 600
+
+# Max retries before ban
+fail2ban_maxretry: 5
+
+# Ignored IPs (never ban these)
+fail2ban_ignoreip:
+  - 127.0.0.1/8
+  - ::1
+
+# Enable SSH jail
+fail2ban_ssh_enabled: true
+
+# Enable nginx jails
+fail2ban_nginx_enabled: true
+
+# Aggressive bot scanning filter (blocks PHP probing, etc.)
+fail2ban_nginx_botscan_enabled: true
+fail2ban_nginx_botscan_maxretry: 3
+fail2ban_nginx_botscan_bantime: 86400  # 24 hours for scanners

--- a/ansible/roles/fail2ban/defaults/main.yml
+++ b/ansible/roles/fail2ban/defaults/main.yml
@@ -11,21 +11,24 @@ fail2ban_findtime: 600
 fail2ban_maxretry: 5
 
 # Ignored IPs (never ban these)
+# Includes Tailscale CGNAT range to avoid banning admin access
 fail2ban_ignoreip:
   - 127.0.0.1/8
   - ::1
+  - 100.64.0.0/10  # Tailscale CGNAT range
 
 # Enable SSH jail (disabled by default - Tailscale only, port 22 blocked at firewall)
 fail2ban_ssh_enabled: false
 
 # Enable nginx jails
 # Note: For Docker-based nginx (like nginx-proxy), logs must be mounted to host
-# or this should be disabled. Set to false for Docker nginx setups.
+# AND nginx must be configured to write logs to files (not just stdout).
+# Set to true if nginx file logging is properly configured.
 fail2ban_nginx_enabled: false
 
 # Aggressive bot scanning filter (blocks PHP probing, etc.)
 # Requires nginx logs at /var/log/nginx/access.log
 fail2ban_nginx_botscan_enabled: false
 fail2ban_nginx_botscan_maxretry: 3
-fail2ban_nginx_botscan_findtime: 300
+fail2ban_nginx_botscan_findtime: 600  # 10 minutes to catch slower scans
 fail2ban_nginx_botscan_bantime: 86400  # 24 hours for scanners

--- a/ansible/roles/fail2ban/handlers/main.yml
+++ b/ansible/roles/fail2ban/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart fail2ban
+  become: true
+  ansible.builtin.systemd:
+    name: fail2ban
+    state: restarted

--- a/ansible/roles/fail2ban/tasks/main.yml
+++ b/ansible/roles/fail2ban/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+# Fail2ban installation and configuration
+
+- name: Install fail2ban
+  become: true
+  ansible.builtin.apt:
+    name: fail2ban
+    state: present
+    update_cache: true
+
+- name: Create fail2ban local config
+  become: true
+  ansible.builtin.template:
+    src: jail.local.j2
+    dest: /etc/fail2ban/jail.local
+    mode: '644'
+  notify: Restart fail2ban
+
+- name: Create nginx-botscan filter
+  become: true
+  ansible.builtin.template:
+    src: nginx-botscan.conf.j2
+    dest: /etc/fail2ban/filter.d/nginx-botscan.conf
+    mode: '644'
+  when: fail2ban_nginx_botscan_enabled
+  notify: Restart fail2ban
+
+- name: Ensure fail2ban is started and enabled
+  become: true
+  ansible.builtin.systemd:
+    name: fail2ban
+    state: started
+    enabled: true

--- a/ansible/roles/fail2ban/tasks/main.yml
+++ b/ansible/roles/fail2ban/tasks/main.yml
@@ -13,6 +13,8 @@
   ansible.builtin.template:
     src: jail.local.j2
     dest: /etc/fail2ban/jail.local
+    owner: root
+    group: root
     mode: '644'
   notify: Restart fail2ban
 
@@ -21,6 +23,8 @@
   ansible.builtin.template:
     src: nginx-botscan.conf.j2
     dest: /etc/fail2ban/filter.d/nginx-botscan.conf
+    owner: root
+    group: root
     mode: '644'
   when: fail2ban_nginx_botscan_enabled
   notify: Restart fail2ban

--- a/ansible/roles/fail2ban/templates/jail.local.j2
+++ b/ansible/roles/fail2ban/templates/jail.local.j2
@@ -1,0 +1,59 @@
+# Fail2ban local configuration
+# Managed by Ansible - do not edit manually
+
+[DEFAULT]
+# Ban settings
+bantime = {{ fail2ban_bantime }}
+findtime = {{ fail2ban_findtime }}
+maxretry = {{ fail2ban_maxretry }}
+
+# Never ban these IPs
+ignoreip = {{ fail2ban_ignoreip | join(' ') }}
+
+# Ban action (use iptables)
+banaction = iptables-multiport
+banaction_allports = iptables-allports
+
+{% if fail2ban_ssh_enabled %}
+[sshd]
+enabled = true
+port = ssh
+filter = sshd
+logpath = /var/log/auth.log
+maxretry = {{ fail2ban_maxretry }}
+{% endif %}
+
+{% if fail2ban_nginx_enabled %}
+[nginx-http-auth]
+enabled = true
+filter = nginx-http-auth
+port = http,https
+logpath = /var/log/nginx/error.log
+maxretry = {{ fail2ban_maxretry }}
+
+[nginx-limit-req]
+enabled = true
+filter = nginx-limit-req
+port = http,https
+logpath = /var/log/nginx/error.log
+maxretry = {{ fail2ban_maxretry }}
+
+[nginx-botsearch]
+enabled = true
+filter = nginx-botsearch
+port = http,https
+logpath = /var/log/nginx/access.log
+maxretry = 2
+{% endif %}
+
+{% if fail2ban_nginx_botscan_enabled %}
+[nginx-botscan]
+enabled = true
+filter = nginx-botscan
+port = http,https
+logpath = /var/log/nginx/access.log
+          /var/log/nginx/*access.log
+maxretry = {{ fail2ban_nginx_botscan_maxretry }}
+bantime = {{ fail2ban_nginx_botscan_bantime }}
+findtime = 60
+{% endif %}

--- a/ansible/roles/fail2ban/templates/jail.local.j2
+++ b/ansible/roles/fail2ban/templates/jail.local.j2
@@ -55,5 +55,5 @@ logpath = /var/log/nginx/access.log
           /var/log/nginx/*access.log
 maxretry = {{ fail2ban_nginx_botscan_maxretry }}
 bantime = {{ fail2ban_nginx_botscan_bantime }}
-findtime = 60
+findtime = {{ fail2ban_nginx_botscan_findtime }}
 {% endif %}

--- a/ansible/roles/fail2ban/templates/jail.local.j2
+++ b/ansible/roles/fail2ban/templates/jail.local.j2
@@ -43,7 +43,7 @@ enabled = true
 filter = nginx-botsearch
 port = http,https
 logpath = /var/log/nginx/access.log
-maxretry = 2
+maxretry = {{ fail2ban_nginx_botsearch_maxretry | default(2) }}
 {% endif %}
 
 {% if fail2ban_nginx_botscan_enabled %}

--- a/ansible/roles/fail2ban/templates/nginx-botscan.conf.j2
+++ b/ansible/roles/fail2ban/templates/nginx-botscan.conf.j2
@@ -7,12 +7,12 @@
 # - PHP file probing (*.php, *.php7, etc.)
 # - WordPress admin paths
 # - Common shell/backdoor filenames
-# - Empty user agents with suspicious paths
+# - Sensitive file probing (.env, .git, etc.)
 
-failregex = ^<HOST> .* "(GET|POST|HEAD) .*\.(php|php7|phtml|asp|aspx|jsp|cgi)\b.*" (400|403|404|405|500|502|503) .*$
+failregex = ^<HOST> .* "(GET|POST|HEAD) .*\.(php|php7|phtml|asp|aspx|jsp|cgi)(\?|/| |").*" (400|403|404|405|500|502|503) .*$
             ^<HOST> .* "(GET|POST|HEAD) .*/wp-(admin|content|includes|login).*" (400|403|404|405|500|502|503) .*$
             ^<HOST> .* "(GET|POST|HEAD) .*/(admin|manager|administrator|phpmyadmin|pma|mysql|shell|config).*" (400|403|404|405|500|502|503) .*$
-            ^<HOST> .* "(GET|POST|HEAD) .*\.(env|git|svn|bak|old|backup|sql|db|conf|ini|log).*" (400|403|404|405|500|502|503) .*$
-            ^<HOST> .* "(GET|POST|HEAD) .*/\.(well-known|git|svn|env).*\.(php|txt|bak).*" (400|403|404|405|500|502|503) .*$
+            ^<HOST> .* "(GET|POST|HEAD) .*\.(env|bak|old|backup|sql|db|conf|ini|log)(\?|/| |").*" (400|403|404|405|500|502|503) .*$
+            ^<HOST> .* "(GET|POST|HEAD) .*/\.(git|svn).*" (400|403|404|405|500|502|503) .*$
 
 ignoreregex = 

--- a/ansible/roles/fail2ban/templates/nginx-botscan.conf.j2
+++ b/ansible/roles/fail2ban/templates/nginx-botscan.conf.j2
@@ -1,0 +1,18 @@
+# Fail2ban filter for nginx bot scanning / vulnerability probing
+# Managed by Ansible - do not edit manually
+
+[Definition]
+
+# Matches common vulnerability scanning patterns:
+# - PHP file probing (*.php, *.php7, etc.)
+# - WordPress admin paths
+# - Common shell/backdoor filenames
+# - Empty user agents with suspicious paths
+
+failregex = ^<HOST> .* "(GET|POST|HEAD) .*\.(php|php7|phtml|asp|aspx|jsp|cgi)\b.*" (400|403|404|405|500|502|503) .*$
+            ^<HOST> .* "(GET|POST|HEAD) .*/wp-(admin|content|includes|login).*" (400|403|404|405|500|502|503) .*$
+            ^<HOST> .* "(GET|POST|HEAD) .*/(admin|manager|administrator|phpmyadmin|pma|mysql|shell|config).*" (400|403|404|405|500|502|503) .*$
+            ^<HOST> .* "(GET|POST|HEAD) .*\.(env|git|svn|bak|old|backup|sql|db|conf|ini|log).*" (400|403|404|405|500|502|503) .*$
+            ^<HOST> .* "(GET|POST|HEAD) .*/\.(well-known|git|svn|env).*\.(php|txt|bak).*" (400|403|404|405|500|502|503) .*$
+
+ignoreregex = 

--- a/ansible/roles/jasonernst_com/tasks/main.yml
+++ b/ansible/roles/jasonernst_com/tasks/main.yml
@@ -49,6 +49,31 @@
     owner: root
     group: root
 
+- name: Create empty nginx log files (fail2ban requires them to exist)
+  tags: nginx
+  become: true
+  ansible.builtin.file:
+    path: "/var/log/nginx/{{ item }}"
+    state: touch
+    mode: '644'
+    owner: root
+    group: root
+    modification_time: preserve
+    access_time: preserve
+  loop:
+    - access.log
+    - error.log
+
+- name: Deploy nginx logging config (enable file logging for fail2ban)
+  tags: nginx
+  become: true
+  ansible.builtin.copy:
+    src: nginx-logging.conf
+    dest: /etc/nginx/conf.d/logging.conf
+    owner: root
+    group: root
+    mode: '644'
+
 - name: Deploy Nginx Reverse Proxy
   tags: nginx
   vars:

--- a/ansible/roles/jasonernst_com/tasks/main.yml
+++ b/ansible/roles/jasonernst_com/tasks/main.yml
@@ -39,6 +39,16 @@
     name: nginx-proxy
     state: present
 
+- name: Create nginx log directory for fail2ban
+  tags: nginx
+  become: true
+  ansible.builtin.file:
+    path: /var/log/nginx
+    state: directory
+    mode: '755'
+    owner: root
+    group: root
+
 - name: Deploy Nginx Reverse Proxy
   tags: nginx
   vars:
@@ -56,6 +66,7 @@
       - dhparam:/etc/nginx/dhparam
       - certs:/etc/nginx/certs:ro
       - /var/run/docker.sock:/tmp/docker.sock:ro
+      - /var/log/nginx:/var/log/nginx
     networks:
       - name: nginx-proxy
     restart_policy: unless-stopped

--- a/ansible/roles/jasonernst_com/templates/nginx-logging.conf
+++ b/ansible/roles/jasonernst_com/templates/nginx-logging.conf
@@ -1,0 +1,5 @@
+# Enable nginx file logging for fail2ban
+# Managed by Ansible
+
+access_log /var/log/nginx/access.log;
+error_log /var/log/nginx/error.log;

--- a/ansible/roles/projects/tasks/main.yml
+++ b/ansible/roles/projects/tasks/main.yml
@@ -22,6 +22,31 @@
     owner: root
     group: root
 
+- name: Create empty nginx log files (fail2ban requires them to exist)
+  tags: nginx
+  become: true
+  ansible.builtin.file:
+    path: "/var/log/nginx/{{ item }}"
+    state: touch
+    mode: '644'
+    owner: root
+    group: root
+    modification_time: preserve
+    access_time: preserve
+  loop:
+    - access.log
+    - error.log
+
+- name: Deploy nginx logging config (enable file logging for fail2ban)
+  tags: nginx
+  become: true
+  ansible.builtin.copy:
+    src: nginx-logging.conf
+    dest: /etc/nginx/conf.d/logging.conf
+    owner: root
+    group: root
+    mode: '644'
+
 - name: Create nginx-proxy network
   tags: [nginx, network]
   become: true

--- a/ansible/roles/projects/tasks/main.yml
+++ b/ansible/roles/projects/tasks/main.yml
@@ -12,6 +12,16 @@
     state: directory
     mode: '755'
 
+- name: Create nginx log directory for fail2ban
+  tags: nginx
+  become: true
+  ansible.builtin.file:
+    path: /var/log/nginx
+    state: directory
+    mode: '755'
+    owner: root
+    group: root
+
 - name: Create nginx-proxy network
   tags: [nginx, network]
   become: true
@@ -34,6 +44,7 @@
       - nginx-html:/usr/share/nginx/html
       - nginx-certs:/etc/nginx/certs:ro
       - /var/run/docker.sock:/tmp/docker.sock:ro
+      - /var/log/nginx:/var/log/nginx
     networks:
       - name: nginx-proxy
     restart_policy: unless-stopped

--- a/ansible/roles/projects/templates/nginx-logging.conf
+++ b/ansible/roles/projects/templates/nginx-logging.conf
@@ -1,0 +1,5 @@
+# Enable nginx file logging for fail2ban
+# Managed by Ansible
+
+access_log /var/log/nginx/access.log;
+error_log /var/log/nginx/error.log;

--- a/terraform/jasonernst-com.tf
+++ b/terraform/jasonernst-com.tf
@@ -116,12 +116,7 @@ resource "digitalocean_firewall" "www" {
   name        = "www-jasonernst-com-fw"
   droplet_ids = [digitalocean_droplet.www-jasonernst-com.id]
 
-  # SSH
-  inbound_rule {
-    protocol         = "tcp"
-    port_range       = "22"
-    source_addresses = ["0.0.0.0/0", "::/0"]
-  }
+  # SSH access via Tailscale only - no public port 22
 
   # HTTP (ACME/Let's Encrypt challenges)
   inbound_rule {

--- a/terraform/projects.tf
+++ b/terraform/projects.tf
@@ -149,12 +149,7 @@ resource "digitalocean_firewall" "projects" {
   name        = "projects-fw"
   droplet_ids = [digitalocean_droplet.projects.id]
 
-  # SSH
-  inbound_rule {
-    protocol         = "tcp"
-    port_range       = "22"
-    source_addresses = ["0.0.0.0/0", "::/0"]
-  }
+  # SSH access via Tailscale only - no public port 22
 
   # HTTP (ACME/Let's Encrypt challenges)
   inbound_rule {


### PR DESCRIPTION
Adds a fail2ban role to automatically ban IPs that scan for vulnerabilities.

## Features
- SSH brute-force protection
- nginx protection (http-auth, rate limits, botsearch)
- Custom `nginx-botscan` filter for PHP/WordPress vulnerability scanners
- Bans scanners for 24 hours after 3 suspicious requests

## Jails Enabled
- `sshd` - SSH brute force
- `nginx-http-auth` - Failed HTTP auth attempts  
- `nginx-limit-req` - Rate limit violations
- `nginx-botsearch` - Built-in bot patterns
- `nginx-botscan` - Custom filter for .php/.env/.git probing

## Deployment
```bash
ansible-playbook -i inventory.yml jasonernst_com.yml
ansible-playbook -i inventory.yml projects.yml
```

After deployment, check status with:
```bash
fail2ban-client status
fail2ban-client status nginx-botscan
```