### PR TITLE
Add reverse proxy support for plex, radarr, and sonarr

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -26,7 +26,7 @@ collections:
   - name: community.docker
     version: "5.1.0"
   - name: compscidr.media_server
-    version: "1.3.2"
+    version: "1.4.0"
   - name: compscidr.github_runner
     version: "0.1.2"
   - name: compscidr.rust_gameserver

--- a/ansible/roles/media_server/tasks/main.yml
+++ b/ansible/roles/media_server/tasks/main.yml
@@ -9,6 +9,7 @@
     media_storage_base_path: /volume1/storage
     media_storage_network_enabled: true
     media_storage_network_name: "media"
+    media_letsencrypt_email: "ernstjason1@gmail.com"
 
 # Initialize media_user facts (UID/GID detection) before other tasks
 # This runs media_storage which depends on media_user
@@ -137,7 +138,7 @@
     plex_memory_swap: "24g"
     plex_shm_size: "8g"
     plex_virtual_host: "plex.jasonernst.com"
-    plex_letsencrypt_email: "ernstjason1@gmail.com"
+    plex_letsencrypt_email: "{{ media_letsencrypt_email }}"
     plex_network_mode: "bridge"
     plex_dlna_port: 1901
 
@@ -164,7 +165,7 @@
     sonarr_memory: "1g"
     sonarr_memory_swap: "1g"
     sonarr_virtual_host: "sonarr.jasonernst.com"
-    sonarr_letsencrypt_email: "ernstjason1@gmail.com"
+    sonarr_letsencrypt_email: "{{ media_letsencrypt_email }}"
 
 - name: Install radarr
   tags: radarr
@@ -177,7 +178,7 @@
     radarr_memory: "1g"
     radarr_memory_swap: "1g"
     radarr_virtual_host: "radarr.jasonernst.com"
-    radarr_letsencrypt_email: "ernstjason1@gmail.com"
+    radarr_letsencrypt_email: "{{ media_letsencrypt_email }}"
 
 - name: Install prowlarr
   tags: prowlarr
@@ -209,7 +210,7 @@
       tags: ombi
   vars:
     ombi_virtual_host: "ombi.jasonernst.com"
-    ombi_letsencrypt_email: "ernstjason1@gmail.com"
+    ombi_letsencrypt_email: "{{ media_letsencrypt_email }}"
 
 - name: Install slskd
   tags: slskd

--- a/ansible/roles/media_server/tasks/main.yml
+++ b/ansible/roles/media_server/tasks/main.yml
@@ -133,11 +133,13 @@
     plex_dri_devices: true
     plex_bonjour_port: 5354
     plex_claim: claim-haziyvUxG2Fb4uj5-tF1
-    plex_memory: "5g"
-    plex_memory_swap: "5g"
-    plex_shm_size: "2g"
-    # Use host mode for DLNA/UPnP discovery
-    plex_network_mode: "host"
+    plex_memory: "24g"
+    plex_memory_swap: "24g"
+    plex_shm_size: "8g"
+    plex_virtual_host: "plex.jasonernst.com"
+    plex_letsencrypt_email: "ernstjason1@gmail.com"
+    plex_network_mode: "bridge"
+    plex_dlna_port: 1901
 
 - name: Install sabnzbd
   tags: sabnzbd
@@ -161,6 +163,8 @@
     sonarr_folder: /etc/sonarr
     sonarr_memory: "1g"
     sonarr_memory_swap: "1g"
+    sonarr_virtual_host: "sonarr.jasonernst.com"
+    sonarr_letsencrypt_email: "ernstjason1@gmail.com"
 
 - name: Install radarr
   tags: radarr
@@ -172,6 +176,8 @@
   vars:
     radarr_memory: "1g"
     radarr_memory_swap: "1g"
+    radarr_virtual_host: "radarr.jasonernst.com"
+    radarr_letsencrypt_email: "ernstjason1@gmail.com"
 
 - name: Install prowlarr
   tags: prowlarr

--- a/terraform/jasonernst-com.tf
+++ b/terraform/jasonernst-com.tf
@@ -66,6 +66,30 @@ resource "digitalocean_record" "CNAME-ombi" {
   value  = "nas.jasonernst.com."
 }
 
+# plex.jasonernst.com -> nas (same dynamic IP, managed by dyndns container)
+resource "digitalocean_record" "CNAME-plex" {
+  domain = digitalocean_domain.default.name
+  type   = "CNAME"
+  name   = "plex"
+  value  = "nas.jasonernst.com."
+}
+
+# radarr.jasonernst.com -> nas (same dynamic IP, managed by dyndns container)
+resource "digitalocean_record" "CNAME-radarr" {
+  domain = digitalocean_domain.default.name
+  type   = "CNAME"
+  name   = "radarr"
+  value  = "nas.jasonernst.com."
+}
+
+# sonarr.jasonernst.com -> nas (same dynamic IP, managed by dyndns container)
+resource "digitalocean_record" "CNAME-sonarr" {
+  domain = digitalocean_domain.default.name
+  type   = "CNAME"
+  name   = "sonarr"
+  value  = "nas.jasonernst.com."
+}
+
 # projects.jasonernst.com -> projects droplet
 resource "digitalocean_record" "A-projects" {
   domain = digitalocean_domain.default.name


### PR DESCRIPTION
## Summary
- Add CNAME DNS records for `plex.jasonernst.com`, `radarr.jasonernst.com`, and `sonarr.jasonernst.com` → `nas.jasonernst.com`
- Configure `virtual_host` and `letsencrypt` vars for automatic nginx-proxy SSL (using new media_server collection 1.4.0 support, see compscidr/ansible-media-server#37)
- Switch plex from host to bridge networking (DLNA not used)
- Remap plex DLNA port to 1901 to avoid conflict with host UPnP service
- Bump plex memory from 5g to 24g and shm from 2g to 8g for 4K transcoding
- Update `compscidr.media_server` collection pin from 1.3.2 to 1.4.0

## Test plan
- [x] Terraform applied — DNS records created
- [x] Ansible deployed — radarr and sonarr accessible via subdomains with SSL
- [x] Plex deployed with bridge networking
- [ ] Verify plex.jasonernst.com accessible with SSL

🤖 Generated with [Claude Code](https://claude.com/claude-code)