### PR TITLE
fix(terraform): reconcile tailscale ACL with live policy; import into state

### DIFF
--- a/terraform/tailscale-acl.hujson
+++ b/terraform/tailscale-acl.hujson
@@ -1,58 +1,58 @@
 // Example/default ACLs for unrestricted connections.
 {
-    // Declare static groups of users. Use autogroups for all users or users with a specific role.
-    // "groups": {
-    //      "group:example": ["alice@example.com", "bob@example.com"],
-    // },
+	// Declare static groups of users. Use autogroups for all users or users with a specific role.
+	// "groups": {
+	//      "group:example": ["alice@example.com", "bob@example.com"],
+	// },
 
-    // Define the tags which can be applied to devices and by which users.
-    // "tagOwners": {
-    //      "tag:example": ["autogroup:admin"],
-    // },
-    "tagOwners": {
-        "tag:agent": ["ernstjason1@gmail.com"],
-    },
+	// Define the tags which can be applied to devices and by which users.
+	// "tagOwners": {
+	//      "tag:example": ["autogroup:admin"],
+	// },
+	"tagOwners": {
+		"tag:agent": ["ernstjason1@gmail.com"],
+	},
 
-    // Define grants that govern access for users, groups, autogroups, tags,
-    // Tailscale IP addresses, and subnet ranges.
-    "grants": [
-        // Your member devices - full access everywhere including tagged machines
-        {"src": ["autogroup:member"], "dst": ["*"], "ip": ["*"]},
+	// Define grants that govern access for users, groups, autogroups, tags,
+	// Tailscale IP addresses, and subnet ranges.
+	"grants": [
+		// Your member devices - full access everywhere including tagged machines
+		{"src": ["autogroup:member"], "dst": ["*"], "ip": ["*"]},
 
-        // Agent (openclaw) - only Ollama + exo access on ubuntu-beast.
-        // Both services are HTTP-over-TCP; explicit `tcp:` prefix
-        // avoids any protocol-default ambiguity in the grants syntax.
-        {
-            "src": ["tag:agent"],
-            "dst": ["100.79.121.111"],
-            "ip":  ["tcp:11434", "tcp:52415"],
-        },
-    ],
+		// Agent (openclaw) - only Ollama + exo access on ubuntu-beast.
+		// Both services are HTTP-over-TCP; explicit `tcp:` prefix
+		// avoids any protocol-default ambiguity in the grants syntax.
+		{
+			"src": ["tag:agent"],
+			"dst": ["100.79.121.111"],
+			"ip":  ["tcp:11434", "tcp:52415"],
+		},
+	],
 
-    // Define users and devices that can use Tailscale SSH.
-    "ssh": [
-        // Allow all users to SSH into their own devices in check mode.
-        {
-            "action": "check",
-            "src":    ["autogroup:member"],
-            "dst":    ["autogroup:self"],
-            "users":  ["autogroup:nonroot", "root"],
-        },
-        // Allow SSH to tagged machines from members
-        {
-            "action": "check",
-            "src":    ["autogroup:member"],
-            "dst":    ["tag:agent"],
-            "users":  ["autogroup:nonroot", "root"],
-        },
-    ],
-    "nodeAttrs": [
-        {
-            // Funnel policy, which lets tailnet members control Funnel
-            // for their own devices.
-            // Learn more at https://tailscale.com/kb/1223/tailscale-funnel/
-            "target": ["autogroup:member"],
-            "attr":   ["funnel"],
-        },
-    ],
+	// Define users and devices that can use Tailscale SSH.
+	"ssh": [
+		// Allow all users to SSH into their own devices in check mode.
+		{
+			"action": "check",
+			"src":    ["autogroup:member"],
+			"dst":    ["autogroup:self"],
+			"users":  ["autogroup:nonroot", "root"],
+		},
+		// Allow SSH to tagged machines from members
+		{
+			"action": "check",
+			"src":    ["autogroup:member"],
+			"dst":    ["tag:agent"],
+			"users":  ["autogroup:nonroot", "root"],
+		},
+	],
+	"nodeAttrs": [
+		{
+			// Funnel policy, which lets tailnet members control Funnel
+			// for their own devices.
+			// Learn more at https://tailscale.com/kb/1223/tailscale-funnel/
+			"target": ["autogroup:member"],
+			"attr":   ["funnel"],
+		},
+	],
 }


### PR DESCRIPTION
## Summary
Makes the checked-in Tailscale policy reflect reality — but the drift ran the **opposite direction** from what you'd expect, so this is worth a read before merging.

`tailscale_acl.policy` was never applied. The resource was absent from terraform state, so `terraform plan` reported it as **"will be created"** with `overwrite_existing_content = true` — meaning any routine full `apply` would have silently overwritten the live tailnet policy. Meanwhile the live policy was the older hand-edited console version, and the review fixes from #423 (explicit `tcp:` prefixes, `clawdbot`→`openclaw` rename) had never actually reached the tailnet.

## What changed
- **Reformatted to Tailscale's canonical form** (tabs, as the API serves it) so the file is byte-identical to the live policy. This is the bulk of the diff — future diffs now show real changes instead of whitespace noise.
- **Kept #423's improvements** rather than reverting them to match the stale console version: explicit `tcp:11434` / `tcp:52415` and the openclaw comment.
- **Imported the resource into state** (`tofu import tailscale_acl.policy acl`) and applied, so those two edits are now live.

The only behavioural change to the tailnet: the `tag:agent` grant narrows from all-protocols to TCP-only on 11434/52415. Ollama and exo are both HTTP-over-TCP, so no functional impact. Member grants and all SSH rules are untouched.

## Verified
- Targeted plan after import showed `0 to add, 1 to change, 0 to destroy` — an in-place update rather than a create-that-overwrites
- Applied with `-target=tailscale_acl.policy` only
- Re-fetched the policy from the Tailscale API afterwards: **byte-identical to this file**
- Tailnet still healthy; SSH to `www` still works

## Follow-up
The `tailscale.tf` bootstrap comment still describes the pre-import "first apply overwrites the console" workflow. Now that the resource is in state that's stale, but I left it alone to keep this diff reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)