### PR TITLE
Add mail support for sair.run

### DIFF
--- a/ansible/roles/mailu/defaults/main.yml
+++ b/ansible/roles/mailu/defaults/main.yml
@@ -23,6 +23,13 @@ mailu_users:
   - user: kai
     password: "{{ lookup('community.general.onepassword', 'mail.jasonernst.com - kai', field='password', vault='Infrastructure', account_id=onepassword_account_id) }}"
 
+# Additional domains hosted on this Mailu instance
+mailu_additional_domains:
+  - domain: sair.run
+    users:
+      - user: jason
+        password: "{{ lookup('community.general.onepassword', 'mail.sair.run - jason', field='password', vault='Infrastructure', account_id=onepassword_account_id) }}"
+
 # Features
 mailu_webmail: roundcube  # roundcube, snappymail, or none
 mailu_antivirus: false    # ClamAV uses lots of RAM

--- a/ansible/roles/mailu/tasks/main.yml
+++ b/ansible/roles/mailu/tasks/main.yml
@@ -104,6 +104,35 @@
   failed_when: false  # May fail if user exists
   no_log: true  # Hide passwords
 
+- name: Import additional domains via config-import
+  become: true
+  ansible.builtin.shell:
+    cmd: |
+      echo 'domain:
+        - name: {{ item.domain }}
+          dkim_key: -generate-
+      ' | docker compose exec -T admin flask mailu config-import --update
+  args:
+    chdir: "{{ mailu_install_path }}"
+  loop: "{{ mailu_additional_domains | default([]) }}"
+  register: domain_result
+  changed_when: "'updated' in domain_result.stdout | default('')"
+  failed_when: false
+
+- name: Create additional domain users
+  become: true
+  ansible.builtin.command:
+    cmd: >
+      docker compose exec -T admin flask mailu user
+      {{ item.1.user }} {{ item.0.domain }} {{ item.1.password }}
+  args:
+    chdir: "{{ mailu_install_path }}"
+  loop: "{{ mailu_additional_domains | default([]) | subelements('users') }}"
+  register: user_result
+  changed_when: false
+  failed_when: false  # May fail if user exists
+  no_log: true  # Hide passwords
+
 - name: Get DKIM public key
   become: true
   ansible.builtin.command:
@@ -120,3 +149,22 @@
       Type: TXT
       Value: {{ dkim_key.stdout | default('DKIM key not yet generated - restart admin container') }}
   when: dkim_key.stdout is defined and dkim_key.stdout | length > 0
+
+- name: Get DKIM public keys for additional domains
+  become: true
+  ansible.builtin.command:
+    cmd: cat "{{ mailu_install_path }}/dkim/{{ item.domain }}.dkim.key"
+  loop: "{{ mailu_additional_domains | default([]) }}"
+  register: additional_dkim_keys
+  changed_when: false
+  failed_when: false
+
+- name: Display DKIM keys for additional domains
+  ansible.builtin.debug:
+    msg: |
+      Add this DKIM record to DNS:
+      Name: dkim._domainkey.{{ item.item.domain }}
+      Type: TXT
+      Value: {{ item.stdout | default('DKIM key not yet generated - add domain in admin UI and restart') }}
+  loop: "{{ additional_dkim_keys.results | default([]) }}"
+  when: item.stdout is defined and item.stdout | length > 0

--- a/ansible/roles/mailu/templates/docker-compose.yml.j2
+++ b/ansible/roles/mailu/templates/docker-compose.yml.j2
@@ -28,9 +28,11 @@ services:
       - certs:/certs:ro
       - "{{ mailu_install_path }}/overrides/nginx:/overrides:ro"
     environment:
-      - VIRTUAL_HOST={{ mailu_hostname }}
+      - VIRTUAL_HOST={{ mailu_hostname }}{% for domain in mailu_additional_domains | default([]) %},mail.{{ domain.domain }}{% endfor %}
+
       - VIRTUAL_PORT=80
-      - LETSENCRYPT_HOST={{ mailu_hostname }}
+      - LETSENCRYPT_HOST={{ mailu_hostname }}{% for domain in mailu_additional_domains | default([]) %},mail.{{ domain.domain }}{% endfor %}
+
       - LETSENCRYPT_EMAIL={{ mailu_admin_email | default('admin@' + mailu_domain) }}
     networks:
       - mailu

--- a/ansible/roles/mailu/templates/mailu.env.j2
+++ b/ansible/roles/mailu/templates/mailu.env.j2
@@ -4,7 +4,8 @@
 # Common configuration
 SECRET_KEY={{ mailu_secret_key }}
 DOMAIN={{ mailu_domain }}
-HOSTNAMES={{ mailu_hostname }}
+HOSTNAMES={{ mailu_hostname }}{% for domain in mailu_additional_domains | default([]) %},mail.{{ domain.domain }}{% endfor %}
+
 POSTMASTER=admin
 
 # Network configuration

--- a/terraform/mail-sair.tf
+++ b/terraform/mail-sair.tf
@@ -1,0 +1,145 @@
+# Mail DNS records for sair.run
+# Mail is handled by the existing Mailu instance on mail.jasonernst.com
+
+# A/AAAA records for mail.sair.run -> www droplet (where Mailu runs)
+resource "digitalocean_record" "sair-A-mail" {
+  domain = digitalocean_domain.sair-run.name
+  type   = "A"
+  name   = "mail"
+  value  = digitalocean_droplet.www-jasonernst-com.ipv4_address
+}
+
+resource "digitalocean_record" "sair-AAAA-mail" {
+  domain = digitalocean_domain.sair-run.name
+  type   = "AAAA"
+  name   = "mail"
+  value  = digitalocean_droplet.www-jasonernst-com.ipv6_address
+}
+
+# MX record - mail.sair.run handles mail for sair.run
+resource "digitalocean_record" "sair-MX" {
+  domain   = digitalocean_domain.sair-run.name
+  type     = "MX"
+  name     = "@"
+  value    = "mail.sair.run."
+  priority = 10
+}
+
+# SPF record - authorize the mail server to send on behalf of this domain
+resource "digitalocean_record" "sair-TXT-SPF" {
+  domain = digitalocean_domain.sair-run.name
+  type   = "TXT"
+  name   = "@"
+  value  = "v=spf1 mx -all"
+}
+
+# DMARC record - policy for handling failed authentication
+resource "digitalocean_record" "sair-TXT-DMARC" {
+  domain = digitalocean_domain.sair-run.name
+  type   = "TXT"
+  name   = "_dmarc"
+  value  = "v=DMARC1; p=reject; rua=mailto:jason@sair.run; ruf=mailto:jason@sair.run; adkim=s; aspf=s"
+}
+
+# DMARC report record - allows receiving DMARC reports for this domain
+resource "digitalocean_record" "sair-TXT-DMARC-report" {
+  domain = digitalocean_domain.sair-run.name
+  type   = "TXT"
+  name   = "sair.run._report._dmarc"
+  value  = "v=DMARC1;"
+}
+
+# DKIM record for Mailu
+resource "digitalocean_record" "sair-TXT-DKIM" {
+  domain = digitalocean_domain.sair-run.name
+  type   = "TXT"
+  name   = "dkim._domainkey"
+  value  = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt5iRGBX4i54jYyQfFZ02XXJlFIE0vqauHm5/fv5qKg2jeVp9m78oimaw4va9uCJaOGXf8Mhwb72NxOsdkS/r5KT7fqUYMo0gxFT5kOgts2fUTiLeFMvjaSOe1YQMtivyULHSfLD5cm+LVOn2pUKxENrycfnaeQ7Qfo84sBZLxr3Fk11ElDWnb75WVESA7Y6R/AHMnc1qhlVTx4OAlNszc1PRjXknUSgyI8I5C7WzHRYty8iJzpmbJrejabJFPJZGUwUyiXmuqGlb15+jRCeVB1eUHKpyRnBrLGBhoA+3Jr2xCYDv/vgkEVvje27nNA55jEH0bpfJ4gvV8Tn8YldmHQIDAQAB"
+}
+
+# Mail client auto-configuration
+resource "digitalocean_record" "sair-CNAME-autoconfig" {
+  domain = digitalocean_domain.sair-run.name
+  type   = "CNAME"
+  name   = "autoconfig"
+  value  = "mail.sair.run."
+}
+
+resource "digitalocean_record" "sair-CNAME-autodiscover" {
+  domain = digitalocean_domain.sair-run.name
+  type   = "CNAME"
+  name   = "autodiscover"
+  value  = "mail.sair.run."
+}
+
+# SRV records for mail client auto-discovery
+resource "digitalocean_record" "sair-SRV-autodiscover" {
+  domain   = digitalocean_domain.sair-run.name
+  type     = "SRV"
+  name     = "_autodiscover._tcp"
+  value    = "mail.sair.run."
+  priority = 10
+  weight   = 1
+  port     = 443
+}
+
+resource "digitalocean_record" "sair-SRV-submissions" {
+  domain   = digitalocean_domain.sair-run.name
+  type     = "SRV"
+  name     = "_submissions._tcp"
+  value    = "mail.sair.run."
+  priority = 10
+  weight   = 1
+  port     = 465
+}
+
+resource "digitalocean_record" "sair-SRV-imaps" {
+  domain   = digitalocean_domain.sair-run.name
+  type     = "SRV"
+  name     = "_imaps._tcp"
+  value    = "mail.sair.run."
+  priority = 10
+  weight   = 1
+  port     = 993
+}
+
+resource "digitalocean_record" "sair-SRV-pop3s" {
+  domain   = digitalocean_domain.sair-run.name
+  type     = "SRV"
+  name     = "_pop3s._tcp"
+  value    = "mail.sair.run."
+  priority = 10
+  weight   = 1
+  port     = 995
+}
+
+# Disable plaintext protocols (SRV with target "." means not available)
+resource "digitalocean_record" "sair-SRV-imap-disabled" {
+  domain   = digitalocean_domain.sair-run.name
+  type     = "SRV"
+  name     = "_imap._tcp"
+  value    = "."
+  priority = 0
+  weight   = 0
+  port     = 0
+}
+
+resource "digitalocean_record" "sair-SRV-pop3-disabled" {
+  domain   = digitalocean_domain.sair-run.name
+  type     = "SRV"
+  name     = "_pop3._tcp"
+  value    = "."
+  priority = 0
+  weight   = 0
+  port     = 0
+}
+
+resource "digitalocean_record" "sair-SRV-submission-disabled" {
+  domain   = digitalocean_domain.sair-run.name
+  type     = "SRV"
+  name     = "_submission._tcp"
+  value    = "."
+  priority = 0
+  weight   = 0
+  port     = 0
+}


### PR DESCRIPTION
## Summary
- Add `sair.run` as an additional domain on the existing Mailu mail server
- DNS records: MX, SPF, DMARC, DKIM, autoconfig/autodiscover, SRV records
- Extend Mailu Ansible role to support multiple domains via `config-import`
- Add `mail.sair.run` as a web-accessible hostname for webmail/admin UI
- Create `jason@sair.run` mail account

## Test plan
- [x] DNS records resolve correctly (`dig mail.sair.run`)
- [x] Webmail accessible at `https://mail.sair.run/webmail/`
- [x] Admin accessible at `https://mail.sair.run/admin/`
- [x] Sending mail from `jason@sair.run` works
- [x] Receiving mail at `jason@sair.run` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)