### PR TITLE
fix(ci): use WORKFLOW_PAT so auto-update PRs trigger downstream CI

### DIFF
--- a/.github/workflows/check-slack-version.yml
+++ b/.github/workflows/check-slack-version.yml
@@ -41,11 +41,21 @@ jobs:
         if: steps.versions.outputs.latest != steps.versions.outputs.current && steps.versions.outputs.latest != ''
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # PRs opened via the default GITHUB_TOKEN don't trigger downstream
+          # workflows (GitHub's recursive-CI safeguard), which is why earlier
+          # auto-update PRs sat with zero checks until close+reopen. Using a
+          # repo-scoped PAT in `secrets.WORKFLOW_PAT` makes the PR look like
+          # a normal user action so verify.yml fires automatically. Fall back
+          # to GITHUB_TOKEN so this workflow keeps working before the secret
+          # is configured (PRs just won't auto-trigger CI until then).
+          # To set up: GitHub → Settings → Developer settings → PATs →
+          # generate a fine-grained PAT with read+write on `Contents` and
+          # `Pull requests`, store as repo secret `WORKFLOW_PAT`.
+          token: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
           title: "chore(deps): update Slack to ${{ steps.versions.outputs.latest }}"
           body: |
             Updates Slack from ${{ steps.versions.outputs.current }} to ${{ steps.versions.outputs.latest }}.
-            
+
             Source: [Slack Linux Downloads](https://slack.com/downloads/linux)
           branch: auto-update-slack-${{ steps.versions.outputs.latest }}
           commit-message: "chore(deps): update Slack to ${{ steps.versions.outputs.latest }}"


### PR DESCRIPTION
## Summary

Auto-update PRs from `check-slack-version.yml` (e.g. #420) sit with zero checks until someone closes+reopens them. That's because GitHub deliberately blocks events triggered by the default `GITHUB_TOKEN` from firing downstream workflows — a [recursion guard](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) against runaway CI.

Fix: pass `secrets.WORKFLOW_PAT` to `peter-evans/create-pull-request` when present, falling back to `GITHUB_TOKEN`. A PR opened with a PAT looks like a normal user action and triggers `verify.yml` normally.

## Setup (after this merges)

1. GitHub → **Settings → Developer settings → Personal access tokens → Fine-grained tokens** → **Generate new token**.
2. Resource access: only this repo (`compscidr/iac`).
3. Repository permissions: **Contents: Read and write**, **Pull requests: Read and write**.
4. Expiration: whatever fits your rotation cadence (90 days is reasonable).
5. Copy the token, then: repo → **Settings → Secrets and variables → Actions → New repository secret** → name it `WORKFLOW_PAT`, paste the value.

Until the secret is set the workflow still works (falls back to `GITHUB_TOKEN`), so this PR is safe to merge before the bootstrap step.

## Why PAT and not a GitHub App

A GitHub App is the more elegant long-term answer (short-lived tokens, finer-grained permissions, no per-user binding). But it requires creating + installing the app, storing app ID + private key as secrets, and wrapping the token issuance with an action like `actions/create-github-app-token`. For a single auto-update workflow in a private repo, the PAT is a reasonable trade. If we add more bots later it's worth revisiting.

## Test plan
- [x] Workflow YAML still parses (no syntax errors).
- [ ] After merge + secret setup: next Monday's scheduled run opens a PR with CI checks attached.
- [ ] OR: trigger manually via `gh workflow run check-slack-version.yml` (after merging + bumping the in-repo Slack version backward so the diff runs) and confirm checks attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)