### PR TITLE
Fix Jinja2 syntax error in orchestrator TLS comment

### DIFF
--- a/ansible/roles/sair-orchestrator/tasks/main.yml
+++ b/ansible/roles/sair-orchestrator/tasks/main.yml
@@ -25,9 +25,7 @@
           'VIRTUAL_PORT': sair_orchestrator_dashboard_port | string,
           'LETSENCRYPT_HOST': sair_orchestrator_domain,
           'LETSENCRYPT_EMAIL': sair_orchestrator_letsencrypt_email,
-          # acme-companion stores certs under /<domain>/fullchain.pem and key.pem.
-          # Root-level <domain>.crt/.key symlinks only exist for containers routed
-          # through nginx-proxy; the orchestrator serves gRPC directly on :9090.
+          {# acme-companion uses /<domain>/fullchain.pem layout, not root-level .crt/.key #}
           'TLS_CERT_PATH': '/certs/' + sair_orchestrator_domain + '/fullchain.pem',
           'TLS_KEY_PATH': '/certs/' + sair_orchestrator_domain + '/key.pem',
         }


### PR DESCRIPTION
## Summary
- The `#` comment added inside the `>-` Jinja2 template block causes a syntax error — Jinja2 doesn't support Python-style `#` comments
- Switched to Jinja2 `{# #}` comment syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)