### PR TITLE
Add SAIR portal infra (sair.run landing page)

### DIFF
--- a/ansible/projects.yml
+++ b/ansible/projects.yml
@@ -13,7 +13,9 @@
     # SAIR orchestrator
     sair_orchestrator_api_key: "{{ lookup('community.general.onepassword', 'sair-api-key', field='credential', vault=onepassword_vault, account_id=onepassword_account_id) }}"
     sair_orchestrator_ghcr_token: "{{ lookup('community.general.onepassword', 'gh-actions-runner-pat', field='credential', vault=onepassword_vault, account_id=onepassword_account_id) }}"
+    sair_portal_ghcr_token: "{{ lookup('community.general.onepassword', 'gh-actions-runner-pat', field='credential', vault=onepassword_vault, account_id=onepassword_account_id) }}"
   roles:
     - projects          # Deploy nginx first so logs exist
     - sair-orchestrator  # SAIR orchestrator behind nginx-proxy + gRPC on :9090
+    - sair-portal        # SAIR landing page at sair.run
     - fail2ban          # Then fail2ban can monitor logs

--- a/ansible/roles/sair-portal/defaults/main.yml
+++ b/ansible/roles/sair-portal/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# SAIR portal role defaults
+
+sair_portal_image: "ghcr.io/compscidr/sair-portal:latest"
+sair_portal_port: 8080
+sair_portal_domain: "sair.run"
+sair_portal_letsencrypt_email: "ernstjason1@gmail.com"
+sair_portal_ghcr_token: ""
+sair_portal_ghcr_user: "compscidr"

--- a/ansible/roles/sair-portal/tasks/main.yml
+++ b/ansible/roles/sair-portal/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+# Deploy SAIR portal on the projects droplet
+# Landing page + future auth/billing at sair.run
+
+- name: Log in to GHCR
+  become: true
+  community.docker.docker_login:
+    registry: ghcr.io
+    username: "{{ sair_portal_ghcr_user }}"
+    password: "{{ sair_portal_ghcr_token }}"
+  when: sair_portal_ghcr_token | length > 0
+  no_log: true
+
+- name: Deploy SAIR portal
+  become: true
+  community.docker.docker_container:
+    name: sair-portal
+    image: "{{ sair_portal_image }}"
+    pull: true
+    restart_policy: unless-stopped
+    networks:
+      - name: nginx-proxy
+    env:
+      PORTAL_PORT: "{{ sair_portal_port | string }}"
+      VIRTUAL_HOST: "{{ sair_portal_domain }},www.{{ sair_portal_domain }}"
+      VIRTUAL_PORT: "{{ sair_portal_port | string }}"
+      LETSENCRYPT_HOST: "{{ sair_portal_domain }},www.{{ sair_portal_domain }}"
+      LETSENCRYPT_EMAIL: "{{ sair_portal_letsencrypt_email }}"

--- a/terraform/projects.tf
+++ b/terraform/projects.tf
@@ -178,6 +178,27 @@ resource "digitalocean_domain" "sair-run" {
   name = "sair.run"
 }
 
+resource "digitalocean_record" "sair-A" {
+  domain = digitalocean_domain.sair-run.name
+  type   = "A"
+  name   = "@"
+  value  = digitalocean_droplet.projects.ipv4_address
+}
+
+resource "digitalocean_record" "sair-AAAA" {
+  domain = digitalocean_domain.sair-run.name
+  type   = "AAAA"
+  name   = "@"
+  value  = digitalocean_droplet.projects.ipv6_address
+}
+
+resource "digitalocean_record" "sair-CNAME-www" {
+  domain = digitalocean_domain.sair-run.name
+  type   = "CNAME"
+  name   = "www"
+  value  = "@"
+}
+
 resource "digitalocean_record" "sair-orchestrator-A" {
   domain = digitalocean_domain.sair-run.name
   type   = "A"


### PR DESCRIPTION
## Summary
- Add `sair.run` root domain A/AAAA records + www CNAME (terraform)
- Create `sair-portal` ansible role to deploy portal container behind nginx-proxy with TLS
- Add portal role to projects playbook

**Base:** `jason/move-orchestrator-to-projects` (PR #356) — merge that first.

## Test plan
- [ ] `terraform apply` — root domain DNS records created
- [ ] `ansible-playbook projects.yml` — portal container deployed
- [ ] https://sair.run loads the landing page with TLS

🤖 Generated with [Claude Code](https://claude.com/claude-code)