### PR TITLE
feat: add Clawdbot droplet infrastructure

### DIFF
--- a/ansible/clawdbot.yml
+++ b/ansible/clawdbot.yml
@@ -1,0 +1,25 @@
+---
+# Clawdbot playbook - AI assistant deployment
+# 
+# Prerequisites:
+#   1. Droplet created via Terraform (with Tailscale via cloud-init)
+#   2. Bootstrap run: ansible-playbook bootstrap.yml --limit clawdbot -u root
+#   3. 1Password vault "Clawdbot" with service token
+#
+# Usage:
+#   ansible-playbook -i inventory.yml clawdbot.yml
+
+- name: Deploy Clawdbot
+  hosts: clawdbot
+  vars_files:
+    - vars/user.yml
+  vars:
+    # fnm role vars
+    fnm_node_version: "22"
+    fnm_set_default: true
+    # clawdbot role vars
+    clawdbot_workspace_repo: "git@github.com:compscidr/clawd.git"
+    clawdbot_tailscale_serve: true
+  roles:
+    - fnm       # Install Node.js via fnm
+    - clawdbot  # Install and configure Clawdbot

--- a/ansible/clawdbot.yml
+++ b/ansible/clawdbot.yml
@@ -18,7 +18,7 @@
     fnm_node_version: "22"
     fnm_set_default: true
     # clawdbot role vars
-    clawdbot_workspace_repo: "git@github.com:compscidr/clawd.git"
+    clawdbot_workspace_repo: "git@github.com:compscidr/kai-workspace.git"
     clawdbot_tailscale_serve: true
   roles:
     - fnm       # Install Node.js via fnm

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -8,6 +8,7 @@ ungrouped:
     nas.local:
     mail:
     projects:
+    clawdbot:
 
 academic_gui:
   hosts:

--- a/ansible/roles/clawdbot/defaults/main.yml
+++ b/ansible/roles/clawdbot/defaults/main.yml
@@ -20,7 +20,13 @@ clawdbot_config_file: "{{ clawdbot_config_dir }}/clawdbot.json"
 
 # 1Password integration
 clawdbot_op_service_account_token: ""  # Set via vault or extra-vars
-clawdbot_op_vault: "Clawdbot"          # Vault name for secrets
+clawdbot_op_vault: "openclaw"          # Vault name for secrets
+# Items in vault:
+#   - "openclaw anthropic" - Anthropic API key
+#   - "github" - GitHub credentials  
+#   - "openai - text embedding for memory search" - OpenAI embeddings
+#   - "discord clawdbot" - Discord bot token
+#   - "mail.jasonernst.com - kai" - Email credentials
 
 # Tailscale Serve (recommended for web UI auth)
 clawdbot_tailscale_serve: true

--- a/ansible/roles/clawdbot/defaults/main.yml
+++ b/ansible/roles/clawdbot/defaults/main.yml
@@ -19,9 +19,10 @@ clawdbot_config_dir: "/home/{{ clawdbot_user }}/.clawdbot"
 clawdbot_config_file: "{{ clawdbot_config_dir }}/clawdbot.json"
 
 # 1Password integration
-clawdbot_op_service_account_token: ""  # Set via vault or extra-vars
-clawdbot_op_vault: "openclaw"          # Vault name for secrets
-# Items in vault:
+# Service account token fetched from Infrastructure vault, allows Clawdbot to access openclaw vault at runtime
+clawdbot_op_service_account_token: "{{ lookup('community.general.onepassword', 'Clawdbot Service Account', field='credential', vault=onepassword_vault, account_id=onepassword_account_id) }}"
+clawdbot_op_vault: "openclaw"          # Vault name Clawdbot accesses at runtime
+# Items in openclaw vault:
 #   - "openclaw anthropic" - Anthropic API key
 #   - "github" - GitHub credentials  
 #   - "openai - text embedding for memory search" - OpenAI embeddings

--- a/ansible/roles/clawdbot/defaults/main.yml
+++ b/ansible/roles/clawdbot/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+# Clawdbot role defaults
+
+# User to run clawdbot as (from vars/user.yml typically)
+clawdbot_user: "{{ username }}"
+
+# Workspace
+clawdbot_workspace_repo: ""  # Required: git repo for workspace (e.g., git@github.com:user/clawd.git)
+clawdbot_workspace_path: "/home/{{ clawdbot_user }}/clawd"
+
+# Installation
+clawdbot_install_method: "npm"  # npm or git
+clawdbot_npm_package: "clawdbot"
+clawdbot_git_repo: "https://github.com/clawdbot/clawdbot.git"
+clawdbot_git_branch: "main"
+
+# Config location
+clawdbot_config_dir: "/home/{{ clawdbot_user }}/.clawdbot"
+clawdbot_config_file: "{{ clawdbot_config_dir }}/clawdbot.json"
+
+# 1Password integration
+clawdbot_op_service_account_token: ""  # Set via vault or extra-vars
+clawdbot_op_vault: "Clawdbot"          # Vault name for secrets
+
+# Tailscale Serve (recommended for web UI auth)
+clawdbot_tailscale_serve: true
+clawdbot_bind: "localhost"  # Bind to localhost when using Tailscale Serve
+clawdbot_port: 18789
+
+# Gateway options
+clawdbot_gateway_extra_args: ""

--- a/ansible/roles/clawdbot/defaults/main.yml
+++ b/ansible/roles/clawdbot/defaults/main.yml
@@ -20,7 +20,7 @@ clawdbot_config_file: "{{ clawdbot_config_dir }}/clawdbot.json"
 
 # 1Password integration
 # Service account token fetched from Infrastructure vault, allows Clawdbot to access openclaw vault at runtime
-clawdbot_op_service_account_token: "{{ lookup('community.general.onepassword', 'Clawdbot Service Account', field='credential', vault=onepassword_vault, account_id=onepassword_account_id) }}"
+clawdbot_op_service_account_token: "{{ lookup('community.general.onepassword', 'openclaw-sa-token', field='credential', vault=onepassword_vault, account_id=onepassword_account_id) }}"
 clawdbot_op_vault: "openclaw"          # Vault name Clawdbot accesses at runtime
 # Items in openclaw vault:
 #   - "openclaw anthropic" - Anthropic API key

--- a/ansible/roles/clawdbot/defaults/main.yml
+++ b/ansible/roles/clawdbot/defaults/main.yml
@@ -9,10 +9,9 @@ clawdbot_workspace_repo: ""  # Required: git repo for workspace (e.g., git@githu
 clawdbot_workspace_path: "/home/{{ clawdbot_user }}/clawd"
 
 # Installation
-clawdbot_install_method: "npm"  # npm or git
+clawdbot_install_method: "npm"  # npm only for now (git not implemented)
 clawdbot_npm_package: "clawdbot"
-clawdbot_git_repo: "https://github.com/clawdbot/clawdbot.git"
-clawdbot_git_branch: "main"
+clawdbot_version: ""  # Pin to specific version, e.g., "1.2.3" (empty = latest)
 
 # Config location
 clawdbot_config_dir: "/home/{{ clawdbot_user }}/.clawdbot"

--- a/ansible/roles/clawdbot/handlers/main.yml
+++ b/ansible/roles/clawdbot/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Reload systemd
+  become: true
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Restart clawdbot
+  become: true
+  ansible.builtin.systemd:
+    name: clawdbot
+    state: restarted

--- a/ansible/roles/clawdbot/tasks/main.yml
+++ b/ansible/roles/clawdbot/tasks/main.yml
@@ -1,0 +1,110 @@
+---
+# Clawdbot installation and configuration
+
+# Install clawdbot globally via npm
+- name: Install clawdbot via npm
+  become: true
+  become_user: "{{ clawdbot_user }}"
+  ansible.builtin.shell: |
+    export PATH="/home/{{ clawdbot_user }}/.local/share/fnm:$PATH"
+    eval "$(fnm env)"
+    npm install -g {{ clawdbot_npm_package }}
+  register: npm_install
+  changed_when: "'added' in npm_install.stdout or 'up to date' not in npm_install.stdout"
+  when: clawdbot_install_method == "npm"
+  tags:
+    - clawdbot
+    - install
+
+# Verify clawdbot is installed
+- name: Check clawdbot installation
+  become: true
+  become_user: "{{ clawdbot_user }}"
+  ansible.builtin.shell: |
+    export PATH="/home/{{ clawdbot_user }}/.local/share/fnm:$PATH"
+    eval "$(fnm env)"
+    clawdbot --version
+  register: clawdbot_version
+  changed_when: false
+  tags:
+    - clawdbot
+    - install
+
+# Clone workspace repository
+- name: Clone workspace repository
+  become: true
+  become_user: "{{ clawdbot_user }}"
+  ansible.builtin.git:
+    repo: "{{ clawdbot_workspace_repo }}"
+    dest: "{{ clawdbot_workspace_path }}"
+    version: main
+    accept_hostkey: true
+  when: clawdbot_workspace_repo | length > 0
+  tags:
+    - clawdbot
+    - workspace
+
+# Create config directory
+- name: Create clawdbot config directory
+  become: true
+  become_user: "{{ clawdbot_user }}"
+  ansible.builtin.file:
+    path: "{{ clawdbot_config_dir }}"
+    state: directory
+    mode: "0700"
+  tags:
+    - clawdbot
+    - config
+
+# Deploy config from template (placeholder - configure via wizard or migration)
+- name: Deploy clawdbot config (placeholder)
+  become: true
+  become_user: "{{ clawdbot_user }}"
+  ansible.builtin.template:
+    src: clawdbot.json.j2
+    dest: "{{ clawdbot_config_file }}"
+    mode: "0600"
+    force: false  # Don't overwrite if config already exists
+  notify: Restart clawdbot
+  tags:
+    - clawdbot
+    - config
+
+# Create systemd service
+- name: Deploy clawdbot systemd service
+  become: true
+  ansible.builtin.template:
+    src: clawdbot.service.j2
+    dest: /etc/systemd/system/clawdbot.service
+    mode: "0644"
+  notify:
+    - Reload systemd
+    - Restart clawdbot
+  tags:
+    - clawdbot
+    - systemd
+
+# Enable and start service
+- name: Enable clawdbot service
+  become: true
+  ansible.builtin.systemd:
+    name: clawdbot
+    enabled: true
+    state: started
+    daemon_reload: true
+  tags:
+    - clawdbot
+    - systemd
+    - molecule-notest
+
+# Configure Tailscale Serve for HTTPS + auth
+- name: Configure Tailscale Serve
+  become: true
+  ansible.builtin.shell: |
+    tailscale serve --bg --https=443 http://localhost:{{ clawdbot_port }}
+  when: clawdbot_tailscale_serve
+  changed_when: false
+  tags:
+    - clawdbot
+    - tailscale
+    - molecule-notest

--- a/ansible/roles/clawdbot/tasks/main.yml
+++ b/ansible/roles/clawdbot/tasks/main.yml
@@ -1,6 +1,20 @@
 ---
 # Clawdbot installation and configuration
 
+# Check current clawdbot version
+- name: Check current clawdbot version
+  become: true
+  become_user: "{{ clawdbot_user }}"
+  ansible.builtin.shell: |
+    export PATH="/home/{{ clawdbot_user }}/.local/share/fnm:$PATH"
+    eval "$(fnm env)"
+    clawdbot --version 2>/dev/null || echo "not installed"
+  register: clawdbot_current_version
+  changed_when: false
+  tags:
+    - clawdbot
+    - install
+
 # Install clawdbot globally via npm
 - name: Install clawdbot via npm
   become: true
@@ -8,24 +22,10 @@
   ansible.builtin.shell: |
     export PATH="/home/{{ clawdbot_user }}/.local/share/fnm:$PATH"
     eval "$(fnm env)"
-    npm install -g {{ clawdbot_npm_package }}
+    npm install -g {{ clawdbot_npm_package }}{% if clawdbot_version | length > 0 %}@{{ clawdbot_version }}{% endif %}
+
   register: npm_install
   changed_when: "'added' in npm_install.stdout or 'up to date' not in npm_install.stdout"
-  when: clawdbot_install_method == "npm"
-  tags:
-    - clawdbot
-    - install
-
-# Verify clawdbot is installed
-- name: Check clawdbot installation
-  become: true
-  become_user: "{{ clawdbot_user }}"
-  ansible.builtin.shell: |
-    export PATH="/home/{{ clawdbot_user }}/.local/share/fnm:$PATH"
-    eval "$(fnm env)"
-    clawdbot --version
-  register: clawdbot_version
-  changed_when: false
   tags:
     - clawdbot
     - install
@@ -66,6 +66,38 @@
     mode: "0600"
     force: false  # Don't overwrite if config already exists
   notify: Restart clawdbot
+  tags:
+    - clawdbot
+    - config
+
+# Create directory for environment file
+- name: Create clawdbot etc directory
+  become: true
+  ansible.builtin.file:
+    path: /etc/clawdbot
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+  tags:
+    - clawdbot
+    - config
+
+# Deploy 1Password service account token (root-only for security)
+- name: Deploy 1Password environment file
+  become: true
+  ansible.builtin.copy:
+    content: |
+      # 1Password service account token for Clawdbot
+      # Managed by Ansible - do not edit
+      OP_SERVICE_ACCOUNT_TOKEN={{ clawdbot_op_service_account_token }}
+    dest: /etc/clawdbot/op.env
+    owner: root
+    group: root
+    mode: "0600"
+  when: clawdbot_op_service_account_token | length > 0
+  notify: Restart clawdbot
+  no_log: true  # Don't log the token
   tags:
     - clawdbot
     - config

--- a/ansible/roles/clawdbot/templates/clawdbot.json.j2
+++ b/ansible/roles/clawdbot/templates/clawdbot.json.j2
@@ -1,0 +1,6 @@
+{
+  "_comment": "Placeholder config - run 'clawdbot setup' or migrate existing config",
+  "gateway": {
+    "port": {{ clawdbot_port }}
+  }
+}

--- a/ansible/roles/clawdbot/templates/clawdbot.service.j2
+++ b/ansible/roles/clawdbot/templates/clawdbot.service.j2
@@ -13,10 +13,8 @@ WorkingDirectory={{ clawdbot_workspace_path }}
 Environment="PATH=/home/{{ clawdbot_user }}/.local/share/fnm/aliases/default/bin:/usr/local/bin:/usr/bin:/bin"
 Environment="FNM_DIR=/home/{{ clawdbot_user }}/.local/share/fnm"
 
-{% if clawdbot_op_service_account_token | length > 0 %}
-# 1Password service account
-Environment="OP_SERVICE_ACCOUNT_TOKEN={{ clawdbot_op_service_account_token }}"
-{% endif %}
+# 1Password service account token loaded from root-only file (mode 0600)
+EnvironmentFile=-/etc/clawdbot/op.env
 
 # Gateway command
 ExecStart=/home/{{ clawdbot_user }}/.local/share/fnm/aliases/default/bin/clawdbot gateway --bind {{ clawdbot_bind }} {{ clawdbot_gateway_extra_args }}
@@ -29,7 +27,7 @@ RestartSec=10
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths={{ clawdbot_workspace_path }} {{ clawdbot_config_dir }} /home/{{ clawdbot_user }}/.clawdbot
+ReadWritePaths={{ clawdbot_workspace_path }} {{ clawdbot_config_dir }}
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/clawdbot/templates/clawdbot.service.j2
+++ b/ansible/roles/clawdbot/templates/clawdbot.service.j2
@@ -1,0 +1,35 @@
+[Unit]
+Description=Clawdbot Gateway
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ clawdbot_user }}
+Group={{ clawdbot_user }}
+WorkingDirectory={{ clawdbot_workspace_path }}
+
+# fnm environment setup
+Environment="PATH=/home/{{ clawdbot_user }}/.local/share/fnm/aliases/default/bin:/usr/local/bin:/usr/bin:/bin"
+Environment="FNM_DIR=/home/{{ clawdbot_user }}/.local/share/fnm"
+
+{% if clawdbot_op_service_account_token | length > 0 %}
+# 1Password service account
+Environment="OP_SERVICE_ACCOUNT_TOKEN={{ clawdbot_op_service_account_token }}"
+{% endif %}
+
+# Gateway command
+ExecStart=/home/{{ clawdbot_user }}/.local/share/fnm/aliases/default/bin/clawdbot gateway --bind {{ clawdbot_bind }} {{ clawdbot_gateway_extra_args }}
+
+# Restart policy
+Restart=always
+RestartSec=10
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths={{ clawdbot_workspace_path }} {{ clawdbot_config_dir }} /home/{{ clawdbot_user }}/.clawdbot
+
+[Install]
+WantedBy=multi-user.target

--- a/terraform/clawdbot.tf
+++ b/terraform/clawdbot.tf
@@ -11,7 +11,7 @@ resource "digitalocean_droplet" "clawdbot" {
   image    = "ubuntu-24-04-x64"
   name     = "clawdbot"
   region   = "sfo3"
-  size     = "s-1vcpu-2gb"  # $12/mo - plenty for Clawdbot
+  size     = "s-1vcpu-2gb" # $12/mo - plenty for Clawdbot
   ipv6     = true
   vpc_uuid = digitalocean_vpc.clawdbot-vpc.id
   ssh_keys = [digitalocean_ssh_key.github.fingerprint]

--- a/terraform/clawdbot.tf
+++ b/terraform/clawdbot.tf
@@ -1,0 +1,59 @@
+# Clawdbot droplet - AI assistant
+# Access via Tailscale only (no public ports)
+
+resource "digitalocean_vpc" "clawdbot-vpc" {
+  name     = "clawdbot-vpc"
+  region   = "sfo3"
+  ip_range = "10.10.30.0/24"
+}
+
+resource "digitalocean_droplet" "clawdbot" {
+  image    = "ubuntu-24-04-x64"
+  name     = "clawdbot"
+  region   = "sfo3"
+  size     = "s-1vcpu-2gb"  # $12/mo - plenty for Clawdbot
+  ipv6     = true
+  vpc_uuid = digitalocean_vpc.clawdbot-vpc.id
+  ssh_keys = [digitalocean_ssh_key.github.fingerprint]
+
+  tags = ["clawdbot"]
+
+  user_data = templatefile("${path.module}/cloud-init/tailscale.yml", {
+    tailscale_authkey = data.onepassword_item.tailscale.credential
+    hostname          = "clawdbot"
+  })
+}
+
+# Firewall - Tailscale only (no public inbound)
+resource "digitalocean_firewall" "clawdbot" {
+  name        = "clawdbot-fw"
+  droplet_ids = [digitalocean_droplet.clawdbot.id]
+
+  # No inbound rules - all access via Tailscale
+
+  # Outbound - allow all (API calls, Tailscale, updates, etc.)
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "icmp"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+}
+
+output "clawdbot_ip" {
+  value = digitalocean_droplet.clawdbot.ipv4_address
+}
+
+output "clawdbot_ipv6" {
+  value = digitalocean_droplet.clawdbot.ipv6_address
+}


### PR DESCRIPTION
Infrastructure for running Clawdbot on a dedicated DigitalOcean droplet.

## Terraform
- New droplet in sfo3 with Tailscale via cloud-init
- No public ports - all access via Tailscale
- Minimal firewall (outbound only)

## Ansible
- `clawdbot.yml` playbook
- `clawdbot` role:
  - Installs Node.js via fnm
  - Installs clawdbot via npm
  - Clones workspace repo
  - Sets up systemd service
  - Configures Tailscale Serve for HTTPS + identity auth

## Deployment Steps
```bash
# 1. Create droplet
cd terraform && terraform apply

# 2. Bootstrap (user + docker + SSH key)
cd ../ansible
ansible-playbook -i inventory.yml bootstrap.yml --limit clawdbot -u root

# 3. Deploy Clawdbot
ansible-playbook -i inventory.yml clawdbot.yml

# 4. Migrate config (from Mac)
scp ~/.clawdbot/clawdbot.json clawdbot:~/.clawdbot/
ssh clawdbot sudo systemctl restart clawdbot
```

## Web UI Access
Via Tailscale: `https://clawdbot.<tailnet>/` (auto-authenticated via Tailscale identity)

## TODO before deploy
- [ ] Create 1Password vault "Clawdbot" with service token
- [ ] Push workspace to git repo
- [ ] Decide on config migration strategy