### PR TITLE
fix: enable Tailscale auth when using Tailscale Serve

### DIFF
--- a/ansible/roles/clawdbot/templates/clawdbot.json.j2
+++ b/ansible/roles/clawdbot/templates/clawdbot.json.j2
@@ -1,6 +1,10 @@
 {
-  "_comment": "Placeholder config - run 'clawdbot setup' or migrate existing config",
   "gateway": {
-    "port": {{ clawdbot_port }}
+    "port": {{ clawdbot_port }},
+    "auth": {
+{% if clawdbot_tailscale_serve %}
+      "allowTailscale": true
+{% endif %}
+    }
   }
 }


### PR DESCRIPTION
Adds `gateway.auth.allowTailscale: true` to the config template when `clawdbot_tailscale_serve` is enabled.