### PR TITLE
Fix Tailscale apt Signed-By conflict between common_cli and dev roles

### DIFF
--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -321,26 +321,6 @@
       - terraform
       - packer
 
-- name: Add tailscale repository
-  become: true
-  tags: tailscale
-  ansible.builtin.deb822_repository:
-    name: tailscale
-    state: present
-    types: [deb]
-    uris: "https://pkgs.tailscale.com/stable/ubuntu"
-    suites: "{{ ansible_distribution_release }}"
-    components: [main]
-    signed_by: "https://pkgs.tailscale.com/stable/ubuntu/{{ ansible_distribution_release }}.noarmor.gpg"
-    enabled: true
-
-- name: Install tailscale tools
-  become: true
-  tags: tailscale
-  ansible.builtin.apt:
-    update_cache: true
-    pkg:
-      - tailscale
 
 # Remove global OP service account token - use interactive signin instead
 - name: Remove global op service account token file


### PR DESCRIPTION
## Summary
- Removes duplicate Tailscale apt repository config from the `dev` role
- The `common_cli` role already installs Tailscale (via `curl | sh`), which sets up the apt source with `Signed-By: /usr/share/keyrings/tailscale-archive-keyring.gpg`
- The `dev` role was redundantly adding the same repo via `deb822_repository` with a different key path (`/etc/apt/keyrings/tailscale.gpg`), causing apt to fail on hosts in both groups (e.g. `ubuntu-cube.local`)

## Manual cleanup needed
On affected hosts, remove the stale deb822 source file:
```
ssh ubuntu-cube.local "sudo rm /etc/apt/sources.list.d/tailscale.sources"
```

## Test plan
- [ ] Run `apt update` on `ubuntu-cube.local` after removing the stale source file
- [ ] Run the sair playbook against `ubuntu-cube.local` to confirm it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)