### PR TITLE
Remove comment from Jinja2 expression block

### DIFF
--- a/ansible/roles/sair-orchestrator/tasks/main.yml
+++ b/ansible/roles/sair-orchestrator/tasks/main.yml
@@ -25,7 +25,6 @@
           'VIRTUAL_PORT': sair_orchestrator_dashboard_port | string,
           'LETSENCRYPT_HOST': sair_orchestrator_domain,
           'LETSENCRYPT_EMAIL': sair_orchestrator_letsencrypt_email,
-          {# acme-companion uses /<domain>/fullchain.pem layout, not root-level .crt/.key #}
           'TLS_CERT_PATH': '/certs/' + sair_orchestrator_domain + '/fullchain.pem',
           'TLS_KEY_PATH': '/certs/' + sair_orchestrator_domain + '/key.pem',
         }


### PR DESCRIPTION
## Summary
- Remove the `{# #}` comment from inside the `{{ }}` Jinja2 expression — no form of comment is valid inside a Jinja2 expression block

🤖 Generated with [Claude Code](https://claude.com/claude-code)