### PR TITLE
Fix claude-desktop download 404 (upstream renamed release assets)

### DIFF
--- a/ansible/roles/dev_gui/tasks/main.yml
+++ b/ansible/roles/dev_gui/tasks/main.yml
@@ -143,10 +143,14 @@
       Renovate bump and update the regex_replace below if aaddrick's
       release naming has changed.
 
-- name: Derive claude-desktop .deb filename version (upstream-aaddrick)
+# As of Aug 2026 aaddrick's assets are named `claude-desktop_<claude-version>_<arch>.deb`
+# (previously `claude-desktop_<claude-version>-<aaddrick-version>_<arch>.deb`), and the
+# package's internal Version field is the bare claude version — so both the download
+# filename and the dpkg-query comparison use just the upstream part of the tag.
+- name: Derive claude-desktop .deb filename version (upstream claude version)
   tags: claude-desktop
   ansible.builtin.set_fact:
-    dev_gui_claude_desktop_filename_version: "{{ dev_gui_claude_desktop_tag | regex_replace('^v(.+)\\+claude(.+)$', '\\2-\\1') }}"
+    dev_gui_claude_desktop_filename_version: "{{ dev_gui_claude_desktop_tag | regex_replace('^v(.+)\\+claude(.+)$', '\\2') }}"
     dev_gui_claude_desktop_deb_arch: "{{ {'x86_64': 'amd64', 'amd64': 'amd64', 'aarch64': 'arm64', 'arm64': 'arm64'}[ansible_architecture] }}"
 
 - name: Query currently installed claude-desktop version


### PR DESCRIPTION
## Summary

Every Molecule run started failing today with a 404 downloading claude-desktop: aaddrick renamed the assets **within existing releases** from `claude-desktop_<claude>-<aaddrick>_<arch>.deb` to `claude-desktop_<claude>_<arch>.deb`. Verified against the release API and by extracting the new .deb's control file — its internal `Version` is now the bare claude version (`1.24012.9`), so both the download filename and the `dpkg-query` idempotence comparison should use just the upstream part of the tag. One-line derivation change (plus comment).

Verified: new URL resolves (HTTP 206 on ranged GET), lint clean, `dev.yml` syntax-check passes.

Merge this before re-running the other open PRs — their Molecule jobs all hit this 404 now.

## Test plan

- [x] New asset URL resolves for the pinned tag
- [x] .deb control `Version` matches the derived comparison value
- [ ] Molecule green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)