### PR TITLE
chore(ansible): ignore stray galaxy roles under ansible/roles

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -4,3 +4,8 @@ test_venv/
 .molecule-collections/
 .galaxy-roles/
 .galaxy-collections/
+
+# Galaxy roles are namespaced (namespace.role) and belong in .galaxy-roles/ per
+# ansible.cfg roles_path. Local roles use underscores, so a dotted directory here
+# is always a stray install — never commit it.
+roles/*.*/


### PR DESCRIPTION
Twice now, galaxy roles installed into `ansible/roles/` (instead of the configured `.galaxy-roles/`) have been swept into a commit by a broad `git add` — most recently 89 files in #475, and previously in #471.

The existing setup is correct: `ansible.cfg` puts `./.galaxy-roles` first in `roles_path`, CI installs there, and `ansible/.gitignore` already excludes it. The only gap is that nothing guards `ansible/roles/` itself against a stray install.

Galaxy roles are always namespaced (`geerlingguy.php`); all 25 local roles use underscores (`rust_game`, `media_server`). Ignoring dotted directories under `ansible/roles/` therefore blocks the mistake with no effect on our own roles.

Verified both directions: a test `testns.testrole/` directory is ignored and invisible to `git status`; `ansible/roles/rust_game` remains fully tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)