### PR TITLE
chore(sair): use sair-user-api-key on ubuntu-cube

### DIFF
--- a/ansible/sair.yml
+++ b/ansible/sair.yml
@@ -13,7 +13,8 @@
 #
 # Prerequisites:
 #   1. Host bootstrapped (bootstrap.yml)
-#   2. 1Password items: sair-api-key, gh-actions-runner-pat (also used for GHCR login; needs read:packages scope)
+#   2. 1Password items: sair-user-api-key (ubuntu-cube), sair-api-key (ubuntu-silverstone),
+#      gh-actions-runner-pat (also used for GHCR login; needs read:packages scope)
 #   3. Orchestrator deployed on projects droplet (projects.yml)
 #
 # Usage:
@@ -24,8 +25,8 @@
   vars_files:
     - vars/user.yml
   vars:
-    sair_api_key: "{{ lookup('community.general.onepassword', 'sair-api-key', field='credential', vault=onepassword_vault, account_id=onepassword_account_id)
-      }}"
+    sair_api_key: "{{ lookup('community.general.onepassword', 'sair-user-api-key', field='credential', vault=onepassword_vault,
+      account_id=onepassword_account_id) }}"
     sair_runner_pat: "{{ lookup('community.general.onepassword', 'gh-actions-runner-pat', field='credential', vault=onepassword_vault,
       account_id=onepassword_account_id) }}"
     sair_ghcr_token: "{{ lookup('community.general.onepassword', 'gh-actions-runner-pat', field='credential', vault=onepassword_vault,


### PR DESCRIPTION
Switches the SAIR stack on `ubuntu-cube` from the admin `sair-api-key` to the user-tier `sair-user-api-key`, per request to stop using the admin key for the device host.

## What changes

`sair_api_key` in the ubuntu-cube play now resolves the `sair-user-api-key` 1Password item. That value is consumed in two places by `roles/sair`:

- `/etc/sair/device-source.env` → `SAIR_API_KEY`
- `/etc/sair/proxy.env` → `SAIR_API_KEY`

`ubuntu-silverstone` is deliberately left on `sair-api-key`. It runs `sair_adb_only: true`, so neither env file is written there, and its CI brings up a fully local stack with `ci-test-key`.

## Verification

- `sair-user-api-key` exists in the `Infrastructure` vault and has a `credential` field, matching the lookup.
- `ansible-playbook -i inventory.yml sair.yml --syntax-check` passes.
- `ansible-lint sair.yml` passes with 0 failures / 0 warnings on the `production` profile.

Not deployed — @compscidr is running the playbooks.

## Before merging: confirm the key resolves server-side

The orchestrator resolves tenants through `CompositeTenantResolver(envResolver, portalDbResolver)`. The env resolver only knows the admin key it was started with (mapped to tenant `default`), so **`sair-user-api-key` must exist as a portal user's API key in `portal.db`** or the proxy's `ReportDevices` and `AcquireLock` calls will be rejected and ubuntu-cube's devices will vanish from the dashboard.

Worth a quick check against the portal before running this, since the failure mode looks identical to the outage fixed earlier today (compscidr/iac#484).

## Side benefit

Jobs under a `user-<int>` tenant *are* written to the `completed_jobs` table, whereas the `default` tenant is silently skipped. So this should also make ubuntu-cube's job history persist, partially addressing compscidr/sair-ochestrator#536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)