### PR TITLE
Pin rust_gameserver 0.1.1; oxide.config.json bootstrap-only

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -31,7 +31,7 @@ collections:
   - name: compscidr.github_runner
     version: "0.1.3"
   - name: compscidr.rust_gameserver
-    version: "0.1.0"
+    version: "0.1.1"
   - name: compscidr.github_cli
     version: "0.0.16"
   - name: compscidr.onepassword

--- a/ansible/roles/rust_game/tasks/main.yml
+++ b/ansible/roles/rust_game/tasks/main.yml
@@ -34,9 +34,13 @@
     mode: "644"
     owner: "1000"
     group: "1000"
+    # oxide.config.json is bootstrap-only: Oxide rewrites it at runtime (adds fields on
+    # upgrades), so re-copying would revert its own changes. The plugin stays force-copied.
+    force: "{{ item.force | default(true) }}"
   loop:
     - src: files/oxide.config.json
       dest: /etc/rust/server/weekly/oxide/oxide.config.json
+      force: false
     - src: files/RustadminOnline.cs
       dest: /etc/rust/server/weekly/oxide/plugins/RustadminOnline.cs
 # only if we want a modded server
@@ -79,9 +83,13 @@
     mode: "644"
     owner: "1000"
     group: "1000"
+    # oxide.config.json is bootstrap-only: Oxide rewrites it at runtime (adds fields on
+    # upgrades), so re-copying would revert its own changes. The plugin stays force-copied.
+    force: "{{ item.force | default(true) }}"
   loop:
     - src: files/oxide.config.json
       dest: /etc/rust/server/monthly/oxide/oxide.config.json
+      force: false
     - src: files/RustadminOnline.cs
       dest: /etc/rust/server/monthly/oxide/plugins/RustadminOnline.cs
 # only if we want a modded server


### PR DESCRIPTION
Completes #474 — this commit was pushed to `jason/rust-panel-managed` after that PR had already been merged, so it never reached main (the deploy already ran with it from a local checkout, so nas matches this state).

- Pins `compscidr.rust_gameserver` 0.1.1 (configurable runtime uid/gid; identity dirs owned by the runtime user; rust.env permissions enforced on existing installs)
- `oxide.config.json` copy becomes create-only — Oxide rewrites its own config at runtime, so re-copying reverted its changes (`RustadminOnline.cs` stays force-copied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)