### PR TITLE
rust: let rustd.xyz write in the identity dir without root

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -31,7 +31,7 @@ collections:
   - name: compscidr.github_runner
     version: "0.1.3"
   - name: compscidr.rust_gameserver
-    version: "0.1.1"
+    version: "0.2.0"
   - name: compscidr.github_cli
     version: "0.0.16"
   - name: compscidr.onepassword

--- a/ansible/roles/rust_game/tasks/main.yml
+++ b/ansible/roles/rust_game/tasks/main.yml
@@ -19,6 +19,16 @@
       account_id=onepassword_account_id) }}"
     rust_gameserver_wipe: "weekly"
     rust_gameserver_manage_wipe_cron: false
+    # rustd.xyz owns wipes (above), so it needs to write in the identity directory:
+    # snapshots, seed.env rewrites, map/save deletion. Group membership, NOT sudo —
+    # all of its filesystem work is confined to that one tree and it drives the
+    # server lifecycle over RCON, so root is never required. SETGID (the 2 in 2775)
+    # is load-bearing: `sed -i` on seed.env replaces the file rather than editing it,
+    # and without setgid the replacement lands in jason's group and the container can
+    # no longer read its own seed.
+    rust_gameserver_manager_users:
+      - jason
+    rust_gameserver_identity_dir_mode: '2775'
     rust_gameserver_overwrite_env: false
     rust_gameserver_seed: 14419
     rust_gameserver_rcon_web_port: 8000
@@ -67,6 +77,16 @@
       account_id=onepassword_account_id) }}"
     rust_gameserver_wipe: "monthly"
     rust_gameserver_manage_wipe_cron: false
+    # rustd.xyz owns wipes (above), so it needs to write in the identity directory:
+    # snapshots, seed.env rewrites, map/save deletion. Group membership, NOT sudo —
+    # all of its filesystem work is confined to that one tree and it drives the
+    # server lifecycle over RCON, so root is never required. SETGID (the 2 in 2775)
+    # is load-bearing: `sed -i` on seed.env replaces the file rather than editing it,
+    # and without setgid the replacement lands in jason's group and the container can
+    # no longer read its own seed.
+    rust_gameserver_manager_users:
+      - jason
+    rust_gameserver_identity_dir_mode: '2775'
     rust_gameserver_overwrite_env: false
     rust_gameserver_seed: 756632467
     rust_gameserver_rcon_web_port: 8001

--- a/ansible/roles/rust_game/tasks/main.yml
+++ b/ansible/roles/rust_game/tasks/main.yml
@@ -19,16 +19,10 @@
       account_id=onepassword_account_id) }}"
     rust_gameserver_wipe: "weekly"
     rust_gameserver_manage_wipe_cron: false
-    # rustd.xyz owns wipes (above), so it needs to write in the identity directory:
-    # snapshots, seed.env rewrites, map/save deletion. Group membership, NOT sudo —
-    # all of its filesystem work is confined to that one tree and it drives the
-    # server lifecycle over RCON, so root is never required. SETGID (the 2 in 2775)
-    # is load-bearing: `sed -i` on seed.env replaces the file rather than editing it,
-    # and without setgid the replacement lands in jason's group and the container can
-    # no longer read its own seed.
-    rust_gameserver_manager_users:
-      - jason
-    rust_gameserver_identity_dir_mode: '2775'
+    # Defined once in vars/main.yml — see there for why this is group membership
+    # rather than sudo, and why the setgid bit is load-bearing.
+    rust_gameserver_manager_users: "{{ rust_game_manager_users }}"
+    rust_gameserver_identity_dir_mode: "{{ rust_game_identity_dir_mode }}"
     rust_gameserver_overwrite_env: false
     rust_gameserver_seed: 14419
     rust_gameserver_rcon_web_port: 8000
@@ -77,16 +71,10 @@
       account_id=onepassword_account_id) }}"
     rust_gameserver_wipe: "monthly"
     rust_gameserver_manage_wipe_cron: false
-    # rustd.xyz owns wipes (above), so it needs to write in the identity directory:
-    # snapshots, seed.env rewrites, map/save deletion. Group membership, NOT sudo —
-    # all of its filesystem work is confined to that one tree and it drives the
-    # server lifecycle over RCON, so root is never required. SETGID (the 2 in 2775)
-    # is load-bearing: `sed -i` on seed.env replaces the file rather than editing it,
-    # and without setgid the replacement lands in jason's group and the container can
-    # no longer read its own seed.
-    rust_gameserver_manager_users:
-      - jason
-    rust_gameserver_identity_dir_mode: '2775'
+    # Defined once in vars/main.yml — see there for why this is group membership
+    # rather than sudo, and why the setgid bit is load-bearing.
+    rust_gameserver_manager_users: "{{ rust_game_manager_users }}"
+    rust_gameserver_identity_dir_mode: "{{ rust_game_identity_dir_mode }}"
     rust_gameserver_overwrite_env: false
     rust_gameserver_seed: 756632467
     rust_gameserver_rcon_web_port: 8001

--- a/ansible/roles/rust_game/vars/main.yml
+++ b/ansible/roles/rust_game/vars/main.yml
@@ -1,0 +1,21 @@
+---
+# rustd.xyz connects to this host over SSH **as the `jason` account** — that is the
+# principal being granted access here; "rustd.xyz" below means "the panel, acting as
+# that user". Both servers set `rust_gameserver_manage_wipe_cron: false`, handing
+# wipes to the panel, so it needs to write inside each identity directory:
+# snapshots, seed.env rewrites, map/save deletion.
+#
+# Group membership rather than sudo: every host-side thing the panel does is confined
+# to that one directory tree, and it drives the server lifecycle over RCON rather than
+# docker or systemd, so root is never required. A stored sudo credential would turn a
+# compromise of the panel into a compromise of the host.
+#
+# SETGID (the 2 in 2775) is load-bearing, not tidiness: `sed -i` on seed.env replaces
+# the file rather than editing it, and without setgid the replacement lands in the
+# manager's own group, at which point the container can no longer read its own seed.
+#
+# Defined once here and referenced by every server block below, so adding a server
+# cannot silently omit them and changing the principal is a one-line edit.
+rust_game_manager_users:
+  - jason
+rust_game_identity_dir_mode: '2775'


### PR DESCRIPTION
**Blocked on compscidr/ansible-rust-gameserver#25** — this pins collection `0.2.0`, which doesn't exist until that merges and releases.

## Why

Both servers already set `rust_gameserver_manage_wipe_cron: false`, handing wipes to rustd.xyz. But the panel's SSH user (`jason`) can't write in `/etc/rust/server/<identity>` — those directories are `drwxr-xr-x steam:steam`. So every wipe would have failed at the snapshot or delete step. Verified on the host: `test -w` fails for both, and `jason` has no passwordless sudo.

That was live: the schedule is armed on both servers, so the next scheduled wipe would have fired and errored.

## Group membership, not sudo

I enumerated every host-side operation the panel performs before picking the mechanism:

```
stop/start server -> RCON "restart 30"   (no host access at all)
snapshot          -> mkdir + cp -a       inside the identity dir
seed update       -> sed -i              identity dir/seed.env
wipe              -> rm -f               inside the identity dir
```

None of it needs elevation — the filesystem work is confined to one tree and the lifecycle goes over RCON, not docker or systemd. So `jason` joins the runtime group instead. Storing a sudo credential would be strictly more privilege than the job needs and would turn a compromise of the panel into a compromise of the host, which is a bad trade generally and a worse one for a product where customers attach their own machines.

## SETGID matters

`rust_gameserver_identity_dir_mode: '2775'` — the sticky bit isn't cosmetic. `sed -i` doesn't edit in place; it writes a temp file and renames over the target, so the replacement belongs to whoever ran it. Without setgid, `seed.env` ends up in `jason`'s group and **the container can no longer read its own seed**. The collection's molecule scenario asserts this with that reasoning in the failure message.

## After merge

Run the role against both servers, then confirm `test -w /etc/rust/server/{weekly,monthly}` succeeds as `jason` and that the directories are `2775`. Group membership only applies to new login sessions, so any pooled SSH connection needs to turn over.