### PR TITLE
chore(deps): update Slack to 4.51.180

### DIFF
--- a/ansible/roles/common_gui/tasks/main.yml
+++ b/ansible/roles/common_gui/tasks/main.yml
@@ -181,7 +181,7 @@
   tags: slack
   become: true
   ansible.builtin.apt:
-    deb: https://downloads.slack-edge.com/desktop-releases/linux/x64/4.50.143/slack-desktop-4.50.143-amd64.deb
+    deb: https://downloads.slack-edge.com/desktop-releases/linux/x64/4.51.180/slack-desktop-4.51.180-amd64.deb
   when: ansible_os_family == "Debian"
 
 - name: Install slack (macOS)


### PR DESCRIPTION
Updates Slack from 4.50.143 to 4.51.180.

Source: [Slack Linux Downloads](https://slack.com/downloads/linux)