### PR TITLE
Add NAS web UI reverse proxy at nas.jasonernst.com

### DIFF
--- a/ansible/roles/media_server/files/nas-proxy.conf
+++ b/ansible/roles/media_server/files/nas-proxy.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        proxy_pass http://host.docker.internal:9999;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/ansible/roles/media_server/handlers/main.yml
+++ b/ansible/roles/media_server/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart nas-proxy container
+  become: true
+  community.docker.docker_container:
+    name: nas-proxy
+    restart: true
+    state: started

--- a/ansible/roles/media_server/tasks/main.yml
+++ b/ansible/roles/media_server/tasks/main.yml
@@ -77,6 +77,48 @@
       - name: media
     restart_policy: unless-stopped
 
+# NAS web UI reverse proxy (proxies nas.jasonernst.com -> host port 9999)
+- name: Create NAS proxy config directory
+  tags: nas-proxy
+  become: true
+  ansible.builtin.file:
+    path: /etc/nas-proxy
+    state: directory
+    mode: '755'
+    owner: root
+    group: root
+
+- name: Copy NAS proxy nginx config
+  tags: nas-proxy
+  become: true
+  ansible.builtin.copy:
+    src: nas-proxy.conf
+    dest: /etc/nas-proxy/default.conf
+    mode: '644'
+    owner: root
+    group: root
+
+- name: Deploy NAS web proxy
+  tags: nas-proxy
+  become: true
+  community.docker.docker_container:
+    name: nas-proxy
+    image: nginx:alpine
+    pull: true
+    volumes:
+      - /etc/nas-proxy/default.conf:/etc/nginx/conf.d/default.conf:ro
+    env:
+      VIRTUAL_HOST: "nas.jasonernst.com"
+      VIRTUAL_PORT: "80"
+      LETSENCRYPT_HOST: "nas.jasonernst.com"
+      LETSENCRYPT_EMAIL: "{{ media_letsencrypt_email | default('ernstjason1@gmail.com') }}"
+    extra_hosts:
+      host.docker.internal: host-gateway
+    networks:
+      - name: media
+    restart_policy: unless-stopped
+    memory: "256m"
+
 # Media storage folders are now created automatically by the media_storage role
 # which is a dependency of the media roles below
 

--- a/ansible/roles/media_server/tasks/main.yml
+++ b/ansible/roles/media_server/tasks/main.yml
@@ -97,6 +97,7 @@
     mode: '644'
     owner: root
     group: root
+  notify: Restart nas-proxy container
 
 - name: Deploy NAS web proxy
   tags: nas-proxy

--- a/ansible/roles/media_server/tasks/main.yml
+++ b/ansible/roles/media_server/tasks/main.yml
@@ -112,7 +112,7 @@
       VIRTUAL_PORT: "80"
       LETSENCRYPT_HOST: "nas.jasonernst.com"
       LETSENCRYPT_EMAIL: "{{ media_letsencrypt_email | default('ernstjason1@gmail.com') }}"
-    extra_hosts:
+    etc_hosts:
       host.docker.internal: host-gateway
     networks:
       - name: media


### PR DESCRIPTION
## Summary
- Deploy a lightweight `nginx:alpine` container that proxies `nas.jasonernst.com` to the host's port 9999 (NAS web management UI)
- Uses `host.docker.internal` (via `extra_hosts: host-gateway`) to reach the host from inside the container
- VIRTUAL_HOST/LETSENCRYPT env vars for automatic nginx-proxy discovery and SSL
- No terraform changes needed — `nas.jasonernst.com` DNS already exists via dyndns

## Test plan
- [ ] Deploy with `ansible-playbook -i inventory.yml nas.yml --tags "nas-proxy"`
- [ ] Verify `nas.jasonernst.com` loads the NAS web UI with SSL

🤖 Generated with [Claude Code](https://claude.com/claude-code)