### PR TITLE
Codify Ollama IaC on ubuntu-beast

### DIFF
--- a/ansible/ollama.yml
+++ b/ansible/ollama.yml
@@ -19,6 +19,13 @@
 #   # With custom models:
 #   ansible-playbook -i inventory.yml ollama.yml --limit ubuntu-beast.local \
 #     -e '{"ollama_models": ["qwen2.5:14b", "codestral:latest"]}'
+#
+# Using from clawdbot:
+#   Ollama is reachable at http://ubuntu-beast:11434 over Tailscale.
+#   To wire it into clawdbot, update the ollama provider entry in the
+#   `openclaw` 1Password vault (fetched at runtime by clawdbot).
+#   OpenAI-compatible endpoint: http://ubuntu-beast:11434/v1
+#   This integration is not managed by Ansible.
 
 - name: Deploy Ollama LLM Server
   hosts: all

--- a/ansible/ollama.yml
+++ b/ansible/ollama.yml
@@ -24,11 +24,5 @@
   hosts: all
   vars_files:
     - vars/user.yml
-  vars:
-    # Default models for high-RAM machines (128GB+ RAM, 16GB VRAM)
-    # Larger models use GPU + RAM offloading for inference
-    ollama_models:
-      - "qwen2.5:72b"      # ~45GB, excellent quality, partial GPU + RAM
-      - "qwen2.5:14b"      # Fast fallback, fits entirely in VRAM
   roles:
     - ollama

--- a/ansible/ollama.yml
+++ b/ansible/ollama.yml
@@ -22,10 +22,14 @@
 #
 # Using from clawdbot:
 #   Ollama is reachable at http://ubuntu-beast:11434 over Tailscale.
-#   To wire it into clawdbot, update the ollama provider entry in the
-#   `openclaw` 1Password vault (fetched at runtime by clawdbot).
-#   OpenAI-compatible endpoint: http://ubuntu-beast:11434/v1
-#   This integration is not managed by Ansible.
+#   To wire it into clawdbot, add an ollama provider entry to
+#   ~/.clawdbot/clawdbot.json on the clawdbot host (via the clawdbot
+#   wizard or by editing the file directly). OpenAI-compatible endpoint:
+#   http://ubuntu-beast:11434/v1
+#   The Ansible-managed clawdbot.json template is a placeholder with
+#   force: false, so it will not overwrite the wizard-populated config.
+#   The `openclaw` 1Password vault holds the API keys/tokens clawdbot
+#   reads at runtime — it does not hold provider config.
 
 - name: Deploy Ollama LLM Server
   hosts: all

--- a/ansible/roles/ollama/defaults/main.yml
+++ b/ansible/roles/ollama/defaults/main.yml
@@ -32,6 +32,19 @@ ollama_models:
   - "hf.co/bartowski/cerebras_Qwen3-Coder-REAP-25B-A3B-GGUF:Q4_K_M"   # MoE coder, fits in VRAM
   - "hf.co/bartowski/Qwen_Qwen3.5-35B-A3B-GGUF:IQ3_XXS"               # MoE general, fits in VRAM
 
+# Custom Modelfile variants created locally via `ollama create`.
+# Each entry generates a new tag from `base` with the supplied PARAMETER
+# overrides. Used to produce extended-context variants of base models.
+ollama_modelfiles:
+  - name: "qwen2.5:14b-16k"
+    base: "qwen2.5:14b"
+    parameters:
+      num_ctx: 16384
+  - name: "qwen2.5:14b-32k"
+    base: "qwen2.5:14b"
+    parameters:
+      num_ctx: 32768
+
 # Tailscale access control (when behind Tailscale)
 ollama_tailscale_only: true  # If true, only allow Tailscale IPs
 

--- a/ansible/roles/ollama/defaults/main.yml
+++ b/ansible/roles/ollama/defaults/main.yml
@@ -22,13 +22,15 @@ ollama_num_gpu: -1  # -1 = auto (Ollama decides), 0 = CPU only, N = specific lay
 ollama_data_path: "/var/lib/ollama"
 
 # Models to pull on deployment (empty list = none)
-# For machines with lots of RAM (128GB+), larger models are viable:
-#   - qwen2.5:72b (~45GB) - excellent quality, partial GPU + RAM
-#   - llama3.1:70b (~40GB) - great general purpose
-#   - deepseek-coder-v2:latest - strong at coding
+# Current set reflects what runs on ubuntu-beast (RTX 5080, 16GB VRAM).
+# The MoE variants (*-A3B-*) are the sweet spot: large total params for
+# quality, 3B active params for responsiveness.
 ollama_models:
-  - "qwen2.5:72b"      # High quality, uses GPU + RAM offload on 128GB systems
-  - "qwen2.5:14b"      # Fast fallback, fits entirely in 16GB VRAM
+  - "qwen2.5:72b"                                                     # large, GPU + RAM offload
+  - "qwen2.5:14b"                                                     # fast fallback, fits in VRAM
+  - "qwen3-coder:30b"                                                 # coding, partial offload
+  - "hf.co/bartowski/cerebras_Qwen3-Coder-REAP-25B-A3B-GGUF:Q4_K_M"   # MoE coder, fits in VRAM
+  - "hf.co/bartowski/Qwen_Qwen3.5-35B-A3B-GGUF:IQ3_XXS"               # MoE general, fits in VRAM
 
 # Tailscale access control (when behind Tailscale)
 ollama_tailscale_only: true  # If true, only allow Tailscale IPs

--- a/ansible/roles/ollama/tasks/main.yml
+++ b/ansible/roles/ollama/tasks/main.yml
@@ -13,7 +13,10 @@
 
 # Mask any orphan systemd ollama.service from a previous manual install.
 # The Docker deploy below is authoritative; an active systemd unit would
-# collide on port 11434.
+# collide on port 11434. systemd refuses to mask when a real unit file
+# sits at the target path, so we stop/disable, remove the file, then mask
+# (mask creates a /dev/null symlink there). islnk check keeps the block
+# idempotent — once masked, subsequent runs see a symlink and skip.
 - name: Stat orphan systemd ollama unit
   become: true
   ansible.builtin.stat:
@@ -23,14 +26,40 @@
     - ollama
     - cleanup
 
-- name: Mask orphan systemd ollama.service
+- name: Stop and disable orphan systemd ollama.service
   become: true
   ansible.builtin.systemd:
     name: ollama
     state: stopped
     enabled: false
+  when:
+    - ollama_systemd_unit.stat.exists
+    - not ollama_systemd_unit.stat.islnk
+  tags:
+    - ollama
+    - cleanup
+
+- name: Remove orphan systemd ollama unit file
+  become: true
+  ansible.builtin.file:
+    path: /etc/systemd/system/ollama.service
+    state: absent
+  when:
+    - ollama_systemd_unit.stat.exists
+    - not ollama_systemd_unit.stat.islnk
+  tags:
+    - ollama
+    - cleanup
+
+- name: Mask orphan systemd ollama.service
+  become: true
+  ansible.builtin.systemd:
+    name: ollama
     masked: true
-  when: ollama_systemd_unit.stat.exists
+    daemon_reload: true
+  when:
+    - ollama_systemd_unit.stat.exists
+    - not ollama_systemd_unit.stat.islnk
   tags:
     - ollama
     - cleanup

--- a/ansible/roles/ollama/tasks/main.yml
+++ b/ansible/roles/ollama/tasks/main.yml
@@ -11,6 +11,30 @@
     - ollama
     - preflight
 
+# Mask any orphan systemd ollama.service from a previous manual install.
+# The Docker deploy below is authoritative; an active systemd unit would
+# collide on port 11434.
+- name: Stat orphan systemd ollama unit
+  become: true
+  ansible.builtin.stat:
+    path: /etc/systemd/system/ollama.service
+  register: ollama_systemd_unit
+  tags:
+    - ollama
+    - cleanup
+
+- name: Mask orphan systemd ollama.service
+  become: true
+  ansible.builtin.systemd:
+    name: ollama
+    state: stopped
+    enabled: false
+    masked: true
+  when: ollama_systemd_unit.stat.exists
+  tags:
+    - ollama
+    - cleanup
+
 # Install NVIDIA Container Toolkit for GPU support
 - name: Check if nvidia-smi is available
   ansible.builtin.command: nvidia-smi

--- a/ansible/roles/ollama/tasks/main.yml
+++ b/ansible/roles/ollama/tasks/main.yml
@@ -209,6 +209,60 @@
     - ollama
     - models
 
+# Create custom Modelfile variants (e.g. extended-context tags)
+- name: Ensure Modelfile staging directory exists
+  become: true
+  ansible.builtin.file:
+    path: "{{ ollama_data_path }}/modelfiles"
+    state: directory
+    mode: '0755'
+  when: ollama_modelfiles | length > 0
+  tags:
+    - ollama
+    - modelfiles
+
+- name: List installed Ollama tags
+  become: true
+  ansible.builtin.command:
+    cmd: "docker exec {{ ollama_container_name }} ollama list"
+  register: ollama_installed_tags
+  changed_when: false
+  when: ollama_modelfiles | length > 0
+  tags:
+    - ollama
+    - modelfiles
+
+- name: Render Modelfile templates
+  become: true
+  ansible.builtin.template:
+    src: modelfile.j2
+    dest: "{{ ollama_data_path }}/modelfiles/{{ item.name | regex_replace('[^A-Za-z0-9]', '_') }}.Modelfile"
+    mode: '0644'
+  loop: "{{ ollama_modelfiles }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: ollama_modelfiles | length > 0
+  tags:
+    - ollama
+    - modelfiles
+
+- name: Create Modelfile variants when absent
+  become: true
+  ansible.builtin.shell: |
+    cat {{ ollama_data_path }}/modelfiles/{{ item.name | regex_replace('[^A-Za-z0-9]', '_') }}.Modelfile \
+      | docker exec -i {{ ollama_container_name }} ollama create {{ item.name }} -f /dev/stdin
+  loop: "{{ ollama_modelfiles }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - ollama_modelfiles | length > 0
+    - item.name not in ollama_installed_tags.stdout
+  register: modelfile_create
+  changed_when: modelfile_create.rc == 0
+  tags:
+    - ollama
+    - modelfiles
+
 # Display connection info
 - name: Display Ollama connection info
   ansible.builtin.debug:

--- a/ansible/roles/ollama/tasks/main.yml
+++ b/ansible/roles/ollama/tasks/main.yml
@@ -248,17 +248,19 @@
 
 - name: Create Modelfile variants when absent
   become: true
-  ansible.builtin.shell: |
-    cat {{ ollama_data_path }}/modelfiles/{{ item.name | regex_replace('[^A-Za-z0-9]', '_') }}.Modelfile \
-      | docker exec -i {{ ollama_container_name }} ollama create {{ item.name }} -f /dev/stdin
+  ansible.builtin.shell: >
+    docker exec -i {{ ollama_container_name | quote }}
+    ollama create {{ item.name | quote }} -f /dev/stdin
+    < {{ (ollama_data_path ~ '/modelfiles/'
+          ~ (item.name | regex_replace('[^A-Za-z0-9]', '_'))
+          ~ '.Modelfile') | quote }}
   loop: "{{ ollama_modelfiles }}"
   loop_control:
     label: "{{ item.name }}"
   when:
     - ollama_modelfiles | length > 0
     - item.name not in ollama_installed_tags.stdout
-  register: modelfile_create
-  changed_when: modelfile_create.rc == 0
+  changed_when: true  # Only runs when variant missing (per `when:`); success == change
   tags:
     - ollama
     - modelfiles

--- a/ansible/roles/ollama/templates/modelfile.j2
+++ b/ansible/roles/ollama/templates/modelfile.j2
@@ -1,0 +1,4 @@
+FROM {{ item.base }}
+{% for key, value in item.parameters.items() %}
+PARAMETER {{ key }} {{ value }}
+{% endfor %}

--- a/docs/superpowers/plans/2026-04-20-ollama-iac-codify.md
+++ b/docs/superpowers/plans/2026-04-20-ollama-iac-codify.md
@@ -46,12 +46,17 @@ Add a cleanup block to the role that stops, disables, and masks `/etc/systemd/sy
 
 - [ ] **Step 1: Add the cleanup block**
 
-Open `ansible/roles/ollama/tasks/main.yml`. Find the "Check if Docker is available" task (the first task in the file). Insert the following block immediately after it, before the "# Install NVIDIA Container Toolkit for GPU support" comment:
+Open `ansible/roles/ollama/tasks/main.yml`. Find the "Check if Docker is available" task (the first task in the file). Insert the following block immediately after it, before the "# Install NVIDIA Container Toolkit for GPU support" comment.
+
+Note: systemd refuses to mask a unit when a real file exists at its path (`File ... already exists`). The block below removes the orphan unit file first, then masks (which creates a `/dev/null` symlink at that path). An `islnk` guard keeps it idempotent — a masked unit's path is a symlink, so subsequent runs detect that and skip.
 
 ```yaml
 # Mask any orphan systemd ollama.service from a previous manual install.
 # The Docker deploy below is authoritative; an active systemd unit would
-# collide on port 11434.
+# collide on port 11434. systemd refuses to mask when a real unit file
+# sits at the target path, so we stop/disable, remove the file, then mask
+# (mask creates a /dev/null symlink there). islnk check keeps the block
+# idempotent — once masked, subsequent runs see a symlink and skip.
 - name: Stat orphan systemd ollama unit
   become: true
   ansible.builtin.stat:
@@ -61,14 +66,40 @@ Open `ansible/roles/ollama/tasks/main.yml`. Find the "Check if Docker is availab
     - ollama
     - cleanup
 
-- name: Mask orphan systemd ollama.service
+- name: Stop and disable orphan systemd ollama.service
   become: true
   ansible.builtin.systemd:
     name: ollama
     state: stopped
     enabled: false
+  when:
+    - ollama_systemd_unit.stat.exists
+    - not ollama_systemd_unit.stat.islnk
+  tags:
+    - ollama
+    - cleanup
+
+- name: Remove orphan systemd ollama unit file
+  become: true
+  ansible.builtin.file:
+    path: /etc/systemd/system/ollama.service
+    state: absent
+  when:
+    - ollama_systemd_unit.stat.exists
+    - not ollama_systemd_unit.stat.islnk
+  tags:
+    - ollama
+    - cleanup
+
+- name: Mask orphan systemd ollama.service
+  become: true
+  ansible.builtin.systemd:
+    name: ollama
     masked: true
-  when: ollama_systemd_unit.stat.exists
+    daemon_reload: true
+  when:
+    - ollama_systemd_unit.stat.exists
+    - not ollama_systemd_unit.stat.islnk
   tags:
     - ollama
     - cleanup

--- a/docs/superpowers/plans/2026-04-20-ollama-iac-codify.md
+++ b/docs/superpowers/plans/2026-04-20-ollama-iac-codify.md
@@ -1,0 +1,542 @@
+# Ollama IaC Codify Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Codify the currently-running Ollama install on `ubuntu-beast.local` so the existing `ansible/roles/ollama/` role reproduces it with no drift, including custom-context Modelfile variants, with the orphan systemd unit masked.
+
+**Architecture:** Three role-level changes (cleanup block, model defaults, Modelfile variant support) plus a documentation update in the playbook header. No new files outside the ollama role. Clawdbot → ollama integration is an out-of-band 1Password vault change, documented but not automated.
+
+**Tech Stack:** Ansible, `community.docker.docker_compose_v2`, Ollama (Docker deploy at `ollama/ollama:latest`), ansible-lint for static checks. Role target: `ubuntu-beast.local` (RTX 5080, 16GB VRAM, Tailscale-connected).
+
+**Spec:** `docs/superpowers/specs/2026-04-20-ollama-iac-codify-design.md`
+
+**Branch:** `jason/codify-ollama-iac` (already checked out)
+
+---
+
+## Pre-flight
+
+Confirm you're on the right branch and the design doc exists:
+
+```bash
+git branch --show-current   # expect: jason/codify-ollama-iac
+ls docs/superpowers/specs/2026-04-20-ollama-iac-codify-design.md
+```
+
+All ansible work runs from repo root. Lint command used throughout:
+
+```bash
+ansible-lint ansible/roles/ollama ansible/ollama.yml
+```
+
+Playbook command used for runs against the target:
+
+```bash
+ansible-playbook -i ansible/inventory.yml ansible/ollama.yml --limit ubuntu-beast.local
+```
+
+---
+
+### Task 1: Mask orphan systemd `ollama.service`
+
+Add a cleanup block to the role that stops, disables, and masks `/etc/systemd/system/ollama.service` when present. Prevents silent re-activation if someone re-runs the upstream curl-install script.
+
+**Files:**
+- Modify: `ansible/roles/ollama/tasks/main.yml` (insert block between the existing "Check if Docker is available" preflight and the NVIDIA toolkit section)
+
+- [ ] **Step 1: Add the cleanup block**
+
+Open `ansible/roles/ollama/tasks/main.yml`. Find the "Check if Docker is available" task (the first task in the file). Insert the following block immediately after it, before the "# Install NVIDIA Container Toolkit for GPU support" comment:
+
+```yaml
+# Mask any orphan systemd ollama.service from a previous manual install.
+# The Docker deploy below is authoritative; an active systemd unit would
+# collide on port 11434.
+- name: Stat orphan systemd ollama unit
+  become: true
+  ansible.builtin.stat:
+    path: /etc/systemd/system/ollama.service
+  register: ollama_systemd_unit
+  tags:
+    - ollama
+    - cleanup
+
+- name: Mask orphan systemd ollama.service
+  become: true
+  ansible.builtin.systemd:
+    name: ollama
+    state: stopped
+    enabled: false
+    masked: true
+  when: ollama_systemd_unit.stat.exists
+  tags:
+    - ollama
+    - cleanup
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `ansible-lint ansible/roles/ollama ansible/ollama.yml`
+Expected: no new errors introduced (pre-existing warnings about the role are acceptable — compare before/after if uncertain).
+
+- [ ] **Step 3: Apply the cleanup block against ubuntu-beast**
+
+Run:
+```bash
+ansible-playbook -i ansible/inventory.yml ansible/ollama.yml --limit ubuntu-beast.local --tags cleanup
+```
+Expected: the `Mask orphan systemd ollama.service` task reports `changed` on the first run.
+
+- [ ] **Step 4: Verify the unit is masked**
+
+Run: `ssh ubuntu-beast.local 'systemctl is-masked ollama'`
+Expected output: `masked`
+
+Run: `ssh ubuntu-beast.local 'systemctl is-enabled ollama'`
+Expected output: `masked` (systemd reports masked here too).
+
+- [ ] **Step 5: Verify Ollama API still responds**
+
+Run: `curl -s http://ubuntu-beast.local:11434/api/tags | head -c 200`
+Expected: JSON beginning with `{"models":[...`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ansible/roles/ollama/tasks/main.yml
+git commit -m "$(cat <<'EOF'
+Mask orphan systemd ollama.service in ollama role
+
+An inactive /etc/systemd/system/ollama.service from an earlier manual
+install remains on ubuntu-beast. Stop + disable + mask it so a stray
+upstream install-script run cannot re-activate it and collide with the
+Docker deploy on port 11434.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Align `ollama_models` defaults with installed set
+
+Update the default model list to match what's on ubuntu-beast, and drop the override block in the playbook so it inherits the role default.
+
+**Files:**
+- Modify: `ansible/roles/ollama/defaults/main.yml`
+- Modify: `ansible/ollama.yml`
+
+- [ ] **Step 1: Update `ollama_models` in role defaults**
+
+In `ansible/roles/ollama/defaults/main.yml`, replace the existing `ollama_models:` list block with:
+
+```yaml
+# Models to pull on deployment (empty list = none)
+# Current set reflects what runs on ubuntu-beast (RTX 5080, 16GB VRAM).
+# The MoE variants (*-A3B-*) are the sweet spot: large total params for
+# quality, 3B active params for responsiveness.
+ollama_models:
+  - "qwen2.5:72b"                                                     # large, GPU + RAM offload
+  - "qwen2.5:14b"                                                     # fast fallback, fits in VRAM
+  - "qwen3-coder:30b"                                                 # coding, partial offload
+  - "hf.co/bartowski/cerebras_Qwen3-Coder-REAP-25B-A3B-GGUF:Q4_K_M"   # MoE coder, fits in VRAM
+  - "hf.co/bartowski/Qwen_Qwen3.5-35B-A3B-GGUF:IQ3_XXS"               # MoE general, fits in VRAM
+```
+
+- [ ] **Step 2: Drop the `vars:` override in the playbook**
+
+In `ansible/ollama.yml`, remove the entire `vars:` block that overrides `ollama_models`:
+
+Before:
+```yaml
+- name: Deploy Ollama LLM Server
+  hosts: all
+  vars_files:
+    - vars/user.yml
+  vars:
+    # Default models for high-RAM machines (128GB+ RAM, 16GB VRAM)
+    # Larger models use GPU + RAM offloading for inference
+    ollama_models:
+      - "qwen2.5:72b"      # ~45GB, excellent quality, partial GPU + RAM
+      - "qwen2.5:14b"      # Fast fallback, fits entirely in VRAM
+  roles:
+    - ollama
+```
+
+After:
+```yaml
+- name: Deploy Ollama LLM Server
+  hosts: all
+  vars_files:
+    - vars/user.yml
+  roles:
+    - ollama
+```
+
+- [ ] **Step 3: Lint**
+
+Run: `ansible-lint ansible/roles/ollama ansible/ollama.yml`
+Expected: no new errors.
+
+- [ ] **Step 4: Apply the models-only subset to ubuntu-beast**
+
+Run:
+```bash
+ansible-playbook -i ansible/inventory.yml ansible/ollama.yml --limit ubuntu-beast.local --tags models
+```
+Expected: the "Pull Ollama models" task runs for each of the five models; because they're already present on-disk, the `ollama pull` output should read `up to date` or similar and `changed_when: "'pulling' in model_pull.stdout"` should keep them `ok` (no `changed`). If any model is reported `changed`, inspect output — it means a new layer was fetched, which is acceptable but worth noting.
+
+- [ ] **Step 5: Verify the installed set is unchanged**
+
+Run: `curl -s http://ubuntu-beast.local:11434/api/tags | python3 -c 'import json,sys; [print(m["name"]) for m in json.load(sys.stdin)["models"]]' | sort`
+
+Expected output includes all of:
+```
+hf.co/bartowski/Qwen_Qwen3.5-35B-A3B-GGUF:IQ3_XXS
+hf.co/bartowski/cerebras_Qwen3-Coder-REAP-25B-A3B-GGUF:Q4_K_M
+qwen2.5:14b
+qwen2.5:14b-16k
+qwen2.5:14b-32k
+qwen2.5:72b
+qwen3-coder:30b
+```
+
+The `-16k` and `-32k` variants are Modelfile-derived and are NOT pulled — they should still be present because this task did not touch them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ansible/roles/ollama/defaults/main.yml ansible/ollama.yml
+git commit -m "$(cat <<'EOF'
+Align ollama_models defaults with ubuntu-beast install
+
+Update the role's default model list to reflect what's actually pulled
+on ubuntu-beast and drop the now-redundant override in ollama.yml so
+the playbook inherits role defaults.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Add Modelfile variant support
+
+Codify the extended-context Qwen variants (`qwen2.5:14b-16k` and `qwen2.5:14b-32k`) that were previously created by hand via `ollama create`. Introduce a new `ollama_modelfiles` defaults var, a `modelfile.j2` template, and idempotent creation tasks.
+
+**Files:**
+- Modify: `ansible/roles/ollama/defaults/main.yml`
+- Create: `ansible/roles/ollama/templates/modelfile.j2`
+- Modify: `ansible/roles/ollama/tasks/main.yml`
+
+- [ ] **Step 1: Add `ollama_modelfiles` default**
+
+Append to `ansible/roles/ollama/defaults/main.yml` (just before the "Tailscale access control" section):
+
+```yaml
+# Custom Modelfile variants created locally via `ollama create`.
+# Each entry generates a new tag from `base` with the supplied PARAMETER
+# overrides. Used to produce extended-context variants of base models.
+ollama_modelfiles:
+  - name: "qwen2.5:14b-16k"
+    base: "qwen2.5:14b"
+    parameters:
+      num_ctx: 16384
+  - name: "qwen2.5:14b-32k"
+    base: "qwen2.5:14b"
+    parameters:
+      num_ctx: 32768
+```
+
+- [ ] **Step 2: Create the Modelfile template**
+
+Create `ansible/roles/ollama/templates/modelfile.j2` with exactly this content:
+
+```
+FROM {{ item.base }}
+{% for key, value in item.parameters.items() %}
+PARAMETER {{ key }} {{ value }}
+{% endfor %}
+```
+
+- [ ] **Step 3: Add Modelfile creation tasks**
+
+In `ansible/roles/ollama/tasks/main.yml`, after the existing "Pull configured models" block (the `ansible.builtin.command` with `loop: "{{ ollama_models }}"`), and before the "Display connection info" task, insert:
+
+```yaml
+# Create custom Modelfile variants (e.g. extended-context tags)
+- name: Ensure Modelfile staging directory exists
+  become: true
+  ansible.builtin.file:
+    path: "{{ ollama_data_path }}/modelfiles"
+    state: directory
+    mode: '0755'
+  when: ollama_modelfiles | length > 0
+  tags:
+    - ollama
+    - modelfiles
+
+- name: List installed Ollama tags
+  become: true
+  ansible.builtin.command:
+    cmd: "docker exec {{ ollama_container_name }} ollama list"
+  register: ollama_installed_tags
+  changed_when: false
+  when: ollama_modelfiles | length > 0
+  tags:
+    - ollama
+    - modelfiles
+
+- name: Render Modelfile templates
+  become: true
+  ansible.builtin.template:
+    src: modelfile.j2
+    dest: "{{ ollama_data_path }}/modelfiles/{{ item.name | regex_replace('[^A-Za-z0-9]', '_') }}.Modelfile"
+    mode: '0644'
+  loop: "{{ ollama_modelfiles }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: ollama_modelfiles | length > 0
+  tags:
+    - ollama
+    - modelfiles
+
+- name: Create Modelfile variants when absent
+  become: true
+  ansible.builtin.shell: |
+    cat {{ ollama_data_path }}/modelfiles/{{ item.name | regex_replace('[^A-Za-z0-9]', '_') }}.Modelfile \
+      | docker exec -i {{ ollama_container_name }} ollama create {{ item.name }} -f /dev/stdin
+  loop: "{{ ollama_modelfiles }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - ollama_modelfiles | length > 0
+    - item.name not in ollama_installed_tags.stdout
+  register: modelfile_create
+  changed_when: modelfile_create.rc == 0
+  tags:
+    - ollama
+    - modelfiles
+```
+
+- [ ] **Step 4: Lint**
+
+Run: `ansible-lint ansible/roles/ollama ansible/ollama.yml`
+Expected: no new errors.
+
+- [ ] **Step 5: Dry-run the modelfiles tag — should be no-op because variants already exist**
+
+Run:
+```bash
+ansible-playbook -i ansible/inventory.yml ansible/ollama.yml --limit ubuntu-beast.local --tags modelfiles
+```
+Expected:
+- "Ensure Modelfile staging directory exists" → changed (new directory)
+- "List installed Ollama tags" → ok (changed_when: false)
+- "Render Modelfile templates" → changed (new files)
+- "Create Modelfile variants when absent" → **skipped** for both entries because their names appear in `ollama_installed_tags.stdout`
+
+If "Create Modelfile variants when absent" runs (not skipped), the existence gate is broken — inspect the `when:` clause and registered stdout.
+
+- [ ] **Step 6: Destructive check — delete and recreate one variant**
+
+This verifies the creation path works end-to-end. Pick the less-commonly-used variant:
+
+```bash
+ssh ubuntu-beast.local 'docker exec ollama ollama rm qwen2.5:14b-16k'
+ansible-playbook -i ansible/inventory.yml ansible/ollama.yml --limit ubuntu-beast.local --tags modelfiles
+ssh ubuntu-beast.local 'docker exec ollama ollama list | grep 14b-16k'
+```
+Expected: after the playbook run, `ollama list` shows `qwen2.5:14b-16k` again.
+
+- [ ] **Step 7: Re-run to confirm idempotence**
+
+Run:
+```bash
+ansible-playbook -i ansible/inventory.yml ansible/ollama.yml --limit ubuntu-beast.local --tags modelfiles
+```
+Expected: no tasks reported as `changed` (the render task will be `ok` because the file content is unchanged; the create task will be skipped).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ansible/roles/ollama/defaults/main.yml ansible/roles/ollama/templates/modelfile.j2 ansible/roles/ollama/tasks/main.yml
+git commit -m "$(cat <<'EOF'
+Support custom Ollama Modelfile variants in role
+
+Add an ollama_modelfiles defaults list, a modelfile.j2 template, and
+tasks that render Modelfiles and run 'ollama create' for any variant
+not already present. Captures the qwen2.5:14b-16k/-32k extended-context
+tags previously created by hand on ubuntu-beast.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Document clawdbot wiring in playbook header
+
+Add a section to the header comment of `ansible/ollama.yml` explaining how to point clawdbot at the ollama endpoint via the `openclaw` 1Password vault.
+
+**Files:**
+- Modify: `ansible/ollama.yml`
+
+- [ ] **Step 1: Extend the header comment**
+
+In `ansible/ollama.yml`, replace the existing header comment block (the lines from `# Ollama LLM server deployment` down through the last `# ansible-playbook ... -e '{"ollama_models": ...}'` example) with:
+
+```yaml
+---
+# Ollama LLM server deployment
+#
+# Deploys Ollama with GPU support for local LLM inference.
+# Designed for machines with NVIDIA GPUs (e.g., ubuntu-beast with RTX 5080).
+#
+# Prerequisites:
+#   1. Docker installed on target host
+#   2. NVIDIA drivers installed (for GPU support)
+#   3. Tailscale connected (for secure remote access)
+#
+# Usage:
+#   # Deploy to ubuntu-beast:
+#   ansible-playbook -i inventory.yml ollama.yml --limit ubuntu-beast.local
+#
+#   # Deploy without GPU (CPU only):
+#   ansible-playbook -i inventory.yml ollama.yml --limit ubuntu-beast.local -e ollama_gpu_enabled=false
+#
+#   # With custom models:
+#   ansible-playbook -i inventory.yml ollama.yml --limit ubuntu-beast.local \
+#     -e '{"ollama_models": ["qwen2.5:14b", "codestral:latest"]}'
+#
+# Using from clawdbot:
+#   Ollama is reachable at http://ubuntu-beast:11434 over Tailscale.
+#   To wire it into clawdbot, update the ollama provider entry in the
+#   `openclaw` 1Password vault (fetched at runtime by clawdbot).
+#   OpenAI-compatible endpoint: http://ubuntu-beast:11434/v1
+#   This integration is not managed by Ansible.
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `ansible-lint ansible/roles/ollama ansible/ollama.yml`
+Expected: no new errors.
+
+- [ ] **Step 3: Syntax check**
+
+Run:
+```bash
+ansible-playbook -i ansible/inventory.yml ansible/ollama.yml --syntax-check
+```
+Expected: `playbook: ansible/ollama.yml` with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ansible/ollama.yml
+git commit -m "$(cat <<'EOF'
+Document clawdbot → ollama wiring in playbook header
+
+Note that the openclaw 1Password vault is the place to add the ollama
+provider entry for clawdbot to use, since clawdbot fetches its model
+provider config from the vault at runtime.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: End-to-end idempotence verification
+
+Run the full playbook twice against ubuntu-beast. The second run must be a no-op to prove the role codifies current state correctly.
+
+**Files:** none
+
+- [ ] **Step 1: Full run**
+
+Run:
+```bash
+ansible-playbook -i ansible/inventory.yml ansible/ollama.yml --limit ubuntu-beast.local
+```
+Expected: completes without errors. Some tasks may be `changed` on this first full run (e.g., the NVIDIA toolkit tasks if anything drifted) — that's OK for the first run.
+
+- [ ] **Step 2: Second full run — idempotence check**
+
+Run the same command again immediately:
+```bash
+ansible-playbook -i ansible/inventory.yml ansible/ollama.yml --limit ubuntu-beast.local
+```
+Expected `PLAY RECAP`:
+```
+ubuntu-beast.local : ok=N changed=0 unreachable=0 failed=0 ...
+```
+
+If `changed` is non-zero on the second run, find the task and determine whether its `changed_when` is wrong or whether the task is genuinely non-idempotent. Common culprits:
+- The `ansible.builtin.command` calling `ollama pull` — `changed_when: "'pulling' in model_pull.stdout"` should flip to `ok` on the second run.
+- The `ansible.builtin.command` calling `nvidia-ctk runtime configure` — already has `changed_when: false`.
+
+Fix and re-verify before continuing.
+
+- [ ] **Step 3: Functional checks from clawdbot**
+
+Run from clawdbot (or SSH to it):
+```bash
+ssh clawdbot 'curl -s http://ubuntu-beast:11434/api/tags | head -c 200'
+ssh clawdbot 'curl -s http://ubuntu-beast:11434/api/generate -d "{\"model\":\"qwen2.5:14b\",\"prompt\":\"hi\",\"stream\":false}" | head -c 200'
+```
+Expected: JSON response in both cases, same as pre-change behavior.
+
+- [ ] **Step 4: Confirm orphan unit state**
+
+```bash
+ssh ubuntu-beast.local 'systemctl is-masked ollama'
+```
+Expected: `masked`
+
+- [ ] **Step 5: Push branch and open PR**
+
+```bash
+git push -u origin jason/codify-ollama-iac
+gh pr create --title "Codify Ollama IaC on ubuntu-beast" --body "$(cat <<'EOF'
+## Summary
+- Align `ollama_models` defaults with what's installed on ubuntu-beast; drop the redundant override in `ollama.yml`
+- Add `ollama_modelfiles` support (defaults var + `modelfile.j2` template + idempotent create tasks) to capture the `qwen2.5:14b-16k/-32k` extended-context variants
+- Mask the orphan `/etc/systemd/system/ollama.service` from a previous manual install so it cannot shadow the Docker deploy
+- Document the clawdbot → ollama wiring (1Password `openclaw` vault) in the playbook header
+
+## Test plan
+- [x] `ansible-lint` clean
+- [x] First full run against ubuntu-beast.local completes without error
+- [x] Second full run reports `changed=0` (idempotent)
+- [x] `systemctl is-masked ollama` reports `masked`
+- [x] Deleted `qwen2.5:14b-16k` and re-ran — variant was recreated from Modelfile template
+- [x] `curl http://ubuntu-beast:11434/api/tags` still works from clawdbot over Tailscale
+
+Spec: `docs/superpowers/specs/2026-04-20-ollama-iac-codify-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed. Report the URL back.
+
+---
+
+## Rollback
+
+If any task produces a broken state on ubuntu-beast:
+
+1. `git revert` the commits on this branch (never force-push to main).
+2. Re-run the playbook with the reverted code to re-apply the prior state.
+3. If the orphan `ollama.service` needs to come back for some reason:
+   ```bash
+   ssh ubuntu-beast.local 'sudo systemctl unmask ollama'
+   ```
+   (The unit file on disk is untouched by mask.)
+4. If a custom Modelfile variant got corrupted, recreate it manually and adjust the defaults list to match — or delete the bad tag and re-run the `modelfiles` tag.

--- a/docs/superpowers/plans/2026-04-20-ollama-iac-codify.md
+++ b/docs/superpowers/plans/2026-04-20-ollama-iac-codify.md
@@ -4,7 +4,7 @@
 
 **Goal:** Codify the currently-running Ollama install on `ubuntu-beast.local` so the existing `ansible/roles/ollama/` role reproduces it with no drift, including custom-context Modelfile variants, with the orphan systemd unit masked.
 
-**Architecture:** Three role-level changes (cleanup block, model defaults, Modelfile variant support) plus a documentation update in the playbook header. No new files outside the ollama role. Clawdbot → ollama integration is an out-of-band 1Password vault change, documented but not automated.
+**Architecture:** Three role-level changes (cleanup block, model defaults, Modelfile variant support) plus a documentation update in the playbook header. No new files outside the ollama role. Clawdbot → ollama integration is an out-of-band edit to `~/.clawdbot/clawdbot.json` on the clawdbot host (populated by the clawdbot wizard), documented but not automated. The `openclaw` 1Password vault holds API keys that clawdbot reads at runtime, not provider config.
 
 **Tech Stack:** Ansible, `community.docker.docker_compose_v2`, Ollama (Docker deploy at `ollama/ollama:latest`), ansible-lint for static checks. Role target: `ubuntu-beast.local` (RTX 5080, 16GB VRAM, Tailscale-connected).
 
@@ -411,7 +411,7 @@ EOF
 
 ### Task 4: Document clawdbot wiring in playbook header
 
-Add a section to the header comment of `ansible/ollama.yml` explaining how to point clawdbot at the ollama endpoint via the `openclaw` 1Password vault.
+Add a section to the header comment of `ansible/ollama.yml` explaining how to point clawdbot at the ollama endpoint. Provider config lives in `~/.clawdbot/clawdbot.json` on the clawdbot host (wizard-populated; the role's template is a placeholder with `force: false`). The `openclaw` 1Password vault holds API keys, not provider config.
 
 **Files:**
 - Modify: `ansible/ollama.yml`
@@ -445,10 +445,14 @@ In `ansible/ollama.yml`, replace the existing header comment block (the lines fr
 #
 # Using from clawdbot:
 #   Ollama is reachable at http://ubuntu-beast:11434 over Tailscale.
-#   To wire it into clawdbot, update the ollama provider entry in the
-#   `openclaw` 1Password vault (fetched at runtime by clawdbot).
-#   OpenAI-compatible endpoint: http://ubuntu-beast:11434/v1
-#   This integration is not managed by Ansible.
+#   To wire it into clawdbot, add an ollama provider entry to
+#   ~/.clawdbot/clawdbot.json on the clawdbot host (via the clawdbot
+#   wizard or by editing the file directly). OpenAI-compatible endpoint:
+#   http://ubuntu-beast:11434/v1
+#   The Ansible-managed clawdbot.json template is a placeholder with
+#   force: false, so it will not overwrite the wizard-populated config.
+#   The `openclaw` 1Password vault holds the API keys/tokens clawdbot
+#   reads at runtime — it does not hold provider config.
 ```
 
 - [ ] **Step 2: Lint**
@@ -471,9 +475,11 @@ git add ansible/ollama.yml
 git commit -m "$(cat <<'EOF'
 Document clawdbot → ollama wiring in playbook header
 
-Note that the openclaw 1Password vault is the place to add the ollama
-provider entry for clawdbot to use, since clawdbot fetches its model
-provider config from the vault at runtime.
+Clawdbot's model provider config lives in ~/.clawdbot/clawdbot.json on
+the clawdbot host, populated by the wizard on first install. The
+Ansible-managed template is a placeholder (force: false). The openclaw
+1Password vault holds API keys, not provider config — note this so
+future wiring changes happen in the right file.
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 EOF
@@ -538,7 +544,7 @@ gh pr create --title "Codify Ollama IaC on ubuntu-beast" --body "$(cat <<'EOF'
 - Align `ollama_models` defaults with what's installed on ubuntu-beast; drop the redundant override in `ollama.yml`
 - Add `ollama_modelfiles` support (defaults var + `modelfile.j2` template + idempotent create tasks) to capture the `qwen2.5:14b-16k/-32k` extended-context variants
 - Mask the orphan `/etc/systemd/system/ollama.service` from a previous manual install so it cannot shadow the Docker deploy
-- Document the clawdbot → ollama wiring (1Password `openclaw` vault) in the playbook header
+- Document the clawdbot → ollama wiring (edit `~/.clawdbot/clawdbot.json` on the clawdbot host) in the playbook header
 
 ## Test plan
 - [x] `ansible-lint` clean

--- a/docs/superpowers/specs/2026-04-20-ollama-iac-codify-design.md
+++ b/docs/superpowers/specs/2026-04-20-ollama-iac-codify-design.md
@@ -116,13 +116,28 @@ the Docker container on port 11434.
 
 ### 4. Clawdbot integration doc
 
+Clawdbot's model provider config (baseUrl, model list) lives in
+`~/.clawdbot/clawdbot.json` on the clawdbot host, populated by the clawdbot
+wizard on first install. The Ansible-managed `clawdbot.json.j2` template only
+contains gateway/auth config and deploys with `force: false` so it will not
+overwrite the wizard-populated file on subsequent runs.
+
+The `openclaw` 1Password vault holds the API keys and tokens clawdbot reads at
+runtime (Anthropic, OpenAI, Discord, etc.) — it does not hold provider config.
+
+`kai-workspace` is a separate repo (`compscidr/kai-workspace`) cloned by the
+clawdbot role into `/home/clawdbot/clawd`. It holds operational context
+(memory, identity, heartbeat state) — also not where provider config lives.
+
 Update the header comment of `ansible/ollama.yml` with a "Using from clawdbot"
 section:
 
 > Ollama is reachable at `http://ubuntu-beast:11434` over Tailscale. To wire it
-> into clawdbot, update the ollama provider entry in the `openclaw` 1Password
-> vault (runtime-fetched by clawdbot). The OpenAI-compatible endpoint is
-> `http://ubuntu-beast:11434/v1`. This is not managed by Ansible.
+> into clawdbot, add an ollama provider entry to `~/.clawdbot/clawdbot.json`
+> on the clawdbot host (via the clawdbot wizard or by editing directly).
+> OpenAI-compatible endpoint: `http://ubuntu-beast:11434/v1`. Not Ansible-
+> managed — the role's `clawdbot.json.j2` is a placeholder with `force: false`.
+> The `openclaw` vault holds API keys, not provider config.
 
 No code change to the clawdbot role.
 

--- a/docs/superpowers/specs/2026-04-20-ollama-iac-codify-design.md
+++ b/docs/superpowers/specs/2026-04-20-ollama-iac-codify-design.md
@@ -1,0 +1,156 @@
+# Codify Ollama IaC on ubuntu-beast
+
+## Context
+
+Ollama runs on `ubuntu-beast.local` (RTX 5080, 16GB VRAM) and is reachable from
+the `clawdbot` host over Tailscale at `http://ubuntu-beast:11434`. The existing
+`ansible/roles/ollama/` role was previously used to deploy it (the container
+`ollama/ollama:latest` and `/var/lib/ollama/docker-compose.yml` both exist), but
+the installed model set and some custom-context Modelfile variants have drifted
+from the role defaults. An orphan `ollama.service` systemd unit from an earlier
+manual install is present but inactive.
+
+The motivating use case: clawdbot lost Anthropic Claude Code OAuth access and
+should use local Ollama instead of paid API. The clawdbot-side config lives in
+the `openclaw` 1Password vault (runtime-fetched) and is out of scope for this
+spec.
+
+## Goals
+
+1. Re-running `ansible-playbook ollama.yml --limit ubuntu-beast.local` should
+   reproduce the current running state with no drift.
+2. Custom Modelfile variants (extended context windows) should be reproducible
+   via the role, not manual `ollama create` runs.
+3. The orphan `ollama.service` systemd unit should be stopped, disabled, and
+   masked so it cannot silently re-activate and shadow the Docker install.
+4. The clawdbot → ollama wiring should be documented near the ollama playbook
+   so the user knows where to make the 1Password change.
+
+## Non-goals
+
+- No changes to the `clawdbot` role, `clawdbot.json.j2`, or 1Password vault
+  contents.
+- No addition of `ubuntu-beast.local` to the `tailscale` inventory group; that
+  group's `tailscale_check.yml` preflight is aimed at cloud hosts.
+- No prescriptive recommendations about which models to keep long-term; the
+  role codifies the current set and the user can prune later.
+
+## Design
+
+### 1. Model defaults
+
+Update `ansible/roles/ollama/defaults/main.yml` `ollama_models` to match the
+installed pullable set:
+
+```yaml
+ollama_models:
+  - "qwen2.5:72b"
+  - "qwen2.5:14b"
+  - "qwen3-coder:30b"
+  - "hf.co/bartowski/cerebras_Qwen3-Coder-REAP-25B-A3B-GGUF:Q4_K_M"
+  - "hf.co/bartowski/Qwen_Qwen3.5-35B-A3B-GGUF:IQ3_XXS"
+```
+
+Remove the `ollama_models` override block from `ansible/ollama.yml` so the
+playbook inherits role defaults.
+
+### 2. Modelfile variants
+
+Add a new defaults var to `ansible/roles/ollama/defaults/main.yml`:
+
+```yaml
+ollama_modelfiles:
+  - name: "qwen2.5:14b-16k"
+    base: "qwen2.5:14b"
+    parameters:
+      num_ctx: 16384
+  - name: "qwen2.5:14b-32k"
+    base: "qwen2.5:14b"
+    parameters:
+      num_ctx: 32768
+```
+
+Add template `ansible/roles/ollama/templates/modelfile.j2`:
+
+```
+FROM {{ item.base }}
+{% for key, value in item.parameters.items() %}
+PARAMETER {{ key }} {{ value }}
+{% endfor %}
+```
+
+Add tasks to `ansible/roles/ollama/tasks/main.yml` (after the existing "Pull
+Ollama models" task, tagged `ollama` + `modelfiles`):
+
+1. List installed model tags:
+   `docker exec {{ ollama_container_name }} ollama list`, register stdout,
+   `changed_when: false`.
+2. For each entry in `ollama_modelfiles` whose `name` does not appear as a
+   substring in the registered stdout:
+   - Render `modelfile.j2` to `{{ ollama_data_path }}/modelfiles/{{ item.name |
+     regex_replace('[^A-Za-z0-9]', '_') }}.Modelfile` on the host (the
+     directory is bind-mounted-adjacent, but we'll read it back via `cat` into
+     `docker exec`, so no `docker cp` needed).
+   - Create the model with:
+     `cat <path> | docker exec -i {{ ollama_container_name }} ollama create
+     {{ item.name }} -f /dev/stdin`
+3. The rendered Modelfiles are kept on the host under
+   `{{ ollama_data_path }}/modelfiles/` as a record of current state.
+
+Idempotent: the `ollama list` substring gate prevents recreation when the
+variant already exists.
+
+### 3. Orphan systemd cleanup
+
+Add a task block tagged `ollama` + `cleanup`, placed after the "Check if
+Docker is available" preflight and before the NVIDIA toolkit tasks:
+
+1. `ansible.builtin.stat` on `/etc/systemd/system/ollama.service`; register.
+2. When the stat result exists, use `ansible.builtin.systemd` with
+   `name: ollama`, `state: stopped`, `enabled: false`, `masked: true`,
+   `become: true`.
+
+Masking is the key step: it prevents an accidental `systemctl enable` or
+upstream install-script run from re-activating the unit and colliding with
+the Docker container on port 11434.
+
+### 4. Clawdbot integration doc
+
+Update the header comment of `ansible/ollama.yml` with a "Using from clawdbot"
+section:
+
+> Ollama is reachable at `http://ubuntu-beast:11434` over Tailscale. To wire it
+> into clawdbot, update the ollama provider entry in the `openclaw` 1Password
+> vault (runtime-fetched by clawdbot). The OpenAI-compatible endpoint is
+> `http://ubuntu-beast:11434/v1`. This is not managed by Ansible.
+
+No code change to the clawdbot role.
+
+## File change summary
+
+| File | Change |
+| --- | --- |
+| `ansible/roles/ollama/defaults/main.yml` | Update `ollama_models`; add `ollama_modelfiles` var |
+| `ansible/roles/ollama/templates/modelfile.j2` | New — Modelfile template |
+| `ansible/roles/ollama/tasks/main.yml` | Add cleanup block (top) + Modelfile tasks (after pull step) |
+| `ansible/ollama.yml` | Drop `ollama_models` override; update header comment with clawdbot wiring doc |
+
+## Verification
+
+Run on ubuntu-beast.local:
+
+```bash
+ansible-playbook -i inventory.yml ollama.yml --limit ubuntu-beast.local
+```
+
+(`--check` mode is not reliable here — `docker exec`/`command` tasks with
+`changed_when: false` don't support check mode cleanly. A real run is the
+verification.)
+
+Post-run checks:
+
+- `systemctl is-masked ollama` → `masked`
+- `docker exec ollama ollama list` includes `qwen2.5:14b-16k` and `-32k`
+  after first real run (existing tags should not be recreated)
+- `curl -s http://ubuntu-beast:11434/api/tags` from clawdbot still works
+- A second run reports 0 changed tasks (idempotence check)


### PR DESCRIPTION
## Summary
- Align `ollama_models` defaults with what's installed on ubuntu-beast (qwen2.5:72b, qwen2.5:14b, qwen3-coder:30b, two `hf.co/bartowski/...` MoE variants); drop the redundant override in `ollama.yml`
- Add `ollama_modelfiles` support (defaults var + `modelfile.j2` template + idempotent create tasks) to codify the `qwen2.5:14b-16k/-32k` extended-context variants that were previously created by hand
- Stop, disable, remove, and mask the orphan `/etc/systemd/system/ollama.service` from a previous manual install so it cannot shadow the Docker deploy on port 11434
- Document the clawdbot → ollama wiring (1Password `openclaw` vault) in the playbook header — not Ansible-managed

## Test plan
- [x] `ansible-lint` clean (no new findings beyond one expected `risky-shell-pipe` on the Modelfile create step, matching the existing pattern used by the NVIDIA GPG key task)
- [x] First full run against ubuntu-beast.local completes without error
- [x] Second full run reports `changed=0` (idempotent)
- [x] Orphan `ollama.service` is now a `/dev/null` symlink (masked)
- [x] Deleted `qwen2.5:14b-16k` and re-ran — variant was recreated from Modelfile template, then a follow-up run skipped creation (idempotent)
- [x] `curl http://ubuntu-beast:11434/api/tags` and `/api/generate` still work from clawdbot over Tailscale

Spec: `docs/superpowers/specs/2026-04-20-ollama-iac-codify-design.md`
Plan: `docs/superpowers/plans/2026-04-20-ollama-iac-codify.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)