### PR TITLE
openclaw: read claude-code credentials from Infrastructure vault

### DIFF
--- a/ansible/openclaw.yml
+++ b/ansible/openclaw.yml
@@ -14,11 +14,14 @@
 # Prerequisites:
 #   1. Droplet created via Terraform (with Tailscale via cloud-init)
 #   2. Bootstrap run: ansible-playbook bootstrap.yml --limit openclaw -u root
-#   3. 1Password vault "openclaw" with API keys and service token, plus
-#      a `openclaw claude-code credentials` item whose `credential` field
+#   3. 1Password `Infrastructure` vault (personal account) contains an
+#      `openclaw claude-code credentials` item whose `credential` field
 #      holds the verbatim contents of ~/.claude/.credentials.json from
 #      a prior `claude login` on the host. Ansible restores this file on
 #      fresh hosts so Claude Code doesn't need an interactive web login.
+#      Other openclaw-consumed secrets (github, openai, discord, mail,
+#      openclaw-sa-token) live in a separate openclaw vault on a
+#      different account and are not touched by this playbook.
 #
 # Usage:
 #   ansible-playbook -i inventory.yml openclaw.yml
@@ -30,7 +33,7 @@
 #
 #   ssh openclaw 'cat ~/.claude/.credentials.json' > /tmp/openclaw-creds.json
 #   op item edit "openclaw claude-code credentials" \
-#     --vault openclaw \
+#     --vault Infrastructure \
 #     "credential[password]=$(cat /tmp/openclaw-creds.json)"
 #   rm /tmp/openclaw-creds.json
 #
@@ -52,7 +55,7 @@
     # openclaw role vars
     openclaw_workspace_repo: "git@github.com:compscidr/kai-workspace.git"
     openclaw_tailscale_serve: true
-    openclaw_claude_credentials: "{{ lookup('community.general.onepassword', 'openclaw claude-code credentials', field='credential', vault='openclaw', account_id=onepassword_account_id) }}"
+    openclaw_claude_credentials: "{{ lookup('community.general.onepassword', 'openclaw claude-code credentials', field='credential', vault=onepassword_vault, account_id=onepassword_account_id) }}"
   roles:
     - fnm       # Install Node.js via fnm
     - openclaw  # Install and configure Openclaw

--- a/ansible/roles/openclaw/defaults/main.yml
+++ b/ansible/roles/openclaw/defaults/main.yml
@@ -15,14 +15,15 @@
 #
 # This role deploys ONE secret to disk: `~/.claude/.credentials.json`,
 # populated from the `openclaw claude-code credentials` item in the
-# `Infrastructure` vault (personal account — same vault every other
-# ansible-read secret in this repo lives in). That file is the OAuth
-# blob the local `claude` binary writes after a `claude login` web
-# flow — ansible restores it on reprovision so the host doesn't have
-# to re-auth interactively. Deployed with `force: no`, so a
-# freshly-refreshed token on an already-provisioned host is never
-# clobbered by a stale vault snapshot. See ansible/openclaw.yml for
-# the pre-destroy sync ritual.
+# `Infrastructure` vault (personal account — the default vault for
+# ansible lookups in this repo, set as `onepassword_vault` in
+# group_vars/all.yml; some playbooks override to a per-host vault).
+# That file is the OAuth blob the local `claude` binary writes after
+# a `claude login` web flow — ansible restores it on reprovision so
+# the host doesn't have to re-auth interactively. Deployed with
+# `force: no`, so a freshly-refreshed token on an already-provisioned
+# host is never clobbered by a stale vault snapshot. See
+# ansible/openclaw.yml for the pre-destroy sync ritual.
 #
 # This role does NOT deploy a service account token to disk. The
 # running openclaw process reads 1Password via its own mechanism

--- a/ansible/roles/openclaw/defaults/main.yml
+++ b/ansible/roles/openclaw/defaults/main.yml
@@ -15,18 +15,21 @@
 #
 # This role deploys ONE secret to disk: `~/.claude/.credentials.json`,
 # populated from the `openclaw claude-code credentials` item in the
-# `openclaw` vault. That file is the OAuth blob the local `claude`
-# binary writes after a `claude login` web flow — ansible restores it
-# on reprovision so the host doesn't have to re-auth interactively.
-# The file is deployed with `force: no`, so a freshly-refreshed token
-# on an already-provisioned host is never clobbered by a stale vault
-# snapshot. See ansible/openclaw.yml for the pre-destroy sync ritual.
+# `Infrastructure` vault (personal account — same vault every other
+# ansible-read secret in this repo lives in). That file is the OAuth
+# blob the local `claude` binary writes after a `claude login` web
+# flow — ansible restores it on reprovision so the host doesn't have
+# to re-auth interactively. Deployed with `force: no`, so a
+# freshly-refreshed token on an already-provisioned host is never
+# clobbered by a stale vault snapshot. See ansible/openclaw.yml for
+# the pre-destroy sync ritual.
 #
 # This role does NOT deploy a service account token to disk. The
 # running openclaw process reads 1Password via its own mechanism
 # (local signed-in account or ~/.clawdbot/credentials/). Items openclaw
-# consumes at runtime from the `openclaw` vault (not managed by this
-# role — openclaw owns them) are documented below for reference:
+# consumes at runtime (from a separate `openclaw` vault on a different
+# 1P account — not touched by this role) are documented below for
+# reference:
 #   - "github" - GitHub credentials
 #   - "openai - text embedding for memory search" - OpenAI embeddings
 #   - "discord clawdbot" - Discord bot token


### PR DESCRIPTION
## Why

The previously-pinned \`openclaw\` vault lives on a different 1P account than this repo's \`onepassword_account_id\` (the personal one, set in \`group_vars/all.yml\`). Every ansible lookup in the repo passes that account id, so the openclaw vault was unreachable:

\`\`\`
[ERROR] 2026/04/23 15:23:16 "openclaw" isn't a vault in this account.
Specify the vault with its ID or name.
\`\`\`

Moving to \`Infrastructure\` (personal account — same vault every other ansible-read secret in this repo uses) avoids wiring the separate openclaw-account service-account token through every ansible run just for one lookup.

Runtime secrets that openclaw itself reads (github, openai, discord, mail, openclaw-sa-token) live on the other account and are still handled by openclaw — not ansible — so that plumbing doesn't need to change.

## Changes

- \`ansible/openclaw.yml\` — lookup now uses \`vault=onepassword_vault\` (resolves to \`Infrastructure\`) instead of hardcoded \`'openclaw'\`.
- \`ansible/openclaw.yml\` header docstring — prerequisites and R-1 sync ritual updated to reference the new vault.
- \`ansible/roles/openclaw/defaults/main.yml\` docstring — same, plus note clarifying which items stay on the other account.

## Operator migration

Create the \`openclaw claude-code credentials\` item in the \`Infrastructure\` vault on the personal 1P account. Single concealed \`credential\` field, contents = \`~/.claude/.credentials.json\` verbatim. The one-liner:

\`\`\`
op item create --account CZG3A4373RA2FC5W5JKFUMYILI --vault Infrastructure \
  --category="API Credential" --title="openclaw claude-code credentials" \
  "credential=\$(cat /tmp/openclaw-creds.json)"
\`\`\`

The old item in the openclaw vault can be deleted or left in place — nothing in this repo references it after this change.

## Test plan

- [x] \`ansible-playbook --syntax-check -i inventory.yml openclaw.yml\` passes
- [ ] CI Ansible Lint stays green
- [ ] \`ansible -i inventory.yml openclaw -m debug -a "msg={{ openclaw_claude_credentials[:40] }}"\` returns the opening of the JSON blob
- [ ] Full \`ansible-playbook -i inventory.yml openclaw.yml\` succeeds on the new openclaw droplet and \`~/.claude/.credentials.json\` is created at 0600

🤖 Generated with [Claude Code](https://claude.com/claude-code)