### PR TITLE
fix(mail): repair DKIM + missing service account after wipe; webroot redirect

### DIFF
--- a/ansible/roles/mailu/defaults/main.yml
+++ b/ansible/roles/mailu/defaults/main.yml
@@ -34,6 +34,11 @@ mailu_additional_domains:
       - user: jason
         password: "{{ lookup('community.general.onepassword', 'mail.sair.run - jason', field='password', vault='Infrastructure',
           account_id=onepassword_account_id) }}"
+      # Service account the sair.run app authenticates as to send magic-link
+      # emails. Credentials must stay in sync with the app's SMTP config.
+      - user: noreply
+        password: "{{ lookup('community.general.onepassword', 'SMTP_USER - sair', field='password', vault='Infrastructure',
+          account_id=onepassword_account_id) }}"
 
 # Features
 mailu_webmail: roundcube # roundcube, snappymail, or none

--- a/ansible/roles/mailu/templates/mailu.env.j2
+++ b/ansible/roles/mailu/templates/mailu.env.j2
@@ -32,7 +32,11 @@ MESSAGE_RATELIMIT_EXEMPTION={{ mailu_message_ratelimit_exemption }}
 # Website settings (accessed via nginx-proxy)
 WEB_ADMIN=/admin
 WEB_WEBMAIL=/webmail
+{% if mailu_webmail != 'none' %}
+# Without this the site root 404s. Only set it when a webmail is actually
+# deployed - docker-compose.yml.j2 omits the service when this is 'none'.
 WEBROOT_REDIRECT=/webmail
+{% endif %}
 WEBMAIL={{ mailu_webmail }}
 
 # Compose paths

--- a/ansible/roles/mailu/templates/mailu.env.j2
+++ b/ansible/roles/mailu/templates/mailu.env.j2
@@ -32,6 +32,7 @@ MESSAGE_RATELIMIT_EXEMPTION={{ mailu_message_ratelimit_exemption }}
 # Website settings (accessed via nginx-proxy)
 WEB_ADMIN=/admin
 WEB_WEBMAIL=/webmail
+WEBROOT_REDIRECT=/webmail
 WEBMAIL={{ mailu_webmail }}
 
 # Compose paths

--- a/terraform/mail-sair.tf
+++ b/terraform/mail-sair.tf
@@ -54,7 +54,7 @@ resource "digitalocean_record" "sair-TXT-DKIM" {
   domain = digitalocean_domain.sair-run.name
   type   = "TXT"
   name   = "dkim._domainkey"
-  value  = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA8/bhNGc+JfsAUTPlvK3b7s34jjR+lLdGdGadPhN9G0R95kMCUutTkYoL1zO60U/xRyWjXaXGMkukOyJL2sIfFqag4LjTCNX5K+TAn/kzTV5y6pLDbUCB4hyrcgbZTMbCCPCjUTYSyQFF1SmJwAAwwQ8WGLPLy+L5JEmRIsu5XVzCe5VKUxncxG/xdufllJx2TRuWxecZOmtmGgLilPa+lVsJQVFRpYuNIeIUFDM2kayqkYQYbv+mt3Edm6iR40uRNpO/8AG8Z26E+P/tL5iwXa2T8bXOiOBgVouiJaUFpO3TnQsZtp0RniSLB34M+10mK7EmryBA6rQyGY1K959GJQIDAQAB"
+  value  = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArSX05Mf3rfpUDunGg1tyumhsL3gcGRGMzh/Ttf4Sur8k6nRpKwG0CDHWdh4D/f5qL8oaeAQqdhhcoVYlKZZ5+u68Ng6M4Fkc3h5/8y8hSt04Rc8xJK6APyne/N3znWc9m4eM/gqgBBKcSZ3Pl2+FMx+z7TZpl11CCV8AF9nGcK+ACdBXr9V8Lf8HJU+OlXeQTD1qbtbttbkhVipsiLVTWGiOtmTpZG9R8z6+vV+q2cHWOZSKn+QoAx5YzOEIrU/3zKKNcyjZK7Y6vsE7wB8vIO73gtOKXW2RZT1af6rm56emA6lB4JFe5vKPcWbheIAZslFerQCOLWZApT5KXCTA0wIDAQAB"
 }
 
 # Mail client auto-configuration

--- a/terraform/mail.tf
+++ b/terraform/mail.tf
@@ -56,7 +56,7 @@ resource "digitalocean_record" "TXT-DKIM" {
   domain = digitalocean_domain.default.name
   type   = "TXT"
   name   = "dkim._domainkey"
-  value  = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwoq0cBEGBSux4sWE2AVkhMhfkjq3q1AHidf0OhzMb0tByDvYm8iGIvEvmH8ZjKjyJMhZGPwgkjomQ7/glVUTQ0RqbjCODt8Z+Ch9OcLc3vwFv5Zd18wCuiu7KlaaaP2zWJMheCfNml6Oroqs0kQJ9m/RVB2UQWHJmu0cjtdVbIu6ICEyd/yY42GXR1wMWKPqYIagZU8dYau7NDHwJJCKmtybKWNLkpMZql9KC4XxrjzvKcCZuhhM6sbxw9hpoTAlTj708nYHMg5rS+GHrUA8T4DqJDBjWhXfVfkmRQnK0lwV5A12KAifOjWu4L5+Bl0y2SE7jojnxQ1rHwHWPLwUHwIDAQAB"
+  value  = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqNdZk7Lp6rXXYfx6hzBVajBpwNMBkEgC7lC1ClSJ7VOTUK277LLlFWeJPPfnHyjNLWXWeK2OXU7Q6kcwm4bEu1ByH+xDKfx9d62I8q6j9kXBZ6lPR9WWPRaxAaVr3ebQGqGKAZMrplyuM2939c1+wO/5CCBC4+/iF3F76xNeqWzR8waG92zlA3vSpXZvJ0DNdkT2oRtxMPEKlfR3uv+i7YS9jwDyXnvJHLmSQ/EsUzIEEOs8Bd2zkDelqKvQXdahnJKOrv83so14T9Mx8OuR7BlFFCojgoAvTMq+0/ID+d8EA+ujMPUnbVgcIkHqVN7STKYHm/0b7DwMLRwRtbiRcwIDAQAB"
 }
 
 # SendGrid DNS records for domain authentication and link branding


### PR DESCRIPTION
## Summary
Repairs three pieces of mail infrastructure damaged by the April server wipe. None of this touches www.jasonernst.com.

### 1. DKIM was broken on both domains
The wipe lost `/opt/mailu`; the redeploy regenerated DKIM keys but DNS was never updated to match.

- **jasonernst.com** — no DKIM key existed on the server at all, so outbound mail carried no DKIM signature. Regenerated via the Mailu admin container; `TXT-DKIM` updated to the new public key.
- **sair.run** — server key was regenerated Apr 30 but DNS still advertised the pre-wipe key. `sair-TXT-DKIM` updated to match the server.

**Impact, stated accurately:** mail was *not* being rejected. Both domains publish `v=spf1 mx ...`, and mail leaves the same host the MX points at, so SPF passed and aligned strictly — which satisfies DMARC on its own regardless of DKIM. Checked the DMARC aggregate reports in `admin@jasonernst.com`: no reporter logged a single message from our sending IP (159.89.157.125), and the only `disposition=reject` rows are forgeries from unrelated IPs, i.e. DMARC doing its job. The real cost of the broken DKIM was weaker deliverability with receivers that weight DKIM, and DMARC failure on any forwarded or relayed path where SPF breaks. Worth fixing, but it was not an outage.

### 2. noreply@sair.run service account was gone
The sair.run app authenticates as `noreply@sair.run` to send magic-link emails. That mailbox died with `/opt/mailu` and the role only declared `jason@sair.run`, so nothing recreated it. Submission from the projects droplet was rejected with `account disabled` since at least 2026-05-31 — **this one was a real user-visible outage**, the app's "failed to send".

Recreated using the credentials already in the `SMTP_USER - sair` 1Password item the app reads, so no app-side config change was needed. Now declared in the role so a rebuild recreates it.

### 3. Root URL returned 404
`WEBROOT_REDIRECT=/webmail` added to the env template so `https://mail.<domain>/` lands on webmail instead of 404ing. This 404 is what made mail look like it was gone entirely — it never actually was. Gated on `mailu_webmail != 'none'` per review feedback, matching the condition `docker-compose.yml.j2` uses to omit the webmail service.

## Applied live and verified
- New jasonernst.com DKIM key generated; rspamd restarted to load it
- Both DKIM TXT records applied via **targeted** `terraform apply`; live DNS matches the on-disk keys byte-for-byte
- `noreply@sair.run` recreated; SMTP AUTH verified from off-network, and Jason confirmed the app's magic emails work again
- End-to-end at a real receiver: test message to Gmail shows **SPF pass, DKIM pass, DMARC pass**, inbox in 2 seconds
- Health check: www 200, apex 301→www, both mail roots 301→webmail
- `ansible-lint roles/mailu` passes (production profile)

## Note
`terraform plan` from `main` will want to revert these DKIM records until this merges, since `main` still holds the old values. The `tailscale_acl` drift is unrelated and handled in #480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)