### PR TITLE
fix: restore rustd.xyz + mailu credential-leak fixes to main (orphaned by #481)

### DIFF
--- a/ansible/jasonernst_com.yml
+++ b/ansible/jasonernst_com.yml
@@ -5,7 +5,10 @@
     - vars/deb_arch.yml
     - vars/user.yml
   pre_tasks:
+    # Tagged 'always' so the connectivity check still runs when the play is
+    # invoked with --tags (untagged tasks are otherwise skipped).
     - name: Check Tailscale connectivity
+      tags: always
       ansible.builtin.include_tasks: tailscale_check.yml
   vars:
     # Enable nginx fail2ban jails (logs mounted from Docker)
@@ -16,7 +19,7 @@
   roles:
     # www-redirect must run before jasonernst_com so redirect container
     # handles apex domain before app container stops serving it
-    - www_redirect
-    - jasonernst_com
-    - fail2ban
-    - mailu
+    - { role: www_redirect, tags: [www-redirect] }
+    - { role: jasonernst_com, tags: [jasonernst-com] }
+    - { role: fail2ban, tags: [fail2ban] }
+    - { role: mailu, tags: [mailu] }

--- a/ansible/roles/mailu/defaults/main.yml
+++ b/ansible/roles/mailu/defaults/main.yml
@@ -39,6 +39,22 @@ mailu_additional_domains:
       - user: noreply
         password: "{{ lookup('community.general.onepassword', 'SMTP_USER - sair', field='password', vault='Infrastructure',
           account_id=onepassword_account_id) }}"
+  # Adding a domain here also adds mail.<domain> to the front container's
+  # VIRTUAL_HOST and LETSENCRYPT_HOST, which resolve to a single SAN cert
+  # covering every mail hostname. Do not add a domain until mail.<domain>
+  # resolves to this host: its ACME challenge would fail and take the whole
+  # certificate issuance - including the already-working hostnames - with it.
+  - domain: rustd.xyz
+    users:
+      - user: jason
+        password: "{{ lookup('community.general.onepassword', 'mail.rustd.xyz - jason', field='password', vault='Infrastructure',
+          account_id=onepassword_account_id) }}"
+      # Service account for rustd.xyz passwordless login. The app hardcodes
+      # quarkus.mailer.from=noreply@rustd.xyz and has no password fallback,
+      # so this account is what makes the panel loginable at all.
+      - user: noreply
+        password: "{{ lookup('community.general.onepassword', 'SMTP_USER - rustd', field='password', vault='Infrastructure',
+          account_id=onepassword_account_id) }}"
 
 # Features
 mailu_webmail: roundcube # roundcube, snappymail, or none

--- a/ansible/roles/mailu/tasks/main.yml
+++ b/ansible/roles/mailu/tasks/main.yml
@@ -104,11 +104,17 @@
   failed_when: false # May fail if user exists
   no_log: true # Hide passwords
 
+# These DKIM tasks loop over domain NAMES, not the mailu_additional_domains
+# entries themselves. The entries nest user passwords, and Ansible echoes the
+# loop item for every skipped or registered result - which printed live
+# mailbox credentials in plaintext. Looping over names keeps secrets out of
+# the output without needing no_log, which would also hide the DKIM keys these
+# tasks exist to surface.
 - name: Check if additional domain DKIM key exists
   become: true
   ansible.builtin.stat:
-    path: "{{ mailu_install_path }}/dkim/{{ item.domain }}.dkim.key"
-  loop: "{{ mailu_additional_domains | default([]) }}"
+    path: "{{ mailu_install_path }}/dkim/{{ item }}.dkim.key"
+  loop: "{{ mailu_additional_domains | default([]) | map(attribute='domain') | list }}"
   register: mailu_additional_dkim_stat
 
 - name: Import additional domains with DKIM key generation (first time only)
@@ -117,7 +123,7 @@
     cmd: |
       set -o pipefail
       echo 'domain:
-        - name: {{ item.item.domain }}
+        - name: {{ item.item }}
           dkim_key: -generate-
       ' | docker compose exec -T admin flask mailu config-import --update
   args:
@@ -135,7 +141,7 @@
     cmd: |
       set -o pipefail
       echo 'domain:
-        - name: {{ item.item.domain }}
+        - name: {{ item.item }}
       ' | docker compose exec -T admin flask mailu config-import --update
   args:
     chdir: "{{ mailu_install_path }}"
@@ -160,10 +166,19 @@
   failed_when: false # May fail if user exists
   no_log: true # Hide passwords
 
+# `<domain>.dkim.key` is the PRIVATE key. These tasks used to cat it and print
+# the result labelled "add this to DNS", which both leaked the signing key to
+# stdout/CI logs and was useless as a DNS value. Derive the public half
+# instead - that is what belongs in the TXT record.
 - name: Get DKIM public key
   become: true
-  ansible.builtin.command:
-    cmd: cat "{{ mailu_install_path }}/dkim/{{ mailu_domain }}.dkim.key"
+  ansible.builtin.shell:
+    cmd: >
+      set -o pipefail &&
+      openssl rsa -in "{{ mailu_install_path }}/dkim/{{ mailu_domain }}.dkim.key"
+      -pubout -outform DER 2>/dev/null | base64 -w0
+  args:
+    executable: /bin/bash
   register: mailu_dkim_key
   changed_when: false
   failed_when: false
@@ -174,14 +189,19 @@
       Add this DKIM record to DNS:
       Name: dkim._domainkey.{{ mailu_domain }}
       Type: TXT
-      Value: {{ mailu_dkim_key.stdout | default('DKIM key not yet generated - restart admin container') }}
+      Value: v=DKIM1; k=rsa; p={{ mailu_dkim_key.stdout }}
   when: mailu_dkim_key.stdout is defined and mailu_dkim_key.stdout | length > 0
 
 - name: Get DKIM public keys for additional domains
   become: true
-  ansible.builtin.command:
-    cmd: cat "{{ mailu_install_path }}/dkim/{{ item.domain }}.dkim.key"
-  loop: "{{ mailu_additional_domains | default([]) }}"
+  ansible.builtin.shell:
+    cmd: >
+      set -o pipefail &&
+      openssl rsa -in "{{ mailu_install_path }}/dkim/{{ item }}.dkim.key"
+      -pubout -outform DER 2>/dev/null | base64 -w0
+  args:
+    executable: /bin/bash
+  loop: "{{ mailu_additional_domains | default([]) | map(attribute='domain') | list }}"
   register: mailu_additional_dkim_keys
   changed_when: false
   failed_when: false
@@ -190,8 +210,8 @@
   ansible.builtin.debug:
     msg: |
       Add this DKIM record to DNS:
-      Name: dkim._domainkey.{{ item.item.domain }}
+      Name: dkim._domainkey.{{ item.item }}
       Type: TXT
-      Value: {{ item.stdout | default('DKIM key not yet generated - add domain in admin UI and restart') }}
+      Value: v=DKIM1; k=rsa; p={{ item.stdout }}
   loop: "{{ mailu_additional_dkim_keys.results | default([]) }}"
   when: item.stdout is defined and item.stdout | length > 0

--- a/ansible/roles/mailu/tasks/main.yml
+++ b/ansible/roles/mailu/tasks/main.yml
@@ -189,8 +189,21 @@
       Add this DKIM record to DNS:
       Name: dkim._domainkey.{{ mailu_domain }}
       Type: TXT
-      Value: v=DKIM1; k=rsa; p={{ mailu_dkim_key.stdout }}
-  when: mailu_dkim_key.stdout is defined and mailu_dkim_key.stdout | length > 0
+      Value: v=DKIM1; k=rsa; p={{ mailu_dkim_key.stdout | trim }}
+  when: mailu_dkim_key.stdout | default('') | trim | length > 0
+
+# The lookup above sets failed_when: false, so a missing key or an openssl failure is
+# silent. Without this, "no key yet" and "key printed fine" look identical in the run
+# output — on a role whose entire purpose here is surfacing the record an operator has
+# to paste into DNS. Say so explicitly rather than skipping quietly.
+- name: Report that the DKIM key is not available yet
+  ansible.builtin.debug:
+    msg: >-
+      No DKIM public key could be read for {{ mailu_domain }}
+      ({{ mailu_install_path }}/dkim/{{ mailu_domain }}.dkim.key).
+      Mailu generates it on first start of the admin container, so this is expected on a
+      fresh install — re-run this play once it is up to get the DNS record.
+  when: mailu_dkim_key.stdout | default('') | trim | length == 0
 
 - name: Get DKIM public keys for additional domains
   become: true
@@ -212,6 +225,21 @@
       Add this DKIM record to DNS:
       Name: dkim._domainkey.{{ item.item }}
       Type: TXT
-      Value: v=DKIM1; k=rsa; p={{ item.stdout }}
+      Value: v=DKIM1; k=rsa; p={{ item.stdout | trim }}
   loop: "{{ mailu_additional_dkim_keys.results | default([]) }}"
-  when: item.stdout is defined and item.stdout | length > 0
+  loop_control:
+    label: "{{ item.item }}"
+  when: item.stdout | default('') | trim | length > 0
+
+# Same reasoning as the primary domain: silence must not be mistaken for success.
+# loop_control.label keeps the loop output to the domain name — the item here is a
+# command result, and printing it whole is how this role leaked secrets before.
+- name: Report additional domains whose DKIM key is not available yet
+  ansible.builtin.debug:
+    msg: >-
+      No DKIM public key could be read for {{ item.item }}. Mailu generates it on first
+      start of the admin container — re-run this play once it is up.
+  loop: "{{ mailu_additional_dkim_keys.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: item.stdout | default('') | trim | length == 0

--- a/docs/superpowers/specs/2026-08-05-rustd-xyz-dns-mail-design.md
+++ b/docs/superpowers/specs/2026-08-05-rustd-xyz-dns-mail-design.md
@@ -1,0 +1,108 @@
+# rustd.xyz DNS and mail groundwork
+
+**Status:** approved, ready for implementation
+**Date:** 2026-08-05
+
+## Problem
+
+`rustd.xyz` is registered but parked at GoDaddy, still delegated to `ns29`/`ns30.domaincontrol.com`. It needs to join the rest of the estate: DNS managed in Terraform, web traffic pointed at the `projects` droplet, and mail served by the existing Mailu instance — the same shape as `sair.run`.
+
+The application (`compscidr/rustd.xyz`, a Kotlin/Quarkus panel) uses passwordless magic-link login as its **only** authentication path, with `quarkus.mailer.from=noreply@rustd.xyz` already hardcoded in `application.properties`. Working outbound mail is therefore a prerequisite for the product being usable at all, not a nice-to-have.
+
+## Scope
+
+**In scope:** DNS zone in Terraform, mail records, Mailu domain and mailboxes, DKIM.
+
+**Out of scope:** deploying the application. The repo has no production Dockerfile, no `src/main/docker/`, and no image-publishing workflow — its only CI job runs `./gradlew build`. Hosting the panel requires authoring a container and publish pipeline first, which is separate work with its own spec.
+
+## Architecture
+
+Mail and web live on different hosts, exactly as with `sair.run`:
+
+- **Web** (`rustd.xyz`, `www.rustd.xyz`) → `projects` droplet (sfo3), which runs nginx-proxy + acme-companion.
+- **Mail** (`mail.rustd.xyz`, MX target) → `www` droplet (sfo2), which runs the single Mailu instance serving every domain.
+
+Adding a domain to `mailu_additional_domains` in the mailu role is all that is needed on the Mailu side: `mailu.env.j2` and `docker-compose.yml.j2` both derive `HOSTNAMES`, `VIRTUAL_HOST`, and `LETSENCRYPT_HOST` from that list.
+
+## The ordering constraint
+
+**This is the single most important part of the plan.**
+
+The `mailu-front` container is issued **one SAN certificate covering all of its mail hostnames**, not a certificate per hostname. Verified on the live host: `mail.jasonernst.com.crt` and `mail.sair.run.crt` are byte-identical files whose SAN list is `DNS:mail.jasonernst.com, DNS:mail.sair.run`.
+
+Because `LETSENCRYPT_HOST` is generated from `mailu_additional_domains`, adding `rustd.xyz` to that list and running the mailu role causes acme-companion to request a certificate covering all three names. If `mail.rustd.xyz` does not yet resolve to the `www` droplet, its HTTP-01 challenge fails — and since it is one certificate, **the entire issuance fails**, putting renewal of the working `mail.jasonernst.com` / `mail.sair.run` certificate at risk. The current certificate expires 2026-09-26, so there is slack rather than immediate breakage, but the rule is absolute:
+
+> Do not run the mailu role with `rustd.xyz` present in `mailu_additional_domains` until `mail.rustd.xyz` resolves to the `www` droplet's IPv4 address.
+
+This is also why DKIM is generated out of band (step 1) rather than by a role run: `flask mailu config-import` creates the domain, generates the key, and creates mailboxes **without** touching `docker-compose.yml` or `mailu.env`, so nothing triggers ACME. That in turn lets the Terraform DKIM record carry the real public key from the start, avoiding the placeholder-then-patch cycle that left `jasonernst.com` advertising a stale key for three months.
+
+## Sequence
+
+1. **1Password items.** Create `mail.rustd.xyz - jason` (field `password`) and `SMTP_USER - rustd` (field `username` = `noreply@rustd.xyz`, field `password`), both in the `Infrastructure` vault, mirroring the naming of the existing `mail.sair.run - jason` and `SMTP_USER - sair` items.
+2. **Mailu domain and mailboxes, out of band.** On `www`, in `/opt/mailu`: `flask mailu config-import --update` with `dkim_key: -generate-` to create the domain and key, then `flask mailu user jason rustd.xyz <pw>` and `flask mailu user noreply rustd.xyz <pw>`. Restart `antispam` so rspamd loads the new key. No compose changes.
+3. **Read the DKIM public key** from `/opt/mailu/dkim/rustd.xyz.dkim.key`.
+4. **Terraform.** Add the records below, with the real DKIM value from step 3.
+5. **Apply**, using `-target` on the new resources. The zone is created at DigitalOcean but inert while GoDaddy holds the delegation.
+6. **Nameserver switch (manual, Jason).** Repoint `rustd.xyz` at `ns1`/`ns2`/`ns3.digitalocean.com` in the GoDaddy console. Terraform cannot do this; the DigitalOcean provider manages the zone, not the registration.
+7. **Codify in Ansible** — add `rustd.xyz` to `mailu_additional_domains` with both users.
+8. **After `mail.rustd.xyz` resolves**, run the mailu role so the certificate picks up the third name.
+
+Steps 1–5 are safe in any order relative to each other. Step 8 must follow step 6.
+
+Step 7 needs care, and "commit" is not the same as "safe". Writing `rustd.xyz` into `mailu_additional_domains` is harmless as a file change, but the moment that change is on `main` **any routine `ansible-playbook jasonernst_com.yml` run picks it up** and triggers the failed certificate issuance described above — the role does not need to be run deliberately for this to happen. So either hold the Ansible change unmerged until step 6 is done, or accept that whoever merges it owns the constraint. The safest ordering is 1–6, then 7, then 8.
+
+## DNS records
+
+In `terraform/projects.tf`, following the existing per-domain block style:
+
+| Resource | Type | Name | Value |
+|---|---|---|---|
+| `rustd-xyz` | domain | `rustd.xyz` | — |
+| `rustd-A` | A | `@` | `projects` droplet IPv4 |
+| `rustd-AAAA` | AAAA | `@` | `projects` droplet IPv6 |
+| `rustd-CNAME-www` | CNAME | `www` | `@` |
+
+In a new `terraform/mail-rustd.tf`, mirroring `mail-sair.tf`:
+
+| Type | Name | Value |
+|---|---|---|
+| A / AAAA | `mail` | **`www` droplet** IPv4 / IPv6 |
+| MX | `@` | `mail.rustd.xyz.` priority 10 |
+| TXT | `@` | `v=spf1 mx -all` |
+| TXT | `_dmarc` | `v=DMARC1; p=reject; rua=mailto:jason@rustd.xyz; ruf=mailto:jason@rustd.xyz; adkim=s; aspf=s` |
+| TXT | `rustd.xyz._report._dmarc` | `v=DMARC1;` |
+| TXT | `dkim._domainkey` | real key from step 3 |
+| CNAME | `autoconfig`, `autodiscover` | `mail.rustd.xyz.` |
+| SRV | `_autodiscover._tcp` (443), `_submissions._tcp` (465), `_imaps._tcp` (993), `_pop3s._tcp` (995) | `mail.rustd.xyz.` |
+| SRV | `_imap._tcp`, `_pop3._tcp`, `_submission._tcp` | `.` (disabled) |
+
+Deliberately omitted: the `google-site-verification` TXT that the other domains carry, since there is no token for this domain yet.
+
+## Divergence from the sair.run pattern
+
+`sair.run` is listed in `www_redirect_domains` in `projects.yml`, which 301s the apex to `www`. **`rustd.xyz` must not get that entry.** The application's `RUSTD_AUTH_BASE_URL` defaults to `https://rustd.xyz` — the apex — and the auth flow sets a `__Host-` prefixed cookie, which is bound to an exact host and cannot survive a cross-host redirect. Redirecting the apex to `www` would break magic-link callbacks.
+
+The apex serves the application; `www` exists only as a CNAME so the name resolves.
+
+## Known trade-offs
+
+- **The parking page goes away.** After the nameserver switch, `rustd.xyz` stops serving GoDaddy's parked page and serves nothing, because nginx-proxy on the `projects` droplet has no vhost for it until the app is deployed. Accepted: this is an unlaunched product and a parking page has no value.
+- **Certificate lag.** Mail for `rustd.xyz` works as soon as the MX resolves, but until step 8 a mail client pointed at `mail.rustd.xyz` will see a certificate name mismatch. Using `mail.jasonernst.com` as the server name works in the interim.
+
+## Future consideration: mail provider for production
+
+The application's own auth-gate design warns against relying on a self-hosted, single-IP relay for production magic links — if sign-in mail is filtered as spam, users cannot log in at all. This spec does not address that: the Mailu account is the correct swappable default (Quarkus mailer config is entirely environment-driven), and it matches what `sair.run` does today.
+
+If an ESP is introduced later, the SPF record must gain an `include:` alongside `mx`, the way `jasonernst.com` carries `include:sendgrid.net`. Changing the sending path without updating SPF would cause exactly the alignment failure this estate has already been bitten by.
+
+## Verification
+
+- The public key derived from `/opt/mailu/dkim/rustd.xyz.dkim.key` matches the published `dkim._domainkey.rustd.xyz` TXT record byte-for-byte.
+- `rustd.xyz` NS records resolve to DigitalOcean; apex A/AAAA, MX, SPF, and DMARC all resolve from `ns1.digitalocean.com`.
+- SMTP AUTH as `noreply@rustd.xyz` succeeds from off-network. Before step 8 this must be tested against `mail.jasonernst.com:465`, which has a valid certificate; testing against `mail.rustd.xyz:465` will fail TLS verification on a name mismatch until the certificate is reissued, and that failure would be a false alarm rather than a mail problem. After step 8, both hostnames work.
+- A test message to an external receiver reports `dkim=pass`, `spf=pass`, `dmarc=pass`.
+- **Regression check:** `mail.jasonernst.com` and `mail.sair.run` still serve, and the certificate still lists them in its SAN set.
+
+## Rollback
+
+Every step is reversible. Terraform records can be destroyed individually; the Mailu domain can be removed with `flask mailu config-import`; the nameserver switch can be reverted at GoDaddy. The only irreversible-ish action is the nameserver change, which propagates on TTL — but since the DigitalOcean zone is fully populated before the switch, there is no window in which the domain resolves incorrectly.

--- a/terraform/mail-rustd.tf
+++ b/terraform/mail-rustd.tf
@@ -1,0 +1,153 @@
+# Mail DNS records for rustd.xyz
+# Mail is handled by the existing Mailu instance on mail.jasonernst.com
+#
+# Note the split: the apex/www records in projects.tf point at the projects
+# droplet (where the app will run), while everything below points at the www
+# droplet (where Mailu runs).
+
+# A/AAAA records for mail.rustd.xyz -> www droplet (where Mailu runs)
+resource "digitalocean_record" "rustd-A-mail" {
+  domain = digitalocean_domain.rustd-xyz.name
+  type   = "A"
+  name   = "mail"
+  value  = digitalocean_droplet.www-jasonernst-com.ipv4_address
+}
+
+resource "digitalocean_record" "rustd-AAAA-mail" {
+  domain = digitalocean_domain.rustd-xyz.name
+  type   = "AAAA"
+  name   = "mail"
+  value  = digitalocean_droplet.www-jasonernst-com.ipv6_address
+}
+
+# MX record - mail.rustd.xyz handles mail for rustd.xyz
+resource "digitalocean_record" "rustd-MX" {
+  domain   = digitalocean_domain.rustd-xyz.name
+  type     = "MX"
+  name     = "@"
+  value    = "mail.rustd.xyz."
+  priority = 10
+}
+
+# SPF record - authorize the mail server to send on behalf of this domain.
+# If an external mail provider is added later (see the design doc), it needs an
+# include: here or its mail will fail SPF alignment under the DMARC policy below.
+resource "digitalocean_record" "rustd-TXT-SPF" {
+  domain = digitalocean_domain.rustd-xyz.name
+  type   = "TXT"
+  name   = "@"
+  value  = "v=spf1 mx -all"
+}
+
+# DMARC record - policy for handling failed authentication
+resource "digitalocean_record" "rustd-TXT-DMARC" {
+  domain = digitalocean_domain.rustd-xyz.name
+  type   = "TXT"
+  name   = "_dmarc"
+  value  = "v=DMARC1; p=reject; rua=mailto:jason@rustd.xyz; ruf=mailto:jason@rustd.xyz; adkim=s; aspf=s"
+}
+
+# DMARC report record - allows receiving DMARC reports for this domain
+resource "digitalocean_record" "rustd-TXT-DMARC-report" {
+  domain = digitalocean_domain.rustd-xyz.name
+  type   = "TXT"
+  name   = "rustd.xyz._report._dmarc"
+  value  = "v=DMARC1;"
+}
+
+# DKIM record for Mailu.
+# Generated up front via `flask mailu config-import` so this record is correct
+# from the start - see the design doc for why a placeholder here is a trap.
+resource "digitalocean_record" "rustd-TXT-DKIM" {
+  domain = digitalocean_domain.rustd-xyz.name
+  type   = "TXT"
+  name   = "dkim._domainkey"
+  value  = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsat/zt9/fOGGoJrkVf4xE9p2+FiSUPL4xsieh7aG9GXkkEek4Ph5WjCfPuAKYsLpjQM6vtW/zUZ1he5TPIOkghIPBGt1HphdV6A68+1NEdk83gG1K/IsMYUUKCew4J+VL3RlGhWBbOpLJaGZTt4W/94F5CIAikr2lvvMIygtkR9uyUSu4Jj7tyPZI4kt01Pll8ilYSxsw3LRnlV0r1uHQ8yoOmhhKMJY7IfpV0BIf5A9ttvPJI0p1tR0+bC4wZDZitemqwpy5DDGeaJC1w1RNaA/vHZlBv1Up7hQcrKmLD4mtdFbaOrkztsD63BMaK39Cwb/93zfzq8EyRzLIrfj1QIDAQAB"
+}
+
+# Mail client auto-configuration
+resource "digitalocean_record" "rustd-CNAME-autoconfig" {
+  domain = digitalocean_domain.rustd-xyz.name
+  type   = "CNAME"
+  name   = "autoconfig"
+  value  = "mail.rustd.xyz."
+}
+
+resource "digitalocean_record" "rustd-CNAME-autodiscover" {
+  domain = digitalocean_domain.rustd-xyz.name
+  type   = "CNAME"
+  name   = "autodiscover"
+  value  = "mail.rustd.xyz."
+}
+
+# SRV records for mail client auto-discovery
+resource "digitalocean_record" "rustd-SRV-autodiscover" {
+  domain   = digitalocean_domain.rustd-xyz.name
+  type     = "SRV"
+  name     = "_autodiscover._tcp"
+  value    = "mail.rustd.xyz."
+  priority = 10
+  weight   = 1
+  port     = 443
+}
+
+resource "digitalocean_record" "rustd-SRV-submissions" {
+  domain   = digitalocean_domain.rustd-xyz.name
+  type     = "SRV"
+  name     = "_submissions._tcp"
+  value    = "mail.rustd.xyz."
+  priority = 10
+  weight   = 1
+  port     = 465
+}
+
+resource "digitalocean_record" "rustd-SRV-imaps" {
+  domain   = digitalocean_domain.rustd-xyz.name
+  type     = "SRV"
+  name     = "_imaps._tcp"
+  value    = "mail.rustd.xyz."
+  priority = 10
+  weight   = 1
+  port     = 993
+}
+
+resource "digitalocean_record" "rustd-SRV-pop3s" {
+  domain   = digitalocean_domain.rustd-xyz.name
+  type     = "SRV"
+  name     = "_pop3s._tcp"
+  value    = "mail.rustd.xyz."
+  priority = 10
+  weight   = 1
+  port     = 995
+}
+
+# Disable plaintext protocols (SRV with target "." means not available)
+resource "digitalocean_record" "rustd-SRV-imap-disabled" {
+  domain   = digitalocean_domain.rustd-xyz.name
+  type     = "SRV"
+  name     = "_imap._tcp"
+  value    = "."
+  priority = 0
+  weight   = 0
+  port     = 0
+}
+
+resource "digitalocean_record" "rustd-SRV-pop3-disabled" {
+  domain   = digitalocean_domain.rustd-xyz.name
+  type     = "SRV"
+  name     = "_pop3._tcp"
+  value    = "."
+  priority = 0
+  weight   = 0
+  port     = 0
+}
+
+resource "digitalocean_record" "rustd-SRV-submission-disabled" {
+  domain   = digitalocean_domain.rustd-xyz.name
+  type     = "SRV"
+  name     = "_submission._tcp"
+  value    = "."
+  priority = 0
+  weight   = 0
+  port     = 0
+}

--- a/terraform/projects.tf
+++ b/terraform/projects.tf
@@ -280,6 +280,40 @@ resource "digitalocean_record" "goblog-TXT-google" {
 }
 
 # ============================================================================
+# rustd.xyz (https://github.com/compscidr/rustd.xyz)
+#
+# Served at the APEX, not www - unlike the other domains here, this one gets
+# no www_redirect entry. The app's auth base URL is https://rustd.xyz and its
+# login sets a __Host- prefixed cookie, which is bound to an exact host and
+# cannot survive an apex -> www redirect. See
+# docs/superpowers/specs/2026-08-05-rustd-xyz-dns-mail-design.md
+# ============================================================================
+resource "digitalocean_domain" "rustd-xyz" {
+  name = "rustd.xyz"
+}
+
+resource "digitalocean_record" "rustd-A" {
+  domain = digitalocean_domain.rustd-xyz.name
+  type   = "A"
+  name   = "@"
+  value  = digitalocean_droplet.projects.ipv4_address
+}
+
+resource "digitalocean_record" "rustd-AAAA" {
+  domain = digitalocean_domain.rustd-xyz.name
+  type   = "AAAA"
+  name   = "@"
+  value  = digitalocean_droplet.projects.ipv6_address
+}
+
+resource "digitalocean_record" "rustd-CNAME-www" {
+  domain = digitalocean_domain.rustd-xyz.name
+  type   = "CNAME"
+  name   = "www"
+  value  = "@"
+}
+
+# ============================================================================
 # Firewall - minimal exposure
 # ============================================================================
 resource "digitalocean_firewall" "projects" {


### PR DESCRIPTION
## ⚠️ Do not run `terraform apply` from `main` until this merges

A plan from `main` right now reports:

```
# digitalocean_domain.rustd-xyz will be destroyed
  (because digitalocean_domain.rustd-xyz is not in configuration)
... 20 rustd.xyz resources destroyed
```

That would **delete the entire rustd.xyz DNS zone**. The nameservers already point at DigitalOcean, so the domain would go completely dark — web, MX, and mail all at once.

From this branch the same plan is `0 to add, 9 to change, 0 to destroy` (only the known perennial `SRV "."` normalization drift).

## What happened

#481 was based on `jason/mail-dkim-webroot-fix` rather than `main`, because it genuinely depended on the `WEBROOT_REDIRECT` fix in #478. The expectation was that GitHub would retarget it to `main` once #478 merged. It didn't — so when #481 was merged, it merged **into the feature branch**, and none of its commits reached `main`.

`gh pr view 481` reports `MERGED`, which is why this wasn't obvious. Confirmed via `git merge-base --is-ancestor`: all four commits are absent from `main`.

## What this restores

- `terraform/mail-rustd.tf` and the `rustd.xyz` block in `projects.tf` — **the config for 20 DNS records that already exist**, which is what stops Terraform destroying them
- `rustd.xyz` in `mailu_additional_domains`. Without it, a mailu role run regenerates `LETSENCRYPT_HOST` without `mail.rustd.xyz`, and the shared SAN certificate gets reissued without that hostname — breaking TLS for it
- **The two credential-leak fixes in the mailu role.** Without these, every run keeps printing DKIM private keys and mailbox passwords in plaintext
- Role tags on the `jasonernst_com` play
- The design spec

## Also fixed here

The branch predated #480, so a direct PR would have **reverted the Tailscale ACL reconcile**. `main` is merged in and `terraform/tailscale-acl.hujson` verified byte-identical to `main`'s version, which is itself byte-identical to the live tailnet policy. No revert.

## Verification
- `terraform plan` from this branch: `0 to destroy`
- ACL file matches `main`
- Live infrastructure already matches this config — it was applied from the feature branch before the merge went astray, so merging this is purely a code-catches-up-to-reality change with no infrastructure effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)