### PR TITLE
Fix Tailscale install idempotency in molecule

### DIFF
--- a/ansible/roles/common_cli/vars/main.yml
+++ b/ansible/roles/common_cli/vars/main.yml
@@ -25,7 +25,6 @@ common_cli_tools_ubuntu:
   - avahi-daemon            # mostly used for <host>.local zeroconf
   - btop                    # modern and colorful cli resource monitor
   - byobu                   # text window manager / multiplexer / devops env
-  - curl                    # http/https/gopher tool
   - docker.io               # containers
   - docker-buildx
   - docker-compose-v2       # docker compose

--- a/ansible/roles/common_cli/vars/main.yml
+++ b/ansible/roles/common_cli/vars/main.yml
@@ -13,6 +13,7 @@ common_cli_dotfile_packages_macos:
   # Consider adding: fish/ or zshrc/ directories to your dotfiles repo for shell configs
 
 common_cli_prereq_packages_ubuntu:
+  - curl
   - gpg-agent
   - ssh
   - git


### PR DESCRIPTION
## Summary
- Adds `curl` to `common_cli_prereq_packages_ubuntu` so it's available before the Tailscale install task
- The `Install Tailscale` task uses `curl -fsSL https://tailscale.com/install.sh | sh`, but curl was only installed later in the "Install CLI tools" step
- In molecule, this caused the script to fail silently on every run, `/usr/bin/tailscale` was never created, and the `creates:` guard never skipped the task — breaking the idempotency check

## Test plan
- [ ] Molecule CI passes (idempotency check for `Install Tailscale` no longer fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)