### PR TITLE
Cast SMTP_PORT to string in docker env

### DIFF
--- a/ansible/roles/sair-portal/tasks/main.yml
+++ b/ansible/roles/sair-portal/tasks/main.yml
@@ -39,7 +39,7 @@
       PORTAL_BASE_URL: "https://{{ sair_portal_domain }}"
       PORTAL_DB_PATH: "/app/data/portal.db"
       SMTP_HOST: "{{ sair_portal_smtp_host }}"
-      SMTP_PORT: "{{ sair_portal_smtp_port }}"
+      SMTP_PORT: "{{ sair_portal_smtp_port | string }}"
       SMTP_USERNAME: "{{ sair_portal_smtp_username }}"
       SMTP_PASSWORD: "{{ sair_portal_smtp_password }}"
       SMTP_FROM: "{{ sair_portal_smtp_from }}"


### PR DESCRIPTION
## Summary
- Fixes deploy failure after #366 changed `sair_portal_smtp_port` default from `"465"` to `465` (integer)
- Docker container env values must be strings — adds `| string` filter, matching the existing pattern used for `PORTAL_PORT` and `VIRTUAL_PORT`

## Test plan
- [ ] Re-run deploy and verify portal starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)