### PR TITLE
feat(terraform): manage Tailscale ACL via tailscale provider

### DIFF
--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "1Password/onepassword"
       version = "3.3.1"
     }
+    tailscale = {
+      source  = "tailscale/tailscale"
+      version = "0.21.0"
+    }
   }
 
   # Remote state in DigitalOcean Spaces (S3-compatible)

--- a/terraform/tailscale-acl.hujson
+++ b/terraform/tailscale-acl.hujson
@@ -1,0 +1,56 @@
+// Example/default ACLs for unrestricted connections.
+{
+    // Declare static groups of users. Use autogroups for all users or users with a specific role.
+    // "groups": {
+    //      "group:example": ["alice@example.com", "bob@example.com"],
+    // },
+
+    // Define the tags which can be applied to devices and by which users.
+    // "tagOwners": {
+    //      "tag:example": ["autogroup:admin"],
+    // },
+    "tagOwners": {
+        "tag:agent": ["ernstjason1@gmail.com"],
+    },
+
+    // Define grants that govern access for users, groups, autogroups, tags,
+    // Tailscale IP addresses, and subnet ranges.
+    "grants": [
+        // Your member devices - full access everywhere including tagged machines
+        {"src": ["autogroup:member"], "dst": ["*"], "ip": ["*"]},
+
+        // Agent (clawdbot) - only Ollama + exo access on ubuntu-beast
+        {
+            "src": ["tag:agent"],
+            "dst": ["100.79.121.111"],
+            "ip":  ["11434", "52415"],
+        },
+    ],
+
+    // Define users and devices that can use Tailscale SSH.
+    "ssh": [
+        // Allow all users to SSH into their own devices in check mode.
+        {
+            "action": "check",
+            "src":    ["autogroup:member"],
+            "dst":    ["autogroup:self"],
+            "users":  ["autogroup:nonroot", "root"],
+        },
+        // Allow SSH to tagged machines from members
+        {
+            "action": "check",
+            "src":    ["autogroup:member"],
+            "dst":    ["tag:agent"],
+            "users":  ["autogroup:nonroot", "root"],
+        },
+    ],
+    "nodeAttrs": [
+        {
+            // Funnel policy, which lets tailnet members control Funnel
+            // for their own devices.
+            // Learn more at https://tailscale.com/kb/1223/tailscale-funnel/
+            "target": ["autogroup:member"],
+            "attr":   ["funnel"],
+        },
+    ],
+}

--- a/terraform/tailscale-acl.hujson
+++ b/terraform/tailscale-acl.hujson
@@ -19,11 +19,13 @@
         // Your member devices - full access everywhere including tagged machines
         {"src": ["autogroup:member"], "dst": ["*"], "ip": ["*"]},
 
-        // Agent (clawdbot) - only Ollama + exo access on ubuntu-beast
+        // Agent (openclaw) - only Ollama + exo access on ubuntu-beast.
+        // Both services are HTTP-over-TCP; explicit `tcp:` prefix
+        // avoids any protocol-default ambiguity in the grants syntax.
         {
             "src": ["tag:agent"],
             "dst": ["100.79.121.111"],
-            "ip":  ["11434", "52415"],
+            "ip":  ["tcp:11434", "tcp:52415"],
         },
     ],
 

--- a/terraform/tailscale.tf
+++ b/terraform/tailscale.tf
@@ -1,0 +1,43 @@
+# Tailscale ACL — manages the tailnet policy file as code.
+#
+# Bootstrap (one-time, before first `terraform apply`):
+#
+#   1. Create an OAuth client at
+#      https://login.tailscale.com/admin/settings/oauth.
+#      Required scope: `acl` (read+write). Other scopes can stay off.
+#
+#   2. Store the credentials in 1Password:
+#        Vault:  Infrastructure
+#        Title:  "Tailscale Terraform OAuth"
+#        Fields:
+#          - username:   <OAuth client ID>
+#          - credential: <OAuth client secret>
+#
+#   3. The first `terraform apply` will import the live ACL into
+#      `tailscale_acl.policy`. `overwrite_existing_content = true`
+#      tells the provider to take over the manually-edited policy
+#      already in the admin console (otherwise the API rejects writes
+#      when there's existing content not written by the same client).
+#
+# Day-to-day: edit tailscale-acl.hujson, then `terraform apply`.
+# The provider validates the HuJSON server-side before applying, so a
+# broken policy fails at plan/apply time instead of locking us out.
+
+data "onepassword_item" "tailscale_terraform_oauth" {
+  vault = "Infrastructure"
+  title = "Tailscale Terraform OAuth"
+}
+
+provider "tailscale" {
+  oauth_client_id     = data.onepassword_item.tailscale_terraform_oauth.username
+  oauth_client_secret = data.onepassword_item.tailscale_terraform_oauth.credential
+  # "-" means "the tailnet associated with the OAuth client" — works
+  # for personal accounts without hardcoding the email/org name.
+  tailnet = "-"
+  scopes  = ["acl"]
+}
+
+resource "tailscale_acl" "policy" {
+  acl                        = file("${path.module}/tailscale-acl.hujson")
+  overwrite_existing_content = true
+}

--- a/terraform/tailscale.tf
+++ b/terraform/tailscale.tf
@@ -15,11 +15,15 @@
 #          - username:   <OAuth client ID>
 #          - credential: <OAuth client secret>
 #
-#   3. The first `terraform apply` will import the live ACL into
-#      `tailscale_acl.policy`. `overwrite_existing_content = true`
-#      tells the provider to take over the manually-edited policy
-#      already in the admin console (otherwise the API rejects writes
-#      when there's existing content not written by the same client).
+#   3. The first `terraform apply` will *write* the checked-in
+#      tailscale-acl.hujson over whatever policy currently lives in
+#      the admin console (no import — this is a create with
+#      `overwrite_existing_content = true`, which the API requires
+#      when there's already content not written by the same client).
+#      Make sure the HuJSON in the repo matches the live policy
+#      *before* applying, or use `tofu state import` if you need a
+#      true import. Any console-side drift after this point will be
+#      reverted on the next apply.
 #
 # Day-to-day: edit tailscale-acl.hujson, then `terraform apply`.
 # The provider validates the HuJSON server-side before applying, so a

--- a/terraform/tailscale.tf
+++ b/terraform/tailscale.tf
@@ -4,7 +4,9 @@
 #
 #   1. Create an OAuth client at
 #      https://login.tailscale.com/admin/settings/oauth.
-#      Required scope: `acl` (read+write). Other scopes can stay off.
+#      Required scope: "Policy File" → Write. Other scopes can stay
+#      off. (Tailscale's UI used to call this scope `acl`; it's now
+#      `policy_file:write` in the OAuth spec.)
 #
 #   2. Store the credentials in 1Password:
 #        Vault:  Infrastructure
@@ -34,7 +36,11 @@ provider "tailscale" {
   # "-" means "the tailnet associated with the OAuth client" — works
   # for personal accounts without hardcoding the email/org name.
   tailnet = "-"
-  scopes  = ["acl"]
+  # `scopes` intentionally omitted so the provider just requests the
+  # scopes the OAuth client was generated with. Pinning to a specific
+  # string (`acl` vs `policy_file:write`) couples this config to the
+  # Tailscale OAuth scope-naming churn — the client itself already
+  # constrains what's grantable.
 }
 
 resource "tailscale_acl" "policy" {


### PR DESCRIPTION
## Summary

Pulls the tailnet policy out of the admin console and into iac. The ACL is the one knob that controls openclaw's ability to reach the local Ollama (port 11434) and Exo (port 52415) endpoints on ubuntu-beast — having it manually editable in the cloud console means it can drift without anyone noticing, and review/rollback go through the UI rather than git.

The current PR also bakes in the port 52415 (exo) addition to the `tag:agent` grant, which the companion ansible PR #422 needs to actually reach the second model fallback over Tailscale.

## Files

- **`terraform/provider.tf`** — adds `tailscale/tailscale` `0.21.0` to `required_providers`.
- **`terraform/tailscale.tf`** — provider block reading OAuth creds from a new 1P item (`Tailscale Terraform OAuth` in `Infrastructure`). `tailnet = "-"` resolves to the OAuth client's own tailnet (no hardcoded org). `tailscale_acl.policy` reads `tailscale-acl.hujson` via `file()`. `overwrite_existing_content = true` lets the first apply take over the manually-edited policy already in the admin console.
- **`terraform/tailscale-acl.hujson`** — current tailnet policy verbatim, plus port 52415 added to the `tag:agent` grant alongside ollama.

## Bootstrap (one-time, before first `./tf apply`)

1. https://login.tailscale.com/admin/settings/oauth → **Generate OAuth client**. Scope: `acl` (read+write). Copy the client ID and secret.
2. Create a new 1P item in the **Infrastructure** vault:
   - Title: `Tailscale Terraform OAuth`
   - Type: API Credential
   - Fields: `username` = OAuth client ID, `credential` = OAuth client secret
3. `./tf init -upgrade` (pulls the new tailscale provider).
4. `./tf plan` — should show a `tailscale_acl.policy` *create*. Verify the planned ACL matches the current admin-console content (modulo whitespace/comments — the HuJSON in the repo is the source of truth from here on).
5. `./tf apply`.
6. (Optional) Confirm at https://login.tailscale.com/admin/acls/file that the policy now matches the repo.

## After this merges

- Companion PR #422 (openclaw ansible automation) needs the Exo grant on port 52415 for the `Add Exo fallback model` task to actually be useful at runtime — that grant ships in this PR's `tailscale-acl.hujson`.
- Day-to-day ACL edits go through `terraform/tailscale-acl.hujson` + `./tf apply`. The provider validates HuJSON server-side before applying, so a broken policy fails at plan/apply time instead of locking us out of the tailnet.

## Test plan
- [ ] Create the `Tailscale Terraform OAuth` 1P item (step 2 above).
- [ ] `./tf init -upgrade` succeeds (provider downloads).
- [ ] `./tf plan` shows only the create of `tailscale_acl.policy`, no other drift.
- [ ] `./tf apply` succeeds; admin console shows the policy with the openclaw `tag:agent` grant including `52415`.
- [ ] Functional: from openclaw host, `curl http://ubuntu-beast.tail21090.ts.net:52415/v1/models` succeeds.
- [ ] No regression: ollama still reachable at port 11434 from openclaw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)