### PR TITLE
Fix cap_drop syntax for docker_container module

### DIFF
--- a/ansible/roles/sair-orchestrator/tasks/main.yml
+++ b/ansible/roles/sair-orchestrator/tasks/main.yml
@@ -55,9 +55,8 @@
     user: root  # key.pem is 0600 root-only in nginx-certs volume
     security_opts:
       - "no-new-privileges:true"
-    capabilities:
-      drop:
-        - ALL
+    cap_drop:
+      - ALL
     read_only: true
     tmpfs:
       - "/tmp"


### PR DESCRIPTION
## Summary
- `community.docker.docker_container` uses `cap_drop` (flat list), not `capabilities: drop:` (dict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)