### PR TITLE
Add www canonical redirects for all sites

### DIFF
--- a/ansible/jasonernst_com.yml
+++ b/ansible/jasonernst_com.yml
@@ -10,7 +10,12 @@
     # Enable nginx fail2ban jails (logs mounted from Docker)
     fail2ban_nginx_enabled: true
     fail2ban_nginx_botscan_enabled: true
+    www_redirects:
+      - { domain: jasonernst.com, letsencrypt_email: "ernstjason1@gmail.com" }
   roles:
-    - jasonernst_com  # Deploy nginx first so logs exist
-    - fail2ban        # Then fail2ban can monitor logs
+    # www-redirect must run before jasonernst_com so redirect container
+    # handles apex domain before app container stops serving it
+    - www-redirect
+    - jasonernst_com
+    - fail2ban
     - mailu

--- a/ansible/projects.yml
+++ b/ansible/projects.yml
@@ -22,7 +22,17 @@
     sair_portal_stripe_secret_key: "{{ lookup('community.general.onepassword', 'STRIPE_SECRET_KEY - SAIR', field='credential', vault=onepassword_vault, account_id=onepassword_account_id) }}"
     sair_portal_stripe_webhook_secret: "{{ lookup('community.general.onepassword', 'STRIPE_WEBHOOK_SECRET - SAIR', field='credential', vault=onepassword_vault, account_id=onepassword_account_id) }}"
     sair_portal_stripe_solo_price_id: "{{ lookup('community.general.onepassword', 'STRIPE_SOLO_PRICE_ID', field='credential', vault=onepassword_vault, account_id=onepassword_account_id) }}"
+    www_redirects:
+      - { domain: sair.run, letsencrypt_email: "ernstjason1@gmail.com" }
+      - { domain: goblog.live, letsencrypt_email: "ernstjason1@gmail.com" }
+      - { domain: darksearch.xyz, letsencrypt_email: "ernstjason1@gmail.com" }
+      - { domain: ping4.network, letsencrypt_email: "ernstjason1@gmail.com" }
+      - { domain: ping6.network, letsencrypt_email: "ernstjason1@gmail.com" }
+      - { domain: dumpers.xyz, letsencrypt_email: "ernstjason1@gmail.com" }
   roles:
+    # www-redirect must run before projects/sair-portal so redirect containers
+    # handle apex domains before app containers stop serving them
+    - { role: www-redirect, tags: [www-redirect] }
     - { role: projects, tags: [projects] }
     - { role: sair-orchestrator, tags: [sair-orchestrator, sair] }
     - { role: sair-portal, tags: [sair-portal, sair] }

--- a/ansible/roles/jasonernst_com/tasks/main.yml
+++ b/ansible/roles/jasonernst_com/tasks/main.yml
@@ -275,9 +275,9 @@
       - name: nginx-proxy
     restart_policy: unless-stopped
     env:
-      VIRTUAL_HOST: "www.jasonernst.com,jasonernst.com"
+      VIRTUAL_HOST: "www.jasonernst.com"
       VIRTUAL_PORT: "7000"
-      LETSENCRYPT_HOST: "www.jasonernst.com,jasonernst.com"
+      LETSENCRYPT_HOST: "www.jasonernst.com"
       LETSENCRYPT_EMAIL: "ernstjason1@gmail.com"
 
 - name: Deploy staging.jasonernst.com

--- a/ansible/roles/projects/tasks/main.yml
+++ b/ansible/roles/projects/tasks/main.yml
@@ -222,8 +222,8 @@
       - name: nginx-proxy
     restart_policy: unless-stopped
     env:
-      VIRTUAL_HOST: "goblog.live,www.goblog.live"
+      VIRTUAL_HOST: "www.goblog.live"
       VIRTUAL_PORT: "7000"
-      LETSENCRYPT_HOST: "goblog.live,www.goblog.live"
+      LETSENCRYPT_HOST: "www.goblog.live"
       LETSENCRYPT_EMAIL: "{{ projects_letsencrypt_email }}"
       TRUSTED_PROXIES: "172.16.0.0/12"

--- a/ansible/roles/sair-portal/tasks/main.yml
+++ b/ansible/roles/sair-portal/tasks/main.yml
@@ -37,7 +37,7 @@
         type: bind
     env:
       PORTAL_PORT: "{{ sair_portal_port | string }}"
-      PORTAL_BASE_URL: "https://{{ sair_portal_domain }}"
+      PORTAL_BASE_URL: "https://www.{{ sair_portal_domain }}"
       PORTAL_DB_PATH: "/app/data/portal.db"
       SMTP_HOST: "{{ sair_portal_smtp_host }}"
       SMTP_PORT: "{{ sair_portal_smtp_port | string }}"
@@ -47,7 +47,7 @@
       STRIPE_SECRET_KEY: "{{ sair_portal_stripe_secret_key }}"
       STRIPE_WEBHOOK_SECRET: "{{ sair_portal_stripe_webhook_secret }}"
       STRIPE_SOLO_PRICE_ID: "{{ sair_portal_stripe_solo_price_id }}"
-      VIRTUAL_HOST: "{{ sair_portal_domain }},www.{{ sair_portal_domain }}"
+      VIRTUAL_HOST: "www.{{ sair_portal_domain }}"
       VIRTUAL_PORT: "{{ sair_portal_port | string }}"
-      LETSENCRYPT_HOST: "{{ sair_portal_domain }},www.{{ sair_portal_domain }}"
+      LETSENCRYPT_HOST: "www.{{ sair_portal_domain }}"
       LETSENCRYPT_EMAIL: "{{ sair_portal_letsencrypt_email }}"

--- a/ansible/roles/www-redirect/defaults/main.yml
+++ b/ansible/roles/www-redirect/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# List of domains to redirect non-www -> www
+# Each entry needs: domain, letsencrypt_email
+www_redirects: []

--- a/ansible/roles/www-redirect/tasks/main.yml
+++ b/ansible/roles/www-redirect/tasks/main.yml
@@ -2,6 +2,12 @@
 # Deploy lightweight nginx containers that 301 redirect non-www -> www
 # Relies on jwilder/nginx-proxy for SSL termination and auto-config
 
+- name: Ensure nginx-proxy network exists
+  become: true
+  community.docker.docker_network:
+    name: nginx-proxy
+    state: present
+
 - name: Create redirect config directories
   become: true
   ansible.builtin.file:
@@ -42,9 +48,15 @@
 
 - name: Clean up old vhost.d redirect files
   become: true
-  ansible.builtin.shell:
-    cmd: >
-      docker exec nginx-proxy rm -f /etc/nginx/vhost.d/{{ item.domain }} /etc/nginx/vhost.d/{{ item.domain }}_location
+  ansible.builtin.command:
+    argv:
+      - docker
+      - exec
+      - nginx-proxy
+      - rm
+      - -f
+      - "/etc/nginx/vhost.d/{{ item.domain }}"
+      - "/etc/nginx/vhost.d/{{ item.domain }}_location"
   changed_when: false
   failed_when: false
   loop: "{{ www_redirects }}"

--- a/ansible/roles/www-redirect/tasks/main.yml
+++ b/ansible/roles/www-redirect/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+# Deploy lightweight nginx containers that 301 redirect non-www -> www
+# Relies on jwilder/nginx-proxy for SSL termination and auto-config
+
+- name: Create redirect config directories
+  become: true
+  ansible.builtin.file:
+    path: "/opt/www-redirect/{{ item.domain }}"
+    state: directory
+    mode: "0755"
+  loop: "{{ www_redirects }}"
+
+- name: Write redirect configs
+  become: true
+  ansible.builtin.copy:
+    content: |
+      server {
+          listen 80;
+          server_name {{ item.domain }};
+          return 301 https://www.{{ item.domain }}$request_uri;
+      }
+    dest: "/opt/www-redirect/{{ item.domain }}/default.conf"
+    mode: "0644"
+  loop: "{{ www_redirects }}"
+
+- name: Deploy www redirect containers
+  become: true
+  community.docker.docker_container:
+    name: "redirect-{{ item.domain }}"
+    image: nginx:alpine
+    restart_policy: unless-stopped
+    networks:
+      - name: nginx-proxy
+    volumes:
+      - "/opt/www-redirect/{{ item.domain }}/default.conf:/etc/nginx/conf.d/default.conf:ro"
+    env:
+      VIRTUAL_HOST: "{{ item.domain }}"
+      VIRTUAL_PORT: "80"
+      LETSENCRYPT_HOST: "{{ item.domain }}"
+      LETSENCRYPT_EMAIL: "{{ item.letsencrypt_email }}"
+  loop: "{{ www_redirects }}"
+
+- name: Clean up old vhost.d redirect files
+  become: true
+  ansible.builtin.shell:
+    cmd: >
+      docker exec nginx-proxy rm -f /etc/nginx/vhost.d/{{ item.domain }} /etc/nginx/vhost.d/{{ item.domain }}_location
+  changed_when: false
+  failed_when: false
+  loop: "{{ www_redirects }}"

--- a/terraform/jasonernst-com.tf
+++ b/terraform/jasonernst-com.tf
@@ -58,13 +58,6 @@ resource "digitalocean_record" "CNAME-staging" {
   value  = "@"
 }
 
-resource "digitalocean_record" "CNAME-dev" {
-  domain = digitalocean_domain.default.name
-  type   = "CNAME"
-  name   = "dev"
-  value  = "@"
-}
-
 # ombi.jasonernst.com -> nas (same dynamic IP, managed by dyndns container)
 resource "digitalocean_record" "CNAME-ombi" {
   domain = digitalocean_domain.default.name


### PR DESCRIPTION
## Summary
- New `www-redirect` role that deploys lightweight nginx:alpine containers to 301 redirect non-www → www for all sites
- App containers (`sair-portal`, `goblog.live`, `jasonernst.com`) now only serve `www.*` via `VIRTUAL_HOST`
- Redirect role runs first in playbooks to ensure apex domains are handled before app containers stop serving them
- Removes unused `dev.jasonernst.com` CNAME from terraform
- Fixes Google Search Console "Duplicate without user-selected canonical" warnings

**Sites affected:** sair.run, goblog.live, darksearch.xyz, ping4.network, ping6.network, dumpers.xyz, jasonernst.com

**Depends on:** 
- compscidr/network-tools#8
- compscidr/darksearch.xyz#10

## Test plan
- [x] `curl -I https://sair.run` returns 301 → `https://www.sair.run/`
- [ ] `curl -I https://goblog.live` returns 301 → `https://www.goblog.live/`
- [ ] `curl -I https://jasonernst.com` returns 301 → `https://www.jasonernst.com/`
- [ ] `terraform plan` shows only the dev.jasonernst.com CNAME removal
- [ ] Merge dependent PRs before redeploying `projects` role

🤖 Generated with [Claude Code](https://claude.com/claude-code)