### PR TITLE
openclaw: install claude binary and restore OAuth creds from 1P

### DIFF
--- a/ansible/openclaw.yml
+++ b/ansible/openclaw.yml
@@ -14,10 +14,25 @@
 # Prerequisites:
 #   1. Droplet created via Terraform (with Tailscale via cloud-init)
 #   2. Bootstrap run: ansible-playbook bootstrap.yml --limit openclaw -u root
-#   3. 1Password vault "openclaw" with API keys and service token
+#   3. 1Password vault "openclaw" with API keys and service token, plus
+#      a `openclaw claude-code credentials` item whose `credential` field
+#      holds the verbatim contents of ~/.claude/.credentials.json from
+#      a prior `claude login` on the host. Ansible restores this file on
+#      fresh hosts so Claude Code doesn't need an interactive web login.
 #
 # Usage:
 #   ansible-playbook -i inventory.yml openclaw.yml
+#
+# Pre-destroy sync (R-1) — run this on your workstation BEFORE tearing
+# down the droplet, so the 1P copy of the Claude OAuth blob is current.
+# Claude Code refreshes the access token in place; a stale 1P snapshot
+# may restore an expired/revoked token and force a manual re-login.
+#
+#   ssh openclaw 'cat ~/.claude/.credentials.json' > /tmp/openclaw-creds.json
+#   op item edit "openclaw claude-code credentials" \
+#     --vault openclaw \
+#     "credential[password]=$(cat /tmp/openclaw-creds.json)"
+#   rm /tmp/openclaw-creds.json
 #
 # Post-run: if this is a fresh install, run the `openclaw gateway`
 # wizard on the host once so the tool creates its user-level systemd
@@ -37,6 +52,7 @@
     # openclaw role vars
     openclaw_workspace_repo: "git@github.com:compscidr/kai-workspace.git"
     openclaw_tailscale_serve: true
+    openclaw_claude_credentials: "{{ lookup('community.general.onepassword', 'openclaw claude-code credentials', field='credential', vault='openclaw', account_id=onepassword_account_id) }}"
   roles:
     - fnm       # Install Node.js via fnm
     - openclaw  # Install and configure Openclaw

--- a/ansible/roles/openclaw/defaults/main.yml
+++ b/ansible/roles/openclaw/defaults/main.yml
@@ -3,19 +3,30 @@
 #
 # The openclaw CLI tool (formerly "clawdbot") manages its own user-level
 # systemd unit during first-run setup (`openclaw gateway` wizard). This
-# role is a thin bootstrap layer: install the npm package, clone the
-# workspace repo, configure Tailscale Serve, and clean up any legacy
-# system-level clawdbot.service unit left behind by older iac. The
-# runtime systemd unit and the openclaw.json config are created by the
-# wizard and are NOT Ansible-managed.
+# role is a thin bootstrap layer: install the `claude` binary (native
+# installer), restore ~/.claude/.credentials.json from 1Password,
+# install the openclaw npm package, clone the workspace repo, configure
+# Tailscale Serve, and clean up any legacy system-level clawdbot.service
+# unit left behind by older iac. The runtime systemd unit and the
+# openclaw.json config are created by the wizard and are NOT
+# Ansible-managed.
 #
-# 1Password note: this role does NOT deploy a service account token to
-# disk. The running openclaw process reads 1Password via its own
-# mechanism (local signed-in account or ~/.clawdbot/credentials/); a
-# root-owned /etc/clawdbot/op.env at mode 0600 can't be read by the
-# user-level service, so there's no point deploying one. Items clawdbot
-# consumes from the `openclaw` vault are documented below for reference:
-#   - "openclaw anthropic" - Anthropic API key
+# 1Password notes:
+#
+# This role deploys ONE secret to disk: `~/.claude/.credentials.json`,
+# populated from the `openclaw claude-code credentials` item in the
+# `openclaw` vault. That file is the OAuth blob the local `claude`
+# binary writes after a `claude login` web flow — ansible restores it
+# on reprovision so the host doesn't have to re-auth interactively.
+# The file is deployed with `force: no`, so a freshly-refreshed token
+# on an already-provisioned host is never clobbered by a stale vault
+# snapshot. See ansible/openclaw.yml for the pre-destroy sync ritual.
+#
+# This role does NOT deploy a service account token to disk. The
+# running openclaw process reads 1Password via its own mechanism
+# (local signed-in account or ~/.clawdbot/credentials/). Items openclaw
+# consumes at runtime from the `openclaw` vault (not managed by this
+# role — openclaw owns them) are documented below for reference:
 #   - "github" - GitHub credentials
 #   - "openai - text embedding for memory search" - OpenAI embeddings
 #   - "discord clawdbot" - Discord bot token
@@ -47,3 +58,9 @@ openclaw_config_dir: "/home/{{ openclaw_user }}/.clawdbot"
 # Tailscale Serve (recommended for web UI auth)
 openclaw_tailscale_serve: true
 openclaw_port: 18789
+
+# Claude Code OAuth blob (contents of ~/.claude/.credentials.json).
+# Populated by the playbook via a 1Password lookup; empty default means
+# the credential-restore task is a no-op if the playbook doesn't wire
+# it up. See ansible/openclaw.yml.
+openclaw_claude_credentials: ""

--- a/ansible/roles/openclaw/tasks/main.yml
+++ b/ansible/roles/openclaw/tasks/main.yml
@@ -81,7 +81,7 @@
   ansible.builtin.file:
     path: "/home/{{ openclaw_user }}/.claude"
     state: directory
-    mode: "0755"
+    mode: "0700"
   when: openclaw_claude_credentials | length > 0
   tags:
     - openclaw

--- a/ansible/roles/openclaw/tasks/main.yml
+++ b/ansible/roles/openclaw/tasks/main.yml
@@ -3,10 +3,11 @@
 #
 # The openclaw CLI installs and manages its own user-level systemd unit
 # (~/.config/systemd/user/openclaw-gateway.service) during first-run
-# setup via `openclaw gateway`. This role only bootstraps: npm install,
-# workspace clone, Tailscale Serve. On a fresh host the user still needs
-# to run the openclaw wizard once after this role completes so the
-# gateway unit is created and enabled.
+# setup via `openclaw gateway`. This role bootstraps: claude binary
+# install, Claude Code credential restore, npm install of openclaw,
+# workspace clone, Tailscale Serve. On a fresh host the user still
+# needs to run the openclaw wizard once after this role completes so
+# the gateway unit is created and enabled.
 
 # Cleanup: remove the legacy system-level clawdbot.service left behind
 # by older versions of this role. The tool now installs its own
@@ -50,6 +51,63 @@
   tags:
     - openclaw
     - cleanup
+
+# Install the `claude` binary via Anthropic's native installer.
+# Openclaw shells out to this binary for Claude-backed model calls;
+# without it the provider wiring fails. The installer drops a single
+# ELF at ~/.local/share/claude/versions/<ver> and symlinks
+# ~/.local/bin/claude. `creates:` makes this idempotent — upgrades are
+# handled by `claude update` on the host, not by re-running the script.
+- name: Install claude binary via upstream installer
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.shell: |
+    set -euo pipefail
+    curl -fsSL https://claude.ai/install.sh | bash
+  args:
+    creates: "/home/{{ openclaw_user }}/.local/bin/claude"
+    executable: /bin/bash
+  tags:
+    - openclaw
+    - install
+    - claude
+
+# Ensure ~/.claude exists before dropping the credentials file into it.
+# Claude Code creates this dir itself on first run, but on a fresh host
+# we write the credentials *before* the binary has ever been invoked.
+- name: Ensure ~/.claude directory exists
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.file:
+    path: "/home/{{ openclaw_user }}/.claude"
+    state: directory
+    mode: "0755"
+  when: openclaw_claude_credentials | length > 0
+  tags:
+    - openclaw
+    - claude
+    - credentials
+
+# Restore the Claude Code OAuth blob captured from a prior `claude login`
+# web flow on this host. `force: no` means this creates the file on a
+# fresh host but never overwrites a file already on disk — Claude Code
+# refreshes tokens in-place, and a stale vault snapshot must not clobber
+# a fresh on-host token. Keeping the vault in sync is the operator's job
+# (see the R-1 pre-destroy sync ritual in ansible/openclaw.yml).
+- name: Restore Claude Code credentials
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.copy:
+    content: "{{ openclaw_claude_credentials }}"
+    dest: "/home/{{ openclaw_user }}/.claude/.credentials.json"
+    mode: "0600"
+    force: false
+  when: openclaw_claude_credentials | length > 0
+  no_log: true
+  tags:
+    - openclaw
+    - claude
+    - credentials
 
 # Install openclaw globally via npm
 - name: Install openclaw via npm


### PR DESCRIPTION
## Summary

- Adds two new tasks to the `openclaw` role: install the `claude` binary via Anthropic's native installer, and restore `~/.claude/.credentials.json` from a new 1Password item on fresh hosts.
- Wires the playbook to pull the credential blob from the `openclaw claude-code credentials` item in the `openclaw` vault via `community.general.onepassword`.
- Credential restore uses `force: no` so runs on already-provisioned hosts never clobber a freshly-refreshed token on disk with a stale vault snapshot.
- Drops the `openclaw anthropic` raw-API-key reference from the role docstring (item already deleted in 1P).

## Bootstrap (one-time, before first run)

Create the new 1P item from the current openclaw host so ansible has something to restore:

\`\`\`bash
ssh openclaw 'cat ~/.claude/.credentials.json' > /tmp/openclaw-creds.json
op item create --vault openclaw \
  --category=password \
  --title="openclaw claude-code credentials" \
  "credential[password]=$(cat /tmp/openclaw-creds.json)"
rm /tmp/openclaw-creds.json
\`\`\`

## Pre-destroy sync ritual (R-1)

Run this from your workstation **before** \`tofu destroy\`, so the 1P copy is current:

\`\`\`bash
ssh openclaw 'cat ~/.claude/.credentials.json' > /tmp/openclaw-creds.json
op item edit "openclaw claude-code credentials" \
  --vault openclaw \
  "credential[password]=\$(cat /tmp/openclaw-creds.json)"
rm /tmp/openclaw-creds.json
\`\`\`

Claude Code rewrites the access token in place when it refreshes; a stale snapshot can force a manual re-login after restore. This ritual closes the drift window for planned reprovisioning.

## Redeploy flow

1. R-1 sync (above).
2. \`tofu -chdir=terraform destroy -target=digitalocean_droplet.openclaw\` (or full \`destroy\`).
3. \`tofu -chdir=terraform apply\` — cloud-init brings Tailscale up.
4. \`ansible-playbook bootstrap.yml --limit openclaw -u root\`
5. \`ansible-playbook -i inventory.yml openclaw.yml\` — installs \`claude\`, restores creds.
6. SSH in and run \`openclaw gateway\` once (unchanged — wizard creates its user-level systemd unit).

## Test plan

- [ ] Syntax-check passes: \`ansible-playbook --syntax-check -i inventory.yml openclaw.yml\` (verified locally)
- [ ] 1P item \`openclaw claude-code credentials\` exists in \`openclaw\` vault and bootstrap command above populated it from the live host
- [ ] Dry-run: \`ansible-playbook -i inventory.yml openclaw.yml --check --diff --tags claude\` reports the credential task as changed on a hypothetical fresh host (no-op on current host because \`force: no\`)
- [ ] Real run on the rebuilt droplet: \`claude --version\` works, \`~/.claude/.credentials.json\` exists at mode 0600, \`claude\` answers a trivial prompt without prompting for login
- [ ] Openclaw gateway wizard completes and openclaw can call the Claude provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)