### PR TITLE
feat(ansible): install gcloud via apt in dev role

### DIFF
--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -294,6 +294,27 @@
     dest: /etc/environment.d/90-aws.conf
     mode: "644"
 
+- name: Add google cloud sdk repository
+  become: true
+  tags: gcloud
+  ansible.builtin.deb822_repository:
+    name: google-cloud-sdk
+    state: present
+    types: [deb]
+    uris: "https://packages.cloud.google.com/apt"
+    suites: cloud-sdk
+    components: [main]
+    signed_by: "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+    enabled: true
+
+- name: Install google cloud sdk
+  become: true
+  tags: gcloud
+  ansible.builtin.apt:
+    update_cache: true
+    pkg:
+      - google-cloud-cli
+
 - name: Add hashicorp repository
   become: true
   tags: hashicorp

--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -294,6 +294,17 @@
     dest: /etc/environment.d/90-aws.conf
     mode: "644"
 
+# deb822_repository requires python3-debian on the managed host. The shared
+# "Install prereqs" task provides it, but it is skipped when running with
+# --tags gcloud, so install it here to keep the gcloud tag self-contained.
+- name: Install python3-debian prereq for gcloud repository
+  become: true
+  tags: gcloud
+  ansible.builtin.apt:
+    update_cache: true
+    pkg:
+      - python3-debian
+
 - name: Add google cloud sdk repository
   become: true
   tags: gcloud


### PR DESCRIPTION
## Summary
- Adds Google's `cloud-sdk` apt repository via `deb822_repository` and installs `google-cloud-cli` in the `dev` role
- Both tasks tagged `gcloud` so they can be run in isolation with `--tags gcloud`
- Mirrors the existing hashicorp apt pattern (lines 318-343)

## Test plan
- [x] `ansible-playbook -i inventory.yml dev.yml --tags gcloud` runs cleanly on `ubuntu-work-laptop`
- [x] `gcloud` available on PATH after install
- [ ] CI lint passes