### PR TITLE
feat(common_cli): add shellcheck to cli tools

### DIFF
--- a/ansible/roles/common_cli/vars/main.yml
+++ b/ansible/roles/common_cli/vars/main.yml
@@ -42,6 +42,7 @@ common_cli_tools_ubuntu:
   - nvme-cli # get temperature / stats on nmves
   - powerline # prompt and statusline utility
   - screen # terminal multiplexer
+  - shellcheck # static analysis linter for shell scripts
   - stow # use this to manage dotfiles
   - tmux # terminal multiplexer
   - unzip # zip files
@@ -69,6 +70,7 @@ common_cli_tools_macos:
   # nvme-cli - Linux-specific, use smartmontools instead if needed
   - powerline-go # prompt and statusline utility
   - screen # terminal multiplexer
+  - shellcheck # static analysis linter for shell scripts
   - stow # use this to manage dotfiles
   - tmux # terminal multiplexer
   # unzip - built-in on macOS


### PR DESCRIPTION
## What

Adds `shellcheck` to the `common_cli` tools list for both Ubuntu (apt) and macOS (Homebrew).

## Why

Noticed agents attempting to use `shellcheck`, but it isn't installed. It's a static-analysis linter for shell scripts, so it belongs alongside our other general CLI tooling rather than as a standalone task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)