### PR TITLE
Update compscidr/goblog Docker tag to v0.2.3

### DIFF
--- a/ansible/roles/jasonernst_com/tasks/main.yml
+++ b/ansible/roles/jasonernst_com/tasks/main.yml
@@ -255,7 +255,7 @@
     ansible_python_interpreter: "/usr/bin/python3"
   community.docker.docker_container:
     name: www.jasonernst.com
-    image: compscidr/goblog:v0.2.1
+    image: compscidr/goblog:v0.2.2
     volumes:
       - /opt/goblog/prod/uploads:/go/src/github.com/compscidr/goblog/www/uploads
     mounts:
@@ -286,7 +286,7 @@
     ansible_python_interpreter: "/usr/bin/python3"
   community.docker.docker_container:
     name: staging.jasonernst.com
-    image: compscidr/goblog:v0.2.1
+    image: compscidr/goblog:v0.2.2
     volumes:
       - /opt/goblog/staging/uploads:/go/src/github.com/compscidr/goblog/www/uploads
     mounts:

--- a/ansible/roles/jasonernst_com/tasks/main.yml
+++ b/ansible/roles/jasonernst_com/tasks/main.yml
@@ -255,7 +255,7 @@
     ansible_python_interpreter: "/usr/bin/python3"
   community.docker.docker_container:
     name: www.jasonernst.com
-    image: compscidr/goblog:v0.2.2
+    image: compscidr/goblog:v0.2.3
     volumes:
       - /opt/goblog/prod/uploads:/go/src/github.com/compscidr/goblog/www/uploads
     mounts:
@@ -286,7 +286,7 @@
     ansible_python_interpreter: "/usr/bin/python3"
   community.docker.docker_container:
     name: staging.jasonernst.com
-    image: compscidr/goblog:v0.2.2
+    image: compscidr/goblog:v0.2.3
     volumes:
       - /opt/goblog/staging/uploads:/go/src/github.com/compscidr/goblog/www/uploads
     mounts:

--- a/ansible/roles/projects/tasks/main.yml
+++ b/ansible/roles/projects/tasks/main.yml
@@ -207,7 +207,7 @@
   become: true
   community.docker.docker_container:
     name: goblog.live
-    image: compscidr/goblog:v0.2.2
+    image: compscidr/goblog:v0.2.3
     volumes:
       - /opt/goblog-live/uploads:/go/src/github.com/compscidr/goblog/www/uploads
       - /opt/goblog-live/site-theme:/go/src/github.com/compscidr/goblog/themes/site

--- a/ansible/roles/projects/tasks/main.yml
+++ b/ansible/roles/projects/tasks/main.yml
@@ -207,7 +207,7 @@
   become: true
   community.docker.docker_container:
     name: goblog.live
-    image: compscidr/goblog:v0.2.1
+    image: compscidr/goblog:v0.2.2
     volumes:
       - /opt/goblog-live/uploads:/go/src/github.com/compscidr/goblog/www/uploads
       - /opt/goblog-live/site-theme:/go/src/github.com/compscidr/goblog/themes/site


### PR DESCRIPTION
## Summary
- Bumps the goblog image to v0.2.3 across all three deployments (www.jasonernst.com, staging.jasonernst.com, goblog.live).
- v0.2.3 stacks two fixes for the issue we hit on goblog.live after the redeploy:
  - [goblogplatform/goblog#530](https://github.com/goblogplatform/goblog/pull/530) makes \`IsAdmin\` strict — a pre-populated \`.env\` no longer grants admin authority to anonymous visitors on a fresh install.
  - [goblogplatform/goblog#531](https://github.com/goblogplatform/goblog/pull/531) auto-promotes the first successful OAuth login to admin when no admin user exists, so an operator can finish setup just by signing in with GitHub instead of needing the wizard's UI flow.

## Test plan
- [ ] CI passes
- [ ] Deploy to goblog.live; sign in once with GitHub and confirm the Admin link appears for the operator and stays hidden for anonymous visitors
- [ ] Confirm www.jasonernst.com / staging still serve normally (existing admin_users row unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)