### PR TITLE
Fix portal data directory UID to match container

### DIFF
--- a/ansible/roles/sair-portal/defaults/main.yml
+++ b/ansible/roles/sair-portal/defaults/main.yml
@@ -17,3 +17,6 @@ sair_portal_smtp_from: ""
 
 # Data directory for SQLite database
 sair_portal_data_dir: "/opt/sair-portal/data"
+# Must match the UID/GID of the sair user in the portal container Dockerfile
+sair_portal_uid: "10001"
+sair_portal_gid: "10001"

--- a/ansible/roles/sair-portal/tasks/main.yml
+++ b/ansible/roles/sair-portal/tasks/main.yml
@@ -16,8 +16,8 @@
   ansible.builtin.file:
     path: "{{ sair_portal_data_dir }}"
     state: directory
-    owner: "1000"
-    group: "1000"
+    owner: "10001"
+    group: "10001"
     mode: "0755"
 
 - name: Deploy SAIR portal

--- a/ansible/roles/sair-portal/tasks/main.yml
+++ b/ansible/roles/sair-portal/tasks/main.yml
@@ -16,9 +16,10 @@
   ansible.builtin.file:
     path: "{{ sair_portal_data_dir }}"
     state: directory
-    owner: "10001"
-    group: "10001"
-    mode: "0755"
+    owner: "{{ sair_portal_uid }}"
+    group: "{{ sair_portal_gid }}"
+    mode: "0700"
+    recurse: true
 
 - name: Deploy SAIR portal
   become: true


### PR DESCRIPTION
## Summary
- Changes host directory ownership from `1000:1000` to `10001:10001` to match the portal container's `sair` user UID

The portal container was crash-looping with `Permission denied` on `/app/data/portal.db` because the bind-mounted directory was owned by UID 1000 but the container user has UID 10001.

Companion to https://github.com/compscidr/sair/pull/429

## Test plan
- [ ] Portal container starts without SQLite permission errors after redeployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)