### PR TITLE
Add claude stow package and update dotfiles pin

### DIFF
--- a/ansible/roles/common_cli/tasks/main.yml
+++ b/ansible/roles/common_cli/tasks/main.yml
@@ -630,8 +630,8 @@
   ansible.builtin.git:
     repo: git@github.com:compscidr/dotfiles.git
     dest: ~/dotfiles
-    # Pinned commit adds bun, cargo/rustup, fnm env
-    version: 480a3f2e395e3b652531a87cce241ccfa061453e
+    # Pinned commit adds claude stow package, bashrc.local sourcing
+    version: 307db45cc5ad7f54d98289df08cec0dbdb4b1961
 
 - name: Test .bashrc file to see if its a symlink
   tags: dotfiles

--- a/ansible/roles/common_cli/vars/main.yml
+++ b/ansible/roles/common_cli/vars/main.yml
@@ -2,11 +2,13 @@
 common_cli_dotfile_packages_ubuntu:
   - autostart    # GUI app autostart
   - bashrc       # Bash shell config
+  - claude       # Claude Code config
   - nano         # Text editor
   - tmux         # Terminal multiplexer
   - variety      # Wallpaper manager
 
 common_cli_dotfile_packages_macos:
+  - claude       # Claude Code config
   - nano         # Text editor (cross-platform)
   - tmux         # Terminal multiplexer (cross-platform)
   # Skip: autostart (Linux GUI), bashrc (use zsh), profile (Ubuntu-specific), variety (Linux GUI)


### PR DESCRIPTION
## Summary
- Add `claude` to stow package lists for both Ubuntu and macOS
- Update dotfiles pin to `307db45` which includes:
  - Claude Code config stow package (`settings.json`, `mcp.json`, `CLAUDE.md`, `plugins/installed_plugins.json`)
  - `~/.bashrc.local` sourcing for machine-specific config (CUDA, etc.)

## Test plan
- [ ] Run ansible playbook with `--tags dotfiles` and verify claude symlinks are created
- [ ] Verify Claude Code works with symlinked config on a fresh machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)