### PR TITLE
feat(ansible): re-enable rust_game role on nas

### DIFF
--- a/ansible/nas.yml
+++ b/ansible/nas.yml
@@ -8,6 +8,6 @@
   roles:
     - media_server
     - home_assistant
-    # - rust_game
+    - rust_game
     # - cs2_game
     - dyndns

--- a/ansible/roles/rust_game/tasks/main.yml
+++ b/ansible/roles/rust_game/tasks/main.yml
@@ -29,8 +29,8 @@
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     mode: "644"
-    owner: root
-    group: root
+    owner: "1000"
+    group: "1000"
   loop:
     - src: files/oxide.config.json
       dest: /etc/rust/server/weekly/oxide/oxide.config.json
@@ -71,8 +71,8 @@
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     mode: "644"
-    owner: root
-    group: root
+    owner: "1000"
+    group: "1000"
   loop:
     - src: files/oxide.config.json
       dest: /etc/rust/server/monthly/oxide/oxide.config.json


### PR DESCRIPTION
Re-enables the `rust_game` role in `nas.yml` (disabled in ae1518c when the servers broke).

Root cause of the breakage: `rust-weekly`/`rust-monthly` were restart-looping because `ghcr.io/compscidr/rust-server` is built on Ubuntu 20.04 (glibc 2.31) while Facepunch's current `RustDedicated` requires glibc ≥ 2.34. Fixed in compscidr/rust-server#1 by moving to the `nodejs-22-steamcmd-ubuntu-24.04` base.

Deploy order:
1. Merge compscidr/rust-server#1 → CI publishes new `ghcr.io/compscidr/rust-server:latest`
2. Merge this PR
3. `ansible-playbook -i inventory.yml nas.yml --tags rust-weekly,rust-monthly` — `docker_container` has `pull: true`, so it pulls the fixed image and recreates both containers. Saves/config persist in `/etc/rust/server/*` bind mounts.

`cs2_game` left disabled — likely has the same glibc problem, can be tackled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)