### PR TITLE
tf: ignore_changes on droplets to prevent provider-drift destruction

### DIFF
--- a/terraform/jasonernst-com.tf
+++ b/terraform/jasonernst-com.tf
@@ -22,6 +22,14 @@ resource "digitalocean_droplet" "www-jasonernst-com" {
     tailscale_authkey = data.onepassword_item.tailscale.credential
     hostname          = "www"
   })
+
+  # Don't let DO provider drift force-replace this droplet. See projects.tf
+  # for the full rationale — short version: public_networking regression in
+  # provider 2.84.1, user_data comment edits, and image slug default changes
+  # should not silently destroy a running host.
+  lifecycle {
+    ignore_changes = [public_networking, user_data, image]
+  }
 }
 
 resource "digitalocean_domain" "default" {

--- a/terraform/openclaw.tf
+++ b/terraform/openclaw.tf
@@ -32,6 +32,14 @@ resource "digitalocean_droplet" "openclaw" {
     tailscale_authkey = data.onepassword_item.tailscale.credential
     hostname          = "openclaw"
   })
+
+  # Don't let DO provider drift force-replace this droplet. See projects.tf
+  # for the full rationale — short version: public_networking regression in
+  # provider 2.84.1, user_data comment edits, and image slug default changes
+  # should not silently destroy a running host.
+  lifecycle {
+    ignore_changes = [public_networking, user_data, image]
+  }
 }
 
 # Firewall - Tailscale only (no public inbound)

--- a/terraform/projects.tf
+++ b/terraform/projects.tf
@@ -28,6 +28,19 @@ resource "digitalocean_droplet" "projects" {
     tailscale_authkey = data.onepassword_item.tailscale.credential
     hostname          = "projects"
   })
+
+  # Don't let DO provider drift force-replace this droplet. Concretely:
+  #   - public_networking: added in provider 2.84.1 with a hardcoded default,
+  #     triggers replacement on existing state. Upstream fix in PR #1526.
+  #     https://github.com/digitalocean/terraform-provider-digitalocean/issues/1524
+  #   - user_data: cloud-init template edits would otherwise recreate the host
+  #     just because we tweaked a comment. First-boot script only runs once.
+  #   - image: DO occasionally rolls image slug defaults; we don't want a
+  #     provider-side default change to replace a running droplet.
+  # To intentionally recreate, use `terraform taint` or destroy+apply.
+  lifecycle {
+    ignore_changes = [public_networking, user_data, image]
+  }
 }
 
 # ============================================================================

--- a/terraform/projects.tf
+++ b/terraform/projects.tf
@@ -37,7 +37,8 @@ resource "digitalocean_droplet" "projects" {
   #     just because we tweaked a comment. First-boot script only runs once.
   #   - image: DO occasionally rolls image slug defaults; we don't want a
   #     provider-side default change to replace a running droplet.
-  # To intentionally recreate, use `terraform taint` or destroy+apply.
+  # To intentionally recreate, use `terraform apply -replace="digitalocean_droplet.projects"`
+  # or destroy+apply.
   lifecycle {
     ignore_changes = [public_networking, user_data, image]
   }


### PR DESCRIPTION
Adds \`lifecycle { ignore_changes = [public_networking, user_data, image] }\` to each \`digitalocean_droplet\` resource in the repo.

## Context

A routine \`./tf apply\` today destroyed and recreated \`www-jasonernst-com\` (hosts the site + mail) and \`projects\` — with data loss — because the plan included \`# forces replacement\` lines for \`public_networking\` on resources I wasn't trying to touch. The trigger was DO provider 2.84.1 adding \`public_networking\` to the schema with a hardcoded default, which made the attribute show up as a diff on existing state.

Upstream issue: [digitalocean/terraform-provider-digitalocean#1524](https://github.com/digitalocean/terraform-provider-digitalocean/issues/1524)
Upstream fix (unreleased): [PR #1526](https://github.com/digitalocean/terraform-provider-digitalocean/pull/1526)

## Why these three attributes

- **\`public_networking\`** — the specific trigger from today's incident. Ignoring it closes the regression regardless of when #1526 merges.
- **\`user_data\`** — cloud-init runs once, at first boot. Editing the template shouldn't recreate a running droplet just because a comment moved.
- **\`image\`** — DO periodically changes image slug defaults; a provider-side default drift shouldn't silently destroy a running host.

## What this does NOT change

- Intentional recreation still works: \`terraform taint\` or destroy+apply with \`-target\` bypass \`ignore_changes\`.
- Other droplet attributes (\`size\`, \`region\`, \`tags\`, \`vpc_uuid\`, \`ssh_keys\`, etc.) still diff normally.
- No infrastructure changes — this is purely a plan-time guardrail.

## Test plan

- [x] \`terraform validate\` passes
- [ ] CI (Terraform Validate, Terraform Plan) is green
- [ ] Next \`./tf plan\` shows \`0 to add, 0 to change, 0 to destroy\` on a clean tree (i.e., the ignore_changes doesn't itself force a diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)