### PR TITLE
tf: tailscale logout on droplet destroy to free hostname

### DIFF
--- a/terraform/jasonernst-com.tf
+++ b/terraform/jasonernst-com.tf
@@ -22,6 +22,22 @@ resource "digitalocean_droplet" "www-jasonernst-com" {
     tailscale_authkey = data.onepassword_item.tailscale.credential
     hostname          = "www"
   })
+
+  # Deregister from Tailscale before the droplet is destroyed so the
+  # replacement node can claim the "www" hostname cleanly. See
+  # openclaw.tf for rationale.
+  provisioner "remote-exec" {
+    when       = destroy
+    on_failure = continue
+    inline     = ["tailscale logout || true"]
+    connection {
+      type    = "ssh"
+      user    = "root"
+      host    = self.ipv4_address
+      timeout = "30s"
+      agent   = true
+    }
+  }
 }
 
 resource "digitalocean_domain" "default" {

--- a/terraform/jasonernst-com.tf
+++ b/terraform/jasonernst-com.tf
@@ -25,18 +25,11 @@ resource "digitalocean_droplet" "www-jasonernst-com" {
 
   # Deregister from Tailscale before the droplet is destroyed so the
   # replacement node can claim the "www" hostname cleanly. See
-  # openclaw.tf for rationale.
-  provisioner "remote-exec" {
+  # openclaw.tf for rationale (tailscale ssh vs. remote-exec).
+  provisioner "local-exec" {
     when       = destroy
     on_failure = continue
-    inline     = ["tailscale logout || true"]
-    connection {
-      type    = "ssh"
-      user    = "root"
-      host    = self.ipv4_address
-      timeout = "30s"
-      agent   = true
-    }
+    command    = "tailscale ssh root@www -- tailscale logout 2>&1 || echo 'tailscale logout failed; continuing destroy'"
   }
 }
 

--- a/terraform/jasonernst-com.tf
+++ b/terraform/jasonernst-com.tf
@@ -29,7 +29,7 @@ resource "digitalocean_droplet" "www-jasonernst-com" {
   provisioner "local-exec" {
     when       = destroy
     on_failure = continue
-    command    = "tailscale ssh root@www -- tailscale logout 2>&1 || echo 'tailscale logout failed; continuing destroy'"
+    command    = "tailscale ssh root@www -- tailscale logout"
   }
 }
 

--- a/terraform/openclaw.tf
+++ b/terraform/openclaw.tf
@@ -33,25 +33,28 @@ resource "digitalocean_droplet" "openclaw" {
     hostname          = "openclaw"
   })
 
-  # Deregister from Tailscale before the droplet is destroyed, so the
+  # Deregister from Tailscale before the droplet is destroyed so the
   # replacement node can claim the "openclaw" hostname cleanly instead
   # of getting "-1" appended. Without this, Tailscale keeps the offline
   # node record until key expiry (~180 days) and collides with any
   # replacement that registers the same hostname.
   #
-  # Runs over SSH as root using the operator's SSH agent. If the droplet
-  # is already unreachable, `on_failure = continue` lets destroy proceed.
-  provisioner "remote-exec" {
+  # Uses `tailscale ssh` rather than the remote-exec provisioner because:
+  #   1. The DO firewall blocks public port 22; SSH only works over the
+  #      tailnet.
+  #   2. The droplets run with `tailscale up --ssh`, which authenticates
+  #      via tailnet identity, not SSH keys. Terraform's Go SSH client
+  #      can't speak that; the system `tailscale ssh` binary can.
+  #
+  # Requires: the operator running `./tf destroy` must be signed into
+  # the same tailnet with an ACL permitting `ssh` to this host as root.
+  # `on_failure = continue` keeps destroy moving if the droplet is
+  # already unreachable (worst case: fall back to the pre-PR behavior
+  # where the offline record hangs around and the replacement gets -1).
+  provisioner "local-exec" {
     when       = destroy
     on_failure = continue
-    inline     = ["tailscale logout || true"]
-    connection {
-      type    = "ssh"
-      user    = "root"
-      host    = self.ipv4_address
-      timeout = "30s"
-      agent   = true
-    }
+    command    = "tailscale ssh root@openclaw -- tailscale logout 2>&1 || echo 'tailscale logout failed; continuing destroy'"
   }
 }
 

--- a/terraform/openclaw.tf
+++ b/terraform/openclaw.tf
@@ -54,7 +54,7 @@ resource "digitalocean_droplet" "openclaw" {
   provisioner "local-exec" {
     when       = destroy
     on_failure = continue
-    command    = "tailscale ssh root@openclaw -- tailscale logout 2>&1 || echo 'tailscale logout failed; continuing destroy'"
+    command    = "tailscale ssh root@openclaw -- tailscale logout"
   }
 }
 

--- a/terraform/openclaw.tf
+++ b/terraform/openclaw.tf
@@ -32,6 +32,27 @@ resource "digitalocean_droplet" "openclaw" {
     tailscale_authkey = data.onepassword_item.tailscale.credential
     hostname          = "openclaw"
   })
+
+  # Deregister from Tailscale before the droplet is destroyed, so the
+  # replacement node can claim the "openclaw" hostname cleanly instead
+  # of getting "-1" appended. Without this, Tailscale keeps the offline
+  # node record until key expiry (~180 days) and collides with any
+  # replacement that registers the same hostname.
+  #
+  # Runs over SSH as root using the operator's SSH agent. If the droplet
+  # is already unreachable, `on_failure = continue` lets destroy proceed.
+  provisioner "remote-exec" {
+    when       = destroy
+    on_failure = continue
+    inline     = ["tailscale logout || true"]
+    connection {
+      type    = "ssh"
+      user    = "root"
+      host    = self.ipv4_address
+      timeout = "30s"
+      agent   = true
+    }
+  }
 }
 
 # Firewall - Tailscale only (no public inbound)

--- a/terraform/projects.tf
+++ b/terraform/projects.tf
@@ -28,6 +28,22 @@ resource "digitalocean_droplet" "projects" {
     tailscale_authkey = data.onepassword_item.tailscale.credential
     hostname          = "projects"
   })
+
+  # Deregister from Tailscale before the droplet is destroyed so the
+  # replacement node can claim the "projects" hostname cleanly. See
+  # openclaw.tf for rationale.
+  provisioner "remote-exec" {
+    when       = destroy
+    on_failure = continue
+    inline     = ["tailscale logout || true"]
+    connection {
+      type    = "ssh"
+      user    = "root"
+      host    = self.ipv4_address
+      timeout = "30s"
+      agent   = true
+    }
+  }
 }
 
 # ============================================================================

--- a/terraform/projects.tf
+++ b/terraform/projects.tf
@@ -35,7 +35,7 @@ resource "digitalocean_droplet" "projects" {
   provisioner "local-exec" {
     when       = destroy
     on_failure = continue
-    command    = "tailscale ssh root@projects -- tailscale logout 2>&1 || echo 'tailscale logout failed; continuing destroy'"
+    command    = "tailscale ssh root@projects -- tailscale logout"
   }
 }
 

--- a/terraform/projects.tf
+++ b/terraform/projects.tf
@@ -31,18 +31,11 @@ resource "digitalocean_droplet" "projects" {
 
   # Deregister from Tailscale before the droplet is destroyed so the
   # replacement node can claim the "projects" hostname cleanly. See
-  # openclaw.tf for rationale.
-  provisioner "remote-exec" {
+  # openclaw.tf for rationale (tailscale ssh vs. remote-exec).
+  provisioner "local-exec" {
     when       = destroy
     on_failure = continue
-    inline     = ["tailscale logout || true"]
-    connection {
-      type    = "ssh"
-      user    = "root"
-      host    = self.ipv4_address
-      timeout = "30s"
-      agent   = true
-    }
+    command    = "tailscale ssh root@projects -- tailscale logout 2>&1 || echo 'tailscale logout failed; continuing destroy'"
   }
 }
 


### PR DESCRIPTION
Adds a destroy-time provisioner to each `digitalocean_droplet` resource that runs `tailscale logout` on the soon-to-be-destroyed host. This deregisters the device from the tailnet immediately so a replacement droplet can reclaim the original short hostname instead of getting `-1` appended.

## Why

After the provider-drift incident destroyed and recreated three droplets, the tailnet ended up with `www-1`, `projects-1`, and `openclaw-1` while the original names still point to the now-offline old records. Tailscale holds the offline records until key expiry (default ~180 days), so anything that SSHes by short name is broken in the meantime. This is a predictable pattern whenever we reprovision; it shouldn't be manual cleanup every time.

## How it works

```hcl
provisioner "local-exec" {
  when       = destroy
  on_failure = continue
  command    = "tailscale ssh root@<hostname> -- tailscale logout 2>&1 || echo 'tailscale logout failed; continuing destroy'"
}
```

### Why `tailscale ssh` (not `remote-exec`)

1. **Public port 22 is firewalled.** The DO firewall on every droplet blocks port 22 publicly; SSH only works over the tailnet.
2. **`tailscale up --ssh` is enabled** in cloud-init. SSH connections from tailnet peers are handled by Tailscale SSH, which authenticates via tailnet identity — not SSH keys. Terraform's Go SSH client (used by `remote-exec`) can't speak that protocol.
3. Shelling out to the system `tailscale ssh` binary handles both concerns: it connects over the tailnet (bypassing the firewall) and uses tailnet-identity auth natively.

## Caveats

1. **Requires the operator running `./tf destroy` to be signed into the tailnet** with an ACL allowing SSH to the host as root. If someone runs destroy from outside the tailnet, the logout fails and we fall back to today's manual-cleanup behavior (no worse).
2. **Best-effort only.** If the droplet is already unreachable when destroy runs, the logout silently fails (`on_failure = continue`). If you want a hard guarantee, the upgrade path is calling the Tailscale REST API — needs a new API key in 1P and more plumbing.
3. **Doesn't fix the existing `-1` state.** Delete the offline `www`, `projects`, `openclaw` devices in the Tailscale admin UI and either rename the `-1` variants or re-register them.

## Test plan

- [x] `terraform validate` passes
- [ ] CI (Terraform Validate, Terraform Plan) is green
- [ ] Next real destroy on a droplet: verify the offline record does not appear in `tailscale status` after destroy, and the replacement registers under the short name without `-1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)