### PR TITLE
Update goblog to v0.2.1 and add staging noindex

### DIFF
--- a/ansible/roles/jasonernst_com/tasks/main.yml
+++ b/ansible/roles/jasonernst_com/tasks/main.yml
@@ -255,7 +255,7 @@
     ansible_python_interpreter: "/usr/bin/python3"
   community.docker.docker_container:
     name: www.jasonernst.com
-    image: compscidr/goblog:v0.2.0
+    image: compscidr/goblog:v0.2.1
     volumes:
       - /opt/goblog/prod/uploads:/go/src/github.com/compscidr/goblog/www/uploads
     mounts:
@@ -286,7 +286,7 @@
     ansible_python_interpreter: "/usr/bin/python3"
   community.docker.docker_container:
     name: staging.jasonernst.com
-    image: compscidr/goblog:v0.2.0
+    image: compscidr/goblog:v0.2.1
     volumes:
       - /opt/goblog/staging/uploads:/go/src/github.com/compscidr/goblog/www/uploads
     mounts:
@@ -310,5 +310,22 @@
       VIRTUAL_PORT: "7000"
       LETSENCRYPT_HOST: "staging.jasonernst.com"
       LETSENCRYPT_EMAIL: "ernstjason1@gmail.com"
+
+- name: Ensure sqlite3 is installed
+  tags: website
+  become: true
+  ansible.builtin.apt:
+    name: sqlite3
+    state: present
+
+- name: Set noindex on staging to prevent search engine indexing
+  tags: website
+  become: true
+  ansible.builtin.command:
+    argv:
+      - sqlite3
+      - /opt/goblog/staging/database.db
+      - "INSERT OR REPLACE INTO settings (key, type, value) VALUES ('robots_tag', 'text', 'noindex, nofollow');"
+  changed_when: false
 
 # MySQL moved to media_server role (used by Ombi on NAS)

--- a/ansible/roles/projects/tasks/main.yml
+++ b/ansible/roles/projects/tasks/main.yml
@@ -207,7 +207,7 @@
   become: true
   community.docker.docker_container:
     name: goblog.live
-    image: compscidr/goblog:v0.2.0
+    image: compscidr/goblog:v0.2.1
     volumes:
       - /opt/goblog-live/uploads:/go/src/github.com/compscidr/goblog/www/uploads
       - /opt/goblog-live/site-theme:/go/src/github.com/compscidr/goblog/themes/site


### PR DESCRIPTION
## Summary
- Bump goblog from v0.2.0 to v0.2.1 on www.jasonernst.com, staging.jasonernst.com, and goblog.live
  - v0.2.1 includes shared head template, HEAD request support, and configurable `robots_tag`/`site_url` settings
- Install sqlite3 on www host and set `robots_tag=noindex, nofollow` on staging after deploy to prevent search engine indexing

## Test plan
- [x] `curl -s https://www.jasonernst.com | grep robots` shows `index, follow`
- [x] `curl -s https://staging.jasonernst.com | grep robots` shows `noindex, nofollow`
- [x] goblog.live renders correctly with v0.2.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)