### PR TITLE
Fix orchestrator TLS cert paths and key permissions

### DIFF
--- a/ansible/roles/sair-orchestrator/tasks/main.yml
+++ b/ansible/roles/sair-orchestrator/tasks/main.yml
@@ -25,6 +25,9 @@
           'VIRTUAL_PORT': sair_orchestrator_dashboard_port | string,
           'LETSENCRYPT_HOST': sair_orchestrator_domain,
           'LETSENCRYPT_EMAIL': sair_orchestrator_letsencrypt_email,
+          # acme-companion stores certs under /<domain>/fullchain.pem and key.pem.
+          # Root-level <domain>.crt/.key symlinks only exist for containers routed
+          # through nginx-proxy; the orchestrator serves gRPC directly on :9090.
           'TLS_CERT_PATH': '/certs/' + sair_orchestrator_domain + '/fullchain.pem',
           'TLS_KEY_PATH': '/certs/' + sair_orchestrator_domain + '/key.pem',
         }
@@ -53,6 +56,14 @@
     networks:
       - name: nginx-proxy
     user: root  # key.pem is 0600 root-only in nginx-certs volume
+    security_opts:
+      - "no-new-privileges:true"
+    capabilities:
+      drop:
+        - ALL
+    read_only: true
+    tmpfs:
+      - "/tmp"
     volumes:
       - "nginx-certs:/certs:ro"
     dns_servers:

--- a/ansible/roles/sair-orchestrator/tasks/main.yml
+++ b/ansible/roles/sair-orchestrator/tasks/main.yml
@@ -25,8 +25,8 @@
           'VIRTUAL_PORT': sair_orchestrator_dashboard_port | string,
           'LETSENCRYPT_HOST': sair_orchestrator_domain,
           'LETSENCRYPT_EMAIL': sair_orchestrator_letsencrypt_email,
-          'TLS_CERT_PATH': '/certs/' + sair_orchestrator_domain + '.crt',
-          'TLS_KEY_PATH': '/certs/' + sair_orchestrator_domain + '.key',
+          'TLS_CERT_PATH': '/certs/' + sair_orchestrator_domain + '/fullchain.pem',
+          'TLS_KEY_PATH': '/certs/' + sair_orchestrator_domain + '/key.pem',
         }
         | combine(
             {'SAIR_TENANT_CONFIG': sair_orchestrator_tenant_config}
@@ -52,6 +52,7 @@
       - "{{ sair_orchestrator_port }}:{{ sair_orchestrator_port }}"
     networks:
       - name: nginx-proxy
+    user: root  # key.pem is 0600 root-only in nginx-certs volume
     volumes:
       - "nginx-certs:/certs:ro"
     dns_servers:


### PR DESCRIPTION
## Summary
- Fix TLS cert paths: acme-companion uses subdirectory layout (`orchestrator.sair.run/fullchain.pem` and `key.pem`), not root-level `.crt`/`.key` symlinks
- Add `user: root` to container: `key.pem` is `0600` root-only in the nginx-certs volume, and the container runs as non-root `sair` user by default

## Test plan
- [ ] Redeploy orchestrator and verify TLS handshake on port 9090

🤖 Generated with [Claude Code](https://claude.com/claude-code)