### PR TITLE
feat(openclaw): rename paths + automate first-run wizard in ansible

### DIFF
--- a/ansible/openclaw.yml
+++ b/ansible/openclaw.yml
@@ -37,10 +37,23 @@
 #     "credential[password]=$(cat /tmp/openclaw-creds.json)"
 #   rm /tmp/openclaw-creds.json
 #
-# Post-run: if this is a fresh install, run the `openclaw gateway`
-# wizard on the host once so the tool creates its user-level systemd
-# unit (~/.config/systemd/user/openclaw-gateway.service). Ansible does
-# not manage that unit or the openclaw.json config — the wizard does.
+# Post-run: on a fresh install the openclaw runtime config still has to
+# be set up by hand (known gap, separate from this playbook). Sketch:
+#   ssh openclaw -t openclaw setup
+#   ssh openclaw -t openclaw models auth login \
+#       --provider anthropic --method cli --set-default
+#   ssh openclaw -t openclaw plugins install clawhub:@openclaw/discord
+#   ssh openclaw -t openclaw plugins install clawhub:@openclaw/brave-plugin
+#   ssh openclaw "openclaw channels add --channel discord \
+#       --token \"$(op read 'op://openclaw/discord clawdbot/credential')\""
+#   GUILD=$(op read 'op://openclaw/discord clawdbot/username')
+#   ssh openclaw "openclaw config set channels.discord.guilds \
+#       \"{\\\"$GUILD\\\":{\\\"requireMention\\\":false}}\" --strict-json"
+#   ssh openclaw "openclaw config set gateway.controlUi.allowedOrigins \
+#       '[\"https://openclaw.tail21090.ts.net\"]'"
+#   ssh openclaw -t systemctl --user enable --now openclaw-gateway.service
+# Then open https://openclaw.tail21090.ts.net/#token=<gateway-token> and
+# approve the device pairing request via `openclaw devices approve`.
 
 - name: Deploy Openclaw
   hosts: openclaw

--- a/ansible/openclaw.yml
+++ b/ansible/openclaw.yml
@@ -11,17 +11,19 @@
 #
 # After that, `openclaw.tail21090.ts.net` resolves via MagicDNS.
 #
-# Prerequisites:
-#   1. Droplet created via Terraform (with Tailscale via cloud-init)
+# Prerequisites (all 1P items on the personal account ernstjason1@gmail.com):
+#   1. Droplet created via Terraform (with Tailscale via cloud-init).
 #   2. Bootstrap run: ansible-playbook bootstrap.yml --limit openclaw -u root
-#   3. 1Password `Infrastructure` vault (personal account) contains an
-#      `openclaw claude-code credentials` item whose `credential` field
-#      holds the verbatim contents of ~/.claude/.credentials.json from
-#      a prior `claude login` on the host. Ansible restores this file on
-#      fresh hosts so Claude Code doesn't need an interactive web login.
-#      Other openclaw-consumed secrets (github, openai, discord, mail,
-#      openclaw-sa-token) live in a separate openclaw vault on a
-#      different account and are not touched by this playbook.
+#   3. `Infrastructure` vault: `openclaw claude-code credentials` —
+#      `credential` field holds the verbatim contents of
+#      ~/.claude/.credentials.json from a prior `claude login` on the
+#      host. Restored on fresh hosts so Claude Code doesn't need an
+#      interactive web login.
+#   4. `openclaw` vault (separate vault on the same account):
+#        - `discord clawdbot` — `credential`=bot token, `username`=guild ID
+#        - `Brave API` — `credential`=API key
+#      These are pulled into the openclaw config via `openclaw channels
+#      add` / `openclaw config set` by the role.
 #
 # Usage:
 #   ansible-playbook -i inventory.yml openclaw.yml
@@ -37,30 +39,21 @@
 #     "credential[password]=$(cat /tmp/openclaw-creds.json)"
 #   rm /tmp/openclaw-creds.json
 #
-# Post-run: on a fresh install the openclaw runtime config still has to
-# be set up by hand (known gap, separate from this playbook). Sketch:
-#   ssh openclaw -t openclaw setup
-#   ssh openclaw -t openclaw models auth login \
-#       --provider anthropic --method cli --set-default
-#   ssh openclaw -t openclaw plugins install clawhub:@openclaw/discord
-#   ssh openclaw -t openclaw plugins install clawhub:@openclaw/brave-plugin
-#   ssh openclaw "openclaw channels add --channel discord \
-#       --token \"$(op read 'op://openclaw/discord clawdbot/credential')\""
-#   GUILD=$(op read 'op://openclaw/discord clawdbot/username')
-#   ssh openclaw "openclaw config set channels.discord.guilds \
-#       \"{\\\"$GUILD\\\":{\\\"requireMention\\\":false}}\" --strict-json"
-#   ssh openclaw "openclaw config set gateway.controlUi.allowedOrigins \
-#       '[\"https://openclaw.tail21090.ts.net\"]'"
-#   ssh openclaw -t systemctl --user enable --now openclaw-gateway.service
-# Then open https://openclaw.tail21090.ts.net/#token=<gateway-token> and
-# approve the device pairing request via `openclaw devices approve`.
+# Post-run on a fresh install: the playbook brings the gateway all the
+# way up (config, auth profile, plugins, channels, brave key, systemd
+# unit). The only remaining manual step is one-time Control UI device
+# pairing — open https://openclaw.tail21090.ts.net/#token=<gateway-token>
+# in a browser (get the token via `ssh openclaw openclaw dashboard
+# --no-open`), then on the host run `openclaw devices approve --latest`
+# to approve the pairing request.
 
 - name: Deploy Openclaw
   hosts: openclaw
   vars_files:
     - vars/user.yml
   pre_tasks:
-    - ansible.builtin.include_tasks: tailscale_check.yml
+    - name: Verify Tailscale reachability to openclaw host
+      ansible.builtin.include_tasks: tailscale_check.yml
   vars:
     # fnm role vars
     fnm_node_version: "22"
@@ -68,7 +61,35 @@
     # openclaw role vars
     openclaw_workspace_repo: "git@github.com:compscidr/kai-workspace.git"
     openclaw_tailscale_serve: true
-    openclaw_claude_credentials: "{{ lookup('community.general.onepassword', 'openclaw claude-code credentials', field='credential', vault=onepassword_vault, account_id=onepassword_account_id) }}"
+    # Claude OAuth blob — Infrastructure vault (default `onepassword_vault`).
+    openclaw_claude_credentials: >-
+      {{ lookup('community.general.onepassword',
+                'openclaw claude-code credentials',
+                field='credential',
+                vault=onepassword_vault,
+                account_id=onepassword_account_id) }}
+    # Runtime secrets — `openclaw` vault on the same personal account
+    # (separate vault, NOT the Infrastructure default). Field mappings:
+    #   discord clawdbot: credential=bot token, username=Discord guild ID
+    #   Brave API:        credential=API key
+    openclaw_discord_bot_token: >-
+      {{ lookup('community.general.onepassword',
+                'discord clawdbot',
+                field='credential',
+                vault='openclaw',
+                account_id=onepassword_account_id) }}
+    openclaw_discord_guild_id: >-
+      {{ lookup('community.general.onepassword',
+                'discord clawdbot',
+                field='username',
+                vault='openclaw',
+                account_id=onepassword_account_id) }}
+    openclaw_brave_api_key: >-
+      {{ lookup('community.general.onepassword',
+                'Brave API',
+                field='credential',
+                vault='openclaw',
+                account_id=onepassword_account_id) }}
   roles:
     - fnm       # Install Node.js via fnm
     - openclaw  # Install and configure Openclaw

--- a/ansible/roles/openclaw/defaults/main.yml
+++ b/ansible/roles/openclaw/defaults/main.yml
@@ -108,3 +108,12 @@ openclaw_tailscale_origin: "https://openclaw.tail21090.ts.net"
 # memory benefit from it). Sub-fields (frequency, model, timezone,
 # phases) keep the plugin's own defaults.
 openclaw_dreaming_enabled: true
+
+# Remote Ollama as a backup model provider behind Claude. Empty
+# baseUrl disables the ollama-provider tasks entirely. Default points
+# at the local Ollama server on ubuntu-beast over Tailscale (no auth
+# needed — ollama is anonymous). The fallback model gets appended to
+# `models.fallbacks` so the agent falls back here if claude-cli is
+# unreachable or revoked.
+openclaw_ollama_base_url: "http://ubuntu-beast.tail21090.ts.net:11434"
+openclaw_ollama_fallback_model: "qwen2.5:14b-32k"

--- a/ansible/roles/openclaw/defaults/main.yml
+++ b/ansible/roles/openclaw/defaults/main.yml
@@ -101,3 +101,10 @@ openclaw_plugins:
 # `openclaw.<tailnet>.ts.net` form; override per-host if your tailnet
 # differs.
 openclaw_tailscale_origin: "https://openclaw.tail21090.ts.net"
+
+# memory-core "dreaming" mode — the bundled memory plugin's offline
+# review/consolidation cycle. Defaults on so fresh provisions match
+# the long-running behaviour we want on this host (kai's identity +
+# memory benefit from it). Sub-fields (frequency, model, timezone,
+# phases) keep the plugin's own defaults.
+openclaw_dreaming_enabled: true

--- a/ansible/roles/openclaw/defaults/main.yml
+++ b/ansible/roles/openclaw/defaults/main.yml
@@ -2,14 +2,14 @@
 # Openclaw role defaults
 #
 # The openclaw CLI tool (formerly "clawdbot") manages its own user-level
-# systemd unit during first-run setup (`openclaw gateway` wizard). This
-# role is a thin bootstrap layer: install the `claude` binary (native
-# installer), restore ~/.claude/.credentials.json from 1Password,
-# install the openclaw npm package, clone the workspace repo, configure
-# Tailscale Serve, and clean up any legacy system-level clawdbot.service
-# unit left behind by older iac. The runtime systemd unit and the
-# openclaw.json config are created by the wizard and are NOT
-# Ansible-managed.
+# systemd unit during first-run setup (`openclaw setup` / `openclaw
+# onboard`). This role is a thin bootstrap layer: install the `claude`
+# binary (native installer), restore ~/.claude/.credentials.json from
+# 1Password, install the openclaw npm package, clone the workspace repo
+# into the openclaw state dir, configure Tailscale Serve, and clean up
+# any legacy system-level clawdbot.service unit left behind by older
+# iac. The runtime systemd unit and the openclaw.json config are
+# created by the wizard and are NOT Ansible-managed.
 #
 # 1Password notes:
 #
@@ -25,39 +25,44 @@
 # host is never clobbered by a stale vault snapshot. See
 # ansible/openclaw.yml for the pre-destroy sync ritual.
 #
-# This role does NOT deploy a service account token to disk. The
-# running openclaw process reads 1Password via its own mechanism
-# (local signed-in account or ~/.clawdbot/credentials/). Items openclaw
-# consumes at runtime (from a separate `openclaw` vault on a different
-# 1P account — not touched by this role) are documented below for
-# reference:
-#   - "github" - GitHub credentials
+# This role does NOT (yet) deploy openclaw's other runtime secrets.
+# Those items live in the separate `openclaw` 1P vault on the personal
+# account and currently must be configured by hand on first provision
+# via `openclaw channels add` / `openclaw config set`:
+#   - "discord clawdbot" - Discord bot token (credential field) + Discord
+#                          guild ID (username field)
 #   - "openai - text embedding for memory search" - OpenAI embeddings
-#   - "discord clawdbot" - Discord bot token
 #   - "mail.jasonernst.com - kai" - Email credentials
-#
-# Directory naming note: the tool's config directory is still
-# `~/.clawdbot/` on-disk for backwards compatibility with accumulated
-# state (agents, identity, memory, etc.). Only the config filename
-# migrated to `openclaw.json`. Do not change the config_dir path
-# without a coordinated on-host migration.
+#   - "github", "github key", "GH cli" - GitHub credentials
+#   - "Brave API" - Brave web search API key
+#   - "moltbook" - misc
+# Closing this gap (auto-configuring channels/auth via openclaw CLI from
+# 1P lookups) is tracked separately from this role.
 
 # User to run openclaw as (from vars/user.yml typically)
 openclaw_user: "{{ username }}"
 
 # Workspace
+# Cloned into ~/.openclaw/workspace so it matches openclaw's native
+# `agents.defaults.workspace` default. Bootstrap hook (`boot-md`) loads
+# IDENTITY/MEMORY/AGENTS from this path at session start — a mismatch
+# between this path and the path in openclaw.json causes the agent to
+# wake up with an empty/template persona.
 openclaw_workspace_repo: ""  # Required: git repo for workspace (e.g., git@github.com:user/kai-workspace.git)
-openclaw_workspace_path: "/home/{{ openclaw_user }}/clawd"
+openclaw_workspace_path: "/home/{{ openclaw_user }}/.openclaw/workspace"
 
 # Installation
 openclaw_npm_package: "openclaw"
 openclaw_version: ""  # Pin to specific version, e.g., "2026.4.15" (empty = latest)
 
-# Config location
-# Directory path kept as ~/.clawdbot for on-disk backward compatibility
-# with accumulated bot state (agents/, memory/, identity/, canvas/,
-# credentials/, etc.). Openclaw writes openclaw.json inside it.
-openclaw_config_dir: "/home/{{ openclaw_user }}/.clawdbot"
+# Config / state directory
+# Openclaw writes openclaw.json plus all accumulated bot state
+# (agents/, memory/, identity/, canvas/, devices/, flows/, logs/,
+# tasks/, cron/, extensions/, workspace/) inside this dir. The wizard
+# creates it itself on first run, but the role pre-creates it with
+# tight permissions so a fresh host doesn't end up with a world-readable
+# state dir if openclaw is started by some other path.
+openclaw_config_dir: "/home/{{ openclaw_user }}/.openclaw"
 
 # Tailscale Serve (recommended for web UI auth)
 openclaw_tailscale_serve: true

--- a/ansible/roles/openclaw/defaults/main.yml
+++ b/ansible/roles/openclaw/defaults/main.yml
@@ -73,3 +73,31 @@ openclaw_port: 18789
 # the credential-restore task is a no-op if the playbook doesn't wire
 # it up. See ansible/openclaw.yml.
 openclaw_claude_credentials: ""
+
+# PATH used by ansible tasks that invoke the `openclaw` and `node`
+# binaries (both live under fnm's default-alias bin). Ansible's
+# become_user doesn't run a login shell, so PATH is barebones unless
+# we set it explicitly.
+openclaw_path: "/home/{{ openclaw_user }}/.local/share/fnm/aliases/default/bin:/home/{{ openclaw_user }}/.local/bin:/usr/local/bin:/usr/bin:/bin"
+
+# Runtime secrets / config the role applies via `openclaw` CLI after
+# `openclaw setup` writes the base config. All sourced from 1P by the
+# playbook (see ansible/openclaw.yml). Empty defaults mean the
+# corresponding tasks are skipped — the role is still usable on a
+# host where you only want the binaries deployed.
+openclaw_discord_bot_token: ""
+openclaw_discord_guild_id: ""
+openclaw_brave_api_key: ""
+
+# Plugins to install via `openclaw plugins install clawhub:<id>`.
+# 2026.5.7+ moved Discord and Brave out of the bundled set; channels
+# and tools won't work without them.
+openclaw_plugins:
+  - "@openclaw/discord"
+  - "@openclaw/brave-plugin"
+
+# Tailscale origin allowed to load the Control UI. Used when the role
+# configures `gateway.controlUi.allowedOrigins`. Defaults to the
+# `openclaw.<tailnet>.ts.net` form; override per-host if your tailnet
+# differs.
+openclaw_tailscale_origin: "https://openclaw.tail21090.ts.net"

--- a/ansible/roles/openclaw/defaults/main.yml
+++ b/ansible/roles/openclaw/defaults/main.yml
@@ -117,3 +117,13 @@ openclaw_dreaming_enabled: true
 # unreachable or revoked.
 openclaw_ollama_base_url: "http://ubuntu-beast.tail21090.ts.net:11434"
 openclaw_ollama_fallback_model: "qwen2.5:14b-32k"
+
+# Remote exo (https://github.com/exo-explore/exo) as a *second* backup
+# behind ollama. exo speaks the OpenAI-completions API at /v1, so we
+# register it as a custom provider id `exo` and let openclaw route
+# fallback turns to it. Empty baseUrl disables. Same Tailscale path as
+# ollama — only the port differs (52415 is exo's default API port).
+# The fallback model is exo's `id` field as returned by /v1/models;
+# the leading `mlx-community/` is part of the model name, not provider.
+openclaw_exo_base_url: "http://ubuntu-beast.tail21090.ts.net:52415/v1"
+openclaw_exo_fallback_model: "mlx-community/Llama-3.2-3B-Instruct-8bit"

--- a/ansible/roles/openclaw/handlers/main.yml
+++ b/ansible/roles/openclaw/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Restart openclaw-gateway
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.systemd_service:
+    name: openclaw-gateway.service
+    scope: user
+    state: restarted
+    daemon_reload: true

--- a/ansible/roles/openclaw/tasks/main.yml
+++ b/ansible/roles/openclaw/tasks/main.yml
@@ -139,10 +139,12 @@
     - workspace
 
 # Create config directory
-# Path kept as ~/.clawdbot for on-disk backward compatibility. Filename
-# migrated to openclaw.json. The directory accumulates bot state
-# (agents/, memory/, identity/, canvas/, credentials/, etc.) managed by
-# the openclaw runtime — not by Ansible.
+# Openclaw writes openclaw.json plus all accumulated state (agents/,
+# memory/, identity/, canvas/, devices/, flows/, logs/, tasks/, cron/,
+# extensions/, workspace/) inside ~/.openclaw. The wizard creates this
+# dir on first run, but pre-creating it with 0700 mode keeps a fresh
+# host from ever having world-readable state if openclaw is started
+# by some other path before the wizard runs.
 - name: Create openclaw config directory
   become: true
   become_user: "{{ openclaw_user }}"
@@ -155,8 +157,8 @@
     - config
 
 # The systemd unit is created by the openclaw tool itself during
-# `openclaw gateway` first-run setup. Ansible does not manage
-# /etc/systemd/system/openclaw*.service or the user-level
+# `openclaw setup` (or `openclaw onboard`) on first run. Ansible does
+# not manage /etc/systemd/system/openclaw*.service or the user-level
 # ~/.config/systemd/user/openclaw-gateway.service — the tool owns them,
 # including the embedded gateway token env var.
 

--- a/ansible/roles/openclaw/tasks/main.yml
+++ b/ansible/roles/openclaw/tasks/main.yml
@@ -338,6 +338,73 @@
     - config
     - brave
 
+# Remote Ollama provider config — points openclaw's ollama provider at
+# the local Ollama server (ubuntu-beast over Tailscale by default).
+# Schema requires `models` to exist as an array; we leave it empty so
+# the plugin discovers models from the server. Skipped when the
+# baseUrl var is empty.
+- name: Set Ollama provider baseUrl + empty models array
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: >-
+    openclaw config set models.providers.ollama
+    {{ {'baseUrl': openclaw_ollama_base_url, 'models': []} | to_json | quote }}
+    --strict-json
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  when: openclaw_ollama_base_url | length > 0
+  register: openclaw_ollama_set
+  changed_when: "'Updated' in (openclaw_ollama_set.stdout | default(''))"
+  notify: Restart openclaw-gateway
+  tags:
+    - openclaw
+    - config
+    - ollama
+
+# Read current fallback list so we only `add` when the model isn't
+# already present — `openclaw models fallbacks add` would silently
+# duplicate otherwise. Plain text output is parsed via substring match
+# so this is robust against the `--check` path (where the list command
+# is skipped and stdout is empty).
+- name: Read current model fallbacks
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: openclaw models fallbacks list --plain
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  when:
+    - openclaw_ollama_base_url | length > 0
+    - openclaw_ollama_fallback_model | length > 0
+  register: openclaw_fallbacks_list
+  changed_when: false
+  check_mode: false
+  tags:
+    - openclaw
+    - config
+    - ollama
+
+- name: Add Ollama fallback model
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: >-
+    openclaw models fallbacks add ollama/{{ openclaw_ollama_fallback_model }}
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  when:
+    - openclaw_ollama_base_url | length > 0
+    - openclaw_ollama_fallback_model | length > 0
+    - ("ollama/" + openclaw_ollama_fallback_model)
+      not in (openclaw_fallbacks_list.stdout | default(''))
+  changed_when: true
+  notify: Restart openclaw-gateway
+  tags:
+    - openclaw
+    - config
+    - ollama
+
 # Enable memory-core "dreaming" mode (offline review/consolidation
 # cycle). Bundled plugin, no separate install — just a config flip.
 - name: Set memory-core dreaming.enabled

--- a/ansible/roles/openclaw/tasks/main.yml
+++ b/ansible/roles/openclaw/tasks/main.yml
@@ -362,11 +362,36 @@
     - config
     - ollama
 
+# Remote exo provider config — exo speaks the OpenAI-completions API
+# at /v1 so we register it under a custom provider id `exo`. openclaw
+# accepts arbitrary provider ids in models.providers; the runtime
+# treats `exo/<model>` fallbacks as OpenAI-compat calls against the
+# configured baseUrl.
+- name: Set Exo provider baseUrl + empty models array
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: >-
+    openclaw config set models.providers.exo
+    {{ {'baseUrl': openclaw_exo_base_url, 'models': []} | to_json | quote }}
+    --strict-json
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  when: openclaw_exo_base_url | length > 0
+  register: openclaw_exo_set
+  changed_when: "'Updated' in (openclaw_exo_set.stdout | default(''))"
+  notify: Restart openclaw-gateway
+  tags:
+    - openclaw
+    - config
+    - exo
+
 # Read current fallback list so we only `add` when the model isn't
 # already present — `openclaw models fallbacks add` would silently
 # duplicate otherwise. Plain text output is parsed via substring match
 # so this is robust against the `--check` path (where the list command
-# is skipped and stdout is empty).
+# is skipped and stdout is empty). Runs whenever either Ollama or Exo
+# fallback is configured.
 - name: Read current model fallbacks
   become: true
   become_user: "{{ openclaw_user }}"
@@ -374,9 +399,9 @@
   environment:
     PATH: "{{ openclaw_path }}"
     HOME: "/home/{{ openclaw_user }}"
-  when:
-    - openclaw_ollama_base_url | length > 0
-    - openclaw_ollama_fallback_model | length > 0
+  when: >-
+    (openclaw_ollama_base_url | length > 0 and openclaw_ollama_fallback_model | length > 0)
+    or (openclaw_exo_base_url | length > 0 and openclaw_exo_fallback_model | length > 0)
   register: openclaw_fallbacks_list
   changed_when: false
   check_mode: false
@@ -384,6 +409,7 @@
     - openclaw
     - config
     - ollama
+    - exo
 
 - name: Add Ollama fallback model
   become: true
@@ -404,6 +430,26 @@
     - openclaw
     - config
     - ollama
+
+- name: Add Exo fallback model
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: >-
+    openclaw models fallbacks add exo/{{ openclaw_exo_fallback_model }}
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  when:
+    - openclaw_exo_base_url | length > 0
+    - openclaw_exo_fallback_model | length > 0
+    - ("exo/" + openclaw_exo_fallback_model)
+      not in (openclaw_fallbacks_list.stdout | default(''))
+  changed_when: true
+  notify: Restart openclaw-gateway
+  tags:
+    - openclaw
+    - config
+    - exo
 
 # Enable memory-core "dreaming" mode (offline review/consolidation
 # cycle). Bundled plugin, no separate install — just a config flip.

--- a/ansible/roles/openclaw/tasks/main.yml
+++ b/ansible/roles/openclaw/tasks/main.yml
@@ -124,27 +124,11 @@
     - openclaw
     - install
 
-# Clone workspace repository
-- name: Clone workspace repository
-  become: true
-  become_user: "{{ openclaw_user }}"
-  ansible.builtin.git:
-    repo: "{{ openclaw_workspace_repo }}"
-    dest: "{{ openclaw_workspace_path }}"
-    version: main
-    accept_hostkey: true
-  when: openclaw_workspace_repo | length > 0
-  tags:
-    - openclaw
-    - workspace
-
-# Create config directory
-# Openclaw writes openclaw.json plus all accumulated state (agents/,
-# memory/, identity/, canvas/, devices/, flows/, logs/, tasks/, cron/,
-# extensions/, workspace/) inside ~/.openclaw. The wizard creates this
-# dir on first run, but pre-creating it with 0700 mode keeps a fresh
-# host from ever having world-readable state if openclaw is started
-# by some other path before the wizard runs.
+# Create config directory FIRST so the workspace clone below lands
+# inside a 0700-locked parent. Openclaw writes openclaw.json plus all
+# accumulated state (agents/, memory/, identity/, canvas/, devices/,
+# flows/, logs/, tasks/, cron/, extensions/, workspace/) here. Doctor
+# would otherwise warn about 0755 perms on a fresh host.
 - name: Create openclaw config directory
   become: true
   become_user: "{{ openclaw_user }}"
@@ -156,11 +140,220 @@
     - openclaw
     - config
 
-# The systemd unit is created by the openclaw tool itself during
-# `openclaw setup` (or `openclaw onboard`) on first run. Ansible does
-# not manage /etc/systemd/system/openclaw*.service or the user-level
-# ~/.config/systemd/user/openclaw-gateway.service — the tool owns them,
-# including the embedded gateway token env var.
+# Clone the workspace repo (kai-workspace) into the openclaw state
+# dir. `update: false` makes this an initial-clone-only task — once
+# present, openclaw treats the workspace as runtime state and writes
+# to it continuously (memory updates, heartbeat-state.json, etc.), so
+# a re-run must not try to fast-forward main and clobber local changes.
+- name: Clone workspace repository
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.git:
+    repo: "{{ openclaw_workspace_repo }}"
+    dest: "{{ openclaw_workspace_path }}"
+    version: main
+    accept_hostkey: true
+    update: false
+  when: openclaw_workspace_repo | length > 0
+  tags:
+    - openclaw
+    - workspace
+
+# The user-level systemd unit at ~/.config/systemd/user/openclaw-gateway.service
+# is created by `openclaw setup` below. The unit file itself (including
+# its embedded gateway token env var) is NOT Ansible-managed — the tool
+# owns it. The role just runs setup, applies runtime config via the
+# `openclaw` CLI, and enables+starts the unit.
+
+# Enable user-systemd linger so the gateway keeps running when nobody is
+# logged in. Without this the user-level systemd manager exits on logout
+# and the openclaw service stops with it.
+- name: Enable systemd linger for openclaw user
+  become: true
+  ansible.builtin.command: loginctl enable-linger {{ openclaw_user }}
+  args:
+    creates: "/var/lib/systemd/linger/{{ openclaw_user }}"
+  tags:
+    - openclaw
+    - systemd
+
+# `openclaw setup` writes the base ~/.openclaw/openclaw.json plus the
+# user-systemd unit. Idempotent via `creates:` — re-runs of the role
+# won't reset accumulated config (channels, plugins, etc.) on hosts
+# that have been customized further by hand or by later tasks below.
+- name: Initialize openclaw config (`openclaw setup`)
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: openclaw setup
+  args:
+    creates: "{{ openclaw_config_dir }}/openclaw.json"
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  tags:
+    - openclaw
+    - config
+
+# Bind the openclaw `anthropic:claude-cli` auth profile to the local
+# `claude` binary so the agent can do Claude-backed inference. Without
+# this, openclaw has no model provider wired up and every turn fails.
+# The CLI is idempotent — re-running it just re-asserts the same
+# profile — so we don't need an explicit pre-check.
+- name: Bind anthropic:claude-cli auth profile
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: >-
+    openclaw models auth login --provider anthropic --method cli --set-default
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  register: openclaw_auth_login
+  changed_when: false
+  notify: Restart openclaw-gateway
+  tags:
+    - openclaw
+    - config
+    - auth
+
+# Install the external channel/tool plugins. As of openclaw 2026.5.7
+# Discord and Brave moved out of the bundled set and have to be pulled
+# from ClawHub. `creates:` on the extension dir keeps this idempotent.
+- name: Install required openclaw plugins
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: "openclaw plugins install clawhub:{{ item }}"
+  args:
+    creates: "{{ openclaw_config_dir }}/extensions/{{ item | regex_replace('^@openclaw/', '') | regex_replace('-plugin$', '') }}"
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  loop: "{{ openclaw_plugins }}"
+  notify: Restart openclaw-gateway
+  tags:
+    - openclaw
+    - plugins
+
+# Point openclaw at the kai-workspace clone so the boot-md hook can
+# inject IDENTITY.md / MEMORY.md / AGENTS.md at session start. Without
+# this the agent wakes up against the empty default workspace
+# (~/.openclaw/workspace would still get auto-created but with no
+# persona). `openclaw config set` is idempotent for matching values.
+- name: Set agents.defaults.workspace
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: "openclaw config set agents.defaults.workspace {{ openclaw_workspace_path }}"
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  register: openclaw_set_workspace
+  changed_when: "'Updated' in (openclaw_set_workspace.stdout | default(''))"
+  notify: Restart openclaw-gateway
+  tags:
+    - openclaw
+    - config
+
+# Allow the Tailscale-served origin to load the Control UI. Required
+# because openclaw refuses cross-origin WebSocket connects by default,
+# and Tailscale Serve fronts the gateway at https://<host>.<tailnet>.ts.net.
+- name: Set gateway.controlUi.allowedOrigins
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: >-
+    openclaw config set gateway.controlUi.allowedOrigins
+    {{ [openclaw_tailscale_origin] | to_json | quote }} --strict-json
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  register: openclaw_set_origins
+  changed_when: "'Updated' in (openclaw_set_origins.stdout | default(''))"
+  notify: Restart openclaw-gateway
+  tags:
+    - openclaw
+    - config
+
+# Discord channel: add the bot account with token from 1P. The CLI
+# overwrites an existing account with the same name (default), so
+# re-running matches state to vault. Skipped if the playbook didn't
+# wire a token through.
+- name: Add Discord channel account
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: >-
+    openclaw channels add --channel discord --token {{ openclaw_discord_bot_token | quote }}
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  when: openclaw_discord_bot_token | length > 0
+  register: openclaw_discord_add
+  changed_when: "'Added Discord account' in (openclaw_discord_add.stdout | default(''))"
+  notify: Restart openclaw-gateway
+  no_log: true
+  tags:
+    - openclaw
+    - config
+    - discord
+
+# Discord guild config: requireMention=false so the bot replies to plain
+# channel messages (the 2026.5.7 plugin requires an explicit guild ID;
+# `"*"` wildcard keys are accepted by the schema but no-op at runtime).
+- name: Set Discord guild requireMention
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: >-
+    openclaw config set channels.discord.guilds
+    {{ {openclaw_discord_guild_id: {'requireMention': false}} | to_json | quote }}
+    --strict-json
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  when: openclaw_discord_guild_id | length > 0
+  register: openclaw_discord_guild_set
+  changed_when: "'Updated' in (openclaw_discord_guild_set.stdout | default(''))"
+  notify: Restart openclaw-gateway
+  tags:
+    - openclaw
+    - config
+    - discord
+
+# Brave web search API key for the brave plugin's webSearch capability.
+# Stored plaintext in openclaw.json today — fine because the file is
+# 0700 and only readable by the openclaw user. Could be migrated to a
+# SecretRef later.
+- name: Set Brave plugin apiKey
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: >-
+    openclaw config set plugins.entries.brave.config.webSearch.apiKey
+    {{ openclaw_brave_api_key | quote }}
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  when: openclaw_brave_api_key | length > 0
+  register: openclaw_brave_set
+  changed_when: "'Updated' in (openclaw_brave_set.stdout | default(''))"
+  notify: Restart openclaw-gateway
+  no_log: true
+  tags:
+    - openclaw
+    - config
+    - brave
+
+# Ensure the user-level openclaw-gateway service is enabled and running.
+# Unit file is written by `openclaw setup` above. Config changes notify
+# the `Restart openclaw-gateway` handler so a re-run only restarts when
+# something actually changed.
+- name: Enable and start openclaw-gateway.service (user)
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.systemd_service:
+    name: openclaw-gateway.service
+    scope: user
+    enabled: true
+    state: started
+    daemon_reload: true
+  tags:
+    - openclaw
+    - systemd
 
 # Configure Tailscale Serve for HTTPS + auth
 - name: Configure Tailscale Serve

--- a/ansible/roles/openclaw/tasks/main.yml
+++ b/ansible/roles/openclaw/tasks/main.yml
@@ -338,6 +338,25 @@
     - config
     - brave
 
+# Enable memory-core "dreaming" mode (offline review/consolidation
+# cycle). Bundled plugin, no separate install — just a config flip.
+- name: Set memory-core dreaming.enabled
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: >-
+    openclaw config set plugins.entries.memory-core.config.dreaming.enabled
+    {{ openclaw_dreaming_enabled | string | lower }}
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  register: openclaw_dreaming_set
+  changed_when: "'Updated' in (openclaw_dreaming_set.stdout | default(''))"
+  notify: Restart openclaw-gateway
+  tags:
+    - openclaw
+    - config
+    - dreaming
+
 # Ensure the user-level openclaw-gateway service is enabled and running.
 # Unit file is written by `openclaw setup` above. Config changes notify
 # the `Restart openclaw-gateway` handler so a re-run only restarts when


### PR DESCRIPTION
## Summary

Closes two gaps in the openclaw role in one branch:

1. **Path rename** — role pointed at the old `clawdbot`-era paths (`~/clawd` workspace, `~/.clawdbot` config dir) even though openclaw 2026.4+ natively uses `~/.openclaw/*`. On a fresh provision the agent woke up with an empty template workspace because `agents.defaults.workspace` defaults to `~/.openclaw/workspace`, which the role never populated.
   - `openclaw_workspace_path` → `~/.openclaw/workspace`
   - `openclaw_config_dir` → `~/.openclaw`

2. **First-run wizard automation** — until now the role stopped at "binaries installed, config dir created" and left the entire openclaw runtime config (auth profile, plugins, channels, workspace pointer, Control UI origin allowlist, service enable) as a manual checklist for the operator after each fresh provision. New tasks (all idempotent — `--check` against the already-configured host shows 0 changed):
   - Enable user-systemd linger
   - `openclaw setup` (creates the base config + user-systemd unit)
   - Bind `anthropic:claude-cli` auth profile
   - Install `clawhub:@openclaw/discord` + `clawhub:@openclaw/brave-plugin`
   - Add Discord channel with bot token from 1P
   - Set Discord guild `requireMention=false` (guild ID from 1P)
   - Set Brave webSearch `apiKey` from 1P
   - Set `agents.defaults.workspace` and `gateway.controlUi.allowedOrigins`
   - Enable + start `openclaw-gateway.service` (user scope)
   - Restart handler triggered by any config change

Runtime secrets come from the `openclaw` 1P vault (separate from the `Infrastructure` default this repo uses). Field mapping documented in the playbook header:
- `discord clawdbot`: `credential`=bot token, `username`=Discord guild ID
- `Brave API`: `credential`=API key

Other tweaks:
- Reorder: config dir created **before** workspace clone, so `~/.openclaw` is 0700 from the start.
- Workspace git task: `update: false` so re-runs don't clobber the bot's continuous writes to its own workspace (memory, heartbeat-state.json).
- New `openclaw_path` default for the fnm-managed PATH used by every `openclaw`-invoking task.
- Switch systemd enable+start to the `systemd_service` module with `scope: user`, with a handler for restart-on-config-change.
- Name the previously-anonymous `tailscale_check` pre-task.
- Update playbook header — drop the manual checklist, document the one remaining manual step (one-time Control UI device pairing approval).

## On the live host

The openclaw droplet was migrated out-of-band on 2026-05-13 (paths moved from `~/.clawdbot/`+`~/clawd/` into `~/.openclaw/*`, brave + discord plugins installed, Discord guild fix applied). The bot is currently online. `ansible-playbook openclaw.yml --check --diff --limit openclaw` against the live host reports 16 OK / 0 changed / 0 failed.

## Test plan
- [x] `ansible-lint roles/openclaw/ openclaw.yml` — clean for everything I touched (only pre-existing fnm role issues remain).
- [x] `ansible-playbook openclaw.yml --check --diff --limit openclaw` — idempotent against the migrated host.
- [ ] Provision a fresh droplet end-to-end and confirm the only post-playbook step needed is approving the Control UI device pairing.
- [x] Verify no remaining `clawd`/`clawdbot` path references in `roles/openclaw/` (the legacy-systemd-unit cleanup tasks intentionally still reference `clawdbot.service` — they remove it from old hosts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)