### PR TITLE
dev_gui: install claude-desktop from pinned GitHub release .deb

### DIFF
--- a/ansible/roles/dev_gui/defaults/main.yml
+++ b/ansible/roles/dev_gui/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+# Claude Desktop (community .deb from aaddrick/claude-desktop-debian).
+#
+# Anthropic does not ship a Linux build; aaddrick repackages the Windows
+# Electron bundle into a .deb. Until 2026-04-23 this role consumed their
+# `stable` apt channel, but the published Release file has been
+# intermittently unreachable. We now fetch a pinned `.deb` asset directly
+# from the GitHub release and install it with `apt install ./file.deb`.
+#
+# The tag format aaddrick uses is `v<their-version>+claude<upstream>`, e.g.
+# `v2.0.5+claude1.3883.0`. Renovate tracks this value via a custom manager
+# in `renovate.json`; bumps land as auto-merged PRs.
+claude_desktop_tag: "v2.0.5+claude1.3883.0"

--- a/ansible/roles/dev_gui/tasks/main.yml
+++ b/ansible/roles/dev_gui/tasks/main.yml
@@ -123,11 +123,38 @@
     update_cache: true
   when: claude_desktop_legacy_source.changed
 
+# Fail fast when the host arch isn't one of the two aaddrick ships. Any
+# other value would silently pick the wrong asset URL and download a
+# bogus .deb.
+- name: Validate host architecture for claude-desktop .deb
+  tags: claude-desktop
+  ansible.builtin.assert:
+    that:
+      - ansible_architecture in ['x86_64', 'amd64', 'aarch64', 'arm64']
+    fail_msg: >-
+      claude-desktop .deb is only published for x86_64/amd64 and
+      aarch64/arm64 hosts by aaddrick; got {{ ansible_architecture }}.
+
+# Fail fast if the pinned tag doesn't match aaddrick's convention
+# (v<their>+claude<upstream>). Renovate could conceivably land a tag
+# with a different shape, at which point the regex below would silently
+# produce a broken download URL; surface the mismatch explicitly.
+- name: Validate claude_desktop_tag format
+  tags: claude-desktop
+  ansible.builtin.assert:
+    that:
+      - claude_desktop_tag is match('^v[^+]+\\+claude[^ ]+$')
+    fail_msg: >-
+      claude_desktop_tag must match `v<aaddrick>+claude<upstream>` (e.g.
+      v2.0.5+claude1.3883.0); got `{{ claude_desktop_tag }}`. Review the
+      Renovate bump and update the regex_replace below if aaddrick's
+      release naming has changed.
+
 - name: Derive claude-desktop .deb filename version (upstream-aaddrick)
   tags: claude-desktop
   ansible.builtin.set_fact:
     _claude_desktop_filename_version: "{{ claude_desktop_tag | regex_replace('^v(.+)\\+claude(.+)$', '\\2-\\1') }}"
-    _claude_desktop_deb_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}"
+    _claude_desktop_deb_arch: "{{ {'x86_64': 'amd64', 'amd64': 'amd64', 'aarch64': 'arm64', 'arm64': 'arm64'}[ansible_architecture] }}"
 
 - name: Query currently installed claude-desktop version
   tags: claude-desktop

--- a/ansible/roles/dev_gui/tasks/main.yml
+++ b/ansible/roles/dev_gui/tasks/main.yml
@@ -104,31 +104,50 @@
       become: true
   tags: spotify
 
-- name: Check if claude-desktop apt repo exists
+# Claude Desktop — installed from a pinned `.deb` on aaddrick's GitHub
+# Releases. See roles/dev_gui/defaults/main.yml for the pin + context.
+# We deliberately avoid aaddrick's apt channel (their Release file has
+# been intermittently broken) and fetch the .deb asset directly.
+- name: Remove legacy aaddrick claude-desktop apt source
   tags: claude-desktop
   become: true
-  ansible.builtin.stat:
+  ansible.builtin.file:
     path: /etc/apt/sources.list.d/claude-desktop.sources
-  register: claude_desktop_repo_exists
+    state: absent
+  register: claude_desktop_legacy_source
 
-- name: Install claude-desktop apt repo
+- name: Refresh apt cache after removing legacy claude-desktop source
   tags: claude-desktop
   become: true
-  ansible.builtin.deb822_repository:
-    name: claude-desktop
-    types: [deb]
-    uris: https://aaddrick.github.io/claude-desktop-debian
-    signed_by: https://aaddrick.github.io/claude-desktop-debian/KEY.gpg
-    suites: [stable]
-    components: [main]
-    state: present
-    enabled: true
-  when: not claude_desktop_repo_exists.stat.exists
-
-- name: Install claude-desktop
-  become: true
-  tags: claude-desktop
   ansible.builtin.apt:
     update_cache: true
-    pkg:
-      - claude-desktop
+  when: claude_desktop_legacy_source.changed
+
+- name: Derive claude-desktop .deb filename version (upstream-aaddrick)
+  tags: claude-desktop
+  ansible.builtin.set_fact:
+    _claude_desktop_filename_version: "{{ claude_desktop_tag | regex_replace('^v(.+)\\+claude(.+)$', '\\2-\\1') }}"
+    _claude_desktop_deb_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}"
+
+- name: Query currently installed claude-desktop version
+  tags: claude-desktop
+  ansible.builtin.command: dpkg-query -f '${Version}' -W claude-desktop
+  register: claude_desktop_installed
+  changed_when: false
+  failed_when: false
+  check_mode: false
+
+- name: Download pinned claude-desktop .deb
+  tags: claude-desktop
+  ansible.builtin.get_url:
+    url: "https://github.com/aaddrick/claude-desktop-debian/releases/download/{{ claude_desktop_tag }}/claude-desktop_{{ _claude_desktop_filename_version }}_{{ _claude_desktop_deb_arch }}.deb"
+    dest: "/tmp/claude-desktop_{{ _claude_desktop_filename_version }}_{{ _claude_desktop_deb_arch }}.deb"
+    mode: "0644"
+  when: claude_desktop_installed.stdout != _claude_desktop_filename_version
+
+- name: Install claude-desktop from pinned .deb
+  tags: claude-desktop
+  become: true
+  ansible.builtin.apt:
+    deb: "/tmp/claude-desktop_{{ _claude_desktop_filename_version }}_{{ _claude_desktop_deb_arch }}.deb"
+  when: claude_desktop_installed.stdout != _claude_desktop_filename_version

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,20 @@
   ],
   "automerge": true,
   "automergeType": "pr",
-  "platformAutomerge": true
+  "platformAutomerge": true,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track aaddrick/claude-desktop-debian releases for the claude_desktop_tag pin in dev_gui role",
+      "fileMatch": [
+        "^ansible/roles/dev_gui/defaults/main\\.yml$"
+      ],
+      "matchStrings": [
+        "claude_desktop_tag:\\s*[\"'](?<currentValue>[^\"']+)[\"']"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "aaddrick/claude-desktop-debian",
+      "versioningTemplate": "loose"
+    }
+  ]
 }


### PR DESCRIPTION
Closes #402.

## Summary

- Stops consuming aaddrick's apt channel (broken \`Release\` file); fetches a pinned \`.deb\` asset directly from the \`aaddrick/claude-desktop-debian\` GitHub release instead.
- Installs via \`apt install ./file.deb\` so apt still owns the package (shows in \`apt list\`, cleanly uninstallable, deps resolved).
- Pin lives in a new \`ansible/roles/dev_gui/defaults/main.yml\` as \`claude_desktop_tag\`.
- Adds a Renovate custom regex manager in \`renovate.json\` tracking \`aaddrick/claude-desktop-debian\` GitHub releases. With the repo's existing \`automerge: true\`, version bumps land automatically.

## Why not use an Anthropic-direct repo

Anthropic doesn't publish a Linux build of Claude Desktop. The community \`aaddrick\` repo repackages the Windows Electron bundle. This PR gets off their broken apt channel but still consumes their \`.deb\` artifact — just directly from Releases (HTTPS \`github.com\`) rather than via \`aaddrick.github.io\` apt.

## What changes on already-provisioned hosts

- \`/etc/apt/sources.list.d/claude-desktop.sources\` is removed (it points at the broken repo) and \`apt update\` refreshed.
- On next run, \`dpkg-query\` checks the installed version; if it differs from the pin, downloads the \`.deb\` to \`/tmp\` and installs it.
- Architecture (\`amd64\` or \`arm64\`) is selected from \`ansible_architecture\`.

## Renovate versioning note

The tag format \`v2.0.5+claude1.3883.0\` doesn't cleanly map to semver (\`+\` is build-metadata by semver rules). \`loose\` versioning should cover the common case (aaddrick version bumps). If we find we're missing updates where only the \`+claude\` part changes, we can switch to \`regex\` versioning with a custom pattern. Flagging this so we don't chase a silent staleness.

## Test plan

- [x] JSON syntax valid (\`python3 -c 'import json; json.load(open(\"renovate.json\"))'\`)
- [x] Ansible playbook syntax check passes for \`dev.yml\`
- [x] Derived filename matches release asset name (regex_replace produces \`1.3883.0-2.0.5\` from \`v2.0.5+claude1.3883.0\`)
- [x] \`HEAD\` on the constructed download URL returns 200
- [ ] CI \`Molecule Test\` goes green (was red on #401 due to this exact task)
- [ ] Manual run on a \`dev_gui\` host: stale \`claude-desktop.sources\` removed, \`apt update\` succeeds, \`claude-desktop\` upgraded/installed from pinned deb, desktop app still launches
- [ ] Next Renovate scan opens a PR if aaddrick has a newer release than \`v2.0.5+claude1.3883.0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)