### PR TITLE
Use port 465 (TLS) for portal SMTP

### DIFF
--- a/ansible/roles/sair-portal/defaults/main.yml
+++ b/ansible/roles/sair-portal/defaults/main.yml
@@ -10,7 +10,7 @@ sair_portal_ghcr_user: "compscidr"
 
 # SMTP for magic link auth
 sair_portal_smtp_host: "mail.sair.run"
-sair_portal_smtp_port: "465"
+sair_portal_smtp_port: 465
 sair_portal_smtp_username: ""
 sair_portal_smtp_password: ""
 sair_portal_smtp_from: ""

--- a/ansible/roles/sair-portal/defaults/main.yml
+++ b/ansible/roles/sair-portal/defaults/main.yml
@@ -10,7 +10,7 @@ sair_portal_ghcr_user: "compscidr"
 
 # SMTP for magic link auth
 sair_portal_smtp_host: "mail.sair.run"
-sair_portal_smtp_port: "587"
+sair_portal_smtp_port: "465"
 sair_portal_smtp_username: ""
 sair_portal_smtp_password: ""
 sair_portal_smtp_from: ""


### PR DESCRIPTION
## Summary
- Mailu uses port 465 with implicit TLS for outgoing mail, not 587 with STARTTLS
- Updates the default SMTP port from 587 to 465

## Related
- compscidr/sair#430 (adds error logging + switches to `mail.smtp.ssl.enable`)

## Test plan
- [ ] Deploy portal and verify magic link emails send successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)