### PR TITLE
Rust servers: panel-managed mode (collection 0.1.0)

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -31,7 +31,7 @@ collections:
   - name: compscidr.github_runner
     version: "0.1.3"
   - name: compscidr.rust_gameserver
-    version: "0.0.7"
+    version: "0.1.0"
   - name: compscidr.github_cli
     version: "0.0.16"
   - name: compscidr.onepassword

--- a/ansible/roles/rust_game/tasks/main.yml
+++ b/ansible/roles/rust_game/tasks/main.yml
@@ -10,7 +10,6 @@
     rust_gameserver_identity: "weekly"
     rust_gameserver_name: "California | Weekly | No BP Wipe"
     rust_gameserver_description: "Self hosted in Redwood City CA\\nWipes on Thursdays at 7pm PST\\nWorld Size: {{ rust_gameserver_worldsize }}"
-    rust_gameserver_wipe_bp: 0
     rust_gameserver_worldsize: 3000
     rust_gameserver_port: 27015
     rust_gameserver_query_port: 27016
@@ -19,6 +18,8 @@
     rust_gameserver_rcon_password: "{{ lookup('community.general.onepassword', 'rust-rcon-password', field='password', vault=onepassword_vault,
       account_id=onepassword_account_id) }}"
     rust_gameserver_wipe: "weekly"
+    rust_gameserver_manage_wipe_cron: false
+    rust_gameserver_overwrite_env: false
     rust_gameserver_seed: 14419
     rust_gameserver_rcon_web_port: 8000
 
@@ -51,7 +52,6 @@
     rust_gameserver_identity: "monthly"
     rust_gameserver_name: "California | Monthly | No BP Wipe"
     rust_gameserver_description: "Self hosted in Redwood City CA\\nWipes on 1st Wednesday of the Month at 7pm PST\\nWorld Size: {{ rust_gameserver_worldsize }}"
-    rust_gameserver_wipe_bp: 0
     rust_gameserver_worldsize: 4500
     rust_gameserver_port: 28015
     rust_gameserver_query_port: 28016
@@ -60,6 +60,8 @@
     rust_gameserver_rcon_password: "{{ lookup('community.general.onepassword', 'rust-rcon-password', field='password', vault=onepassword_vault,
       account_id=onepassword_account_id) }}"
     rust_gameserver_wipe: "monthly"
+    rust_gameserver_manage_wipe_cron: false
+    rust_gameserver_overwrite_env: false
     rust_gameserver_seed: 756632467
     rust_gameserver_rcon_web_port: 8001
     rust_gameserver_wipe_day_of_week: 3


### PR DESCRIPTION
Depends on compscidr/ansible-rust-gameserver 0.1.0 — ✅ released 2026-08-04 and live on Galaxy.

Sets `rust_gameserver_manage_wipe_cron: false` and `rust_gameserver_overwrite_env: false` for both servers: rustd.xyz owns wipes and runtime env; deploys stop re-stamping `seed.env`/`rust.env` and the on-host wipe crons are removed on the next run. Drops `rust_gameserver_wipe_bp` (only wipe.sh consumed it); keeps `rust_gameserver_wipe` (feeds the server-browser tags).

Pre-deploy checklist:
- [x] collection 0.1.0 released and on Galaxy
- [ ] monthly server added to the rustd.xyz panel (wipe cadence + SSH credential + data path `/etc/rust/server/monthly`) — its wipes stop with the cron otherwise

Post-deploy verification: `seed.env` on nas unchanged (live seeds 18751 weekly / 756632467 monthly), `/etc/cron.d/rust_wipe_*` gone, containers healthy, both servers reconnected in the panel with unchanged map identities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)