### PR TITLE
Fix DKIM key regeneration on Mailu playbook runs

### DIFF
--- a/ansible/roles/mailu/tasks/main.yml
+++ b/ansible/roles/mailu/tasks/main.yml
@@ -104,19 +104,42 @@
   failed_when: false  # May fail if user exists
   no_log: true  # Hide passwords
 
-- name: Import additional domains via config-import
+- name: Check if additional domain DKIM key exists
+  become: true
+  ansible.builtin.stat:
+    path: "{{ mailu_install_path }}/dkim/{{ item.domain }}.dkim.key"
+  loop: "{{ mailu_additional_domains | default([]) }}"
+  register: additional_dkim_stat
+
+- name: Import additional domains with DKIM key generation (first time only)
   become: true
   ansible.builtin.shell:
     cmd: |
       echo 'domain:
-        - name: {{ item.domain }}
+        - name: {{ item.item.domain }}
           dkim_key: -generate-
       ' | docker compose exec -T admin flask mailu config-import --update
   args:
     chdir: "{{ mailu_install_path }}"
-  loop: "{{ mailu_additional_domains | default([]) }}"
-  register: domain_result
-  changed_when: "'updated' in domain_result.stdout | default('')"
+  loop: "{{ additional_dkim_stat.results }}"
+  when: not item.stat.exists
+  register: domain_result_new
+  changed_when: "'updated' in domain_result_new.stdout | default('')"
+  failed_when: false
+
+- name: Import additional domains without regenerating DKIM key
+  become: true
+  ansible.builtin.shell:
+    cmd: |
+      echo 'domain:
+        - name: {{ item.item.domain }}
+      ' | docker compose exec -T admin flask mailu config-import --update
+  args:
+    chdir: "{{ mailu_install_path }}"
+  loop: "{{ additional_dkim_stat.results }}"
+  when: item.stat.exists
+  register: domain_result_existing
+  changed_when: "'updated' in domain_result_existing.stdout | default('')"
   failed_when: false
 
 - name: Create additional domain users

--- a/ansible/roles/mailu/tasks/main.yml
+++ b/ansible/roles/mailu/tasks/main.yml
@@ -121,7 +121,7 @@
       ' | docker compose exec -T admin flask mailu config-import --update
   args:
     chdir: "{{ mailu_install_path }}"
-  loop: "{{ additional_dkim_stat.results }}"
+  loop: "{{ additional_dkim_stat.results | default([]) }}"
   when: not item.stat.exists
   register: domain_result_new
   changed_when: "'updated' in domain_result_new.stdout | default('')"
@@ -136,7 +136,7 @@
       ' | docker compose exec -T admin flask mailu config-import --update
   args:
     chdir: "{{ mailu_install_path }}"
-  loop: "{{ additional_dkim_stat.results }}"
+  loop: "{{ additional_dkim_stat.results | default([]) }}"
   when: item.stat.exists
   register: domain_result_existing
   changed_when: "'updated' in domain_result_existing.stdout | default('')"

--- a/terraform/mail-sair.tf
+++ b/terraform/mail-sair.tf
@@ -54,7 +54,7 @@ resource "digitalocean_record" "sair-TXT-DKIM" {
   domain = digitalocean_domain.sair-run.name
   type   = "TXT"
   name   = "dkim._domainkey"
-  value  = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt5iRGBX4i54jYyQfFZ02XXJlFIE0vqauHm5/fv5qKg2jeVp9m78oimaw4va9uCJaOGXf8Mhwb72NxOsdkS/r5KT7fqUYMo0gxFT5kOgts2fUTiLeFMvjaSOe1YQMtivyULHSfLD5cm+LVOn2pUKxENrycfnaeQ7Qfo84sBZLxr3Fk11ElDWnb75WVESA7Y6R/AHMnc1qhlVTx4OAlNszc1PRjXknUSgyI8I5C7WzHRYty8iJzpmbJrejabJFPJZGUwUyiXmuqGlb15+jRCeVB1eUHKpyRnBrLGBhoA+3Jr2xCYDv/vgkEVvje27nNA55jEH0bpfJ4gvV8Tn8YldmHQIDAQAB"
+  value  = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA8/bhNGc+JfsAUTPlvK3b7s34jjR+lLdGdGadPhN9G0R95kMCUutTkYoL1zO60U/xRyWjXaXGMkukOyJL2sIfFqag4LjTCNX5K+TAn/kzTV5y6pLDbUCB4hyrcgbZTMbCCPCjUTYSyQFF1SmJwAAwwQ8WGLPLy+L5JEmRIsu5XVzCe5VKUxncxG/xdufllJx2TRuWxecZOmtmGgLilPa+lVsJQVFRpYuNIeIUFDM2kayqkYQYbv+mt3Edm6iR40uRNpO/8AG8Z26E+P/tL5iwXa2T8bXOiOBgVouiJaUFpO3TnQsZtp0RniSLB34M+10mK7EmryBA6rQyGY1K959GJQIDAQAB"
 }
 
 # Mail client auto-configuration


### PR DESCRIPTION
## Summary
- The `config-import` task was passing `dkim_key: -generate-` on every playbook run, which could regenerate the DKIM private key and break DNS alignment
- Now checks if the DKIM key file exists before importing: only generates on first domain import, omits `dkim_key` on subsequent runs
- Root cause of sair.run DKIM failures seen in Google DMARC reports (`dkim=fail` while `spf=pass`)

## Test plan
- [ ] Run playbook against mail server — verify sair.run domain is imported without regenerating the DKIM key
- [ ] Verify `/opt/mailu/dkim/sair.run.dkim.key` is unchanged after playbook run
- [ ] Send a test email from sair.run and confirm DKIM passes in email headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)