### PR TITLE
rust: build server and bare-metal test server on ubuntu-cube

### DIFF
--- a/ansible/cube.yml
+++ b/ansible/cube.yml
@@ -1,0 +1,16 @@
+---
+# Rust game servers on ubuntu-cube.local.
+#
+# These are not community servers. The build server is for base design; the test
+# server (see the bare-metal work) is for exercising rustd.xyz against a real game
+# server rather than against the servers people play on.
+#
+# Usage:
+#   ansible-playbook -i inventory.yml cube.yml
+- name: Rust game servers on ubuntu-cube
+  hosts: ubuntu-cube.local
+  vars_files:
+    - vars/user.yml
+    - vars/secrets.yml
+  roles:
+    - rust_game_cube

--- a/ansible/cube.yml
+++ b/ansible/cube.yml
@@ -12,5 +12,9 @@
   vars_files:
     - vars/user.yml
     - vars/secrets.yml
+  vars:
+    rust_test_server_rcon_password: "{{ lookup('community.general.onepassword', 'rust-rcon-password', field='password', vault=onepassword_vault,
+      account_id=onepassword_account_id) }}"
   roles:
     - rust_game_cube
+    - rust_test_server

--- a/ansible/roles/rust_game_cube/tasks/main.yml
+++ b/ansible/roles/rust_game_cube/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+# Rust servers on ubuntu-cube.local.
+#
+# Separate from the `rust_game` role (nas.local) because these are not production
+# community servers: the build server exists for base design and the test server
+# exists for exercising rustd.xyz against a real game server without touching the
+# servers people actually play on.
+- name: Install rust build server
+  tags: rust-build
+  ansible.builtin.include_role:
+    name: compscidr.rust_gameserver.rust_gameserver
+    apply:
+      become: true
+      tags: rust-build
+  vars:
+    rust_gameserver_identity: "build"
+    rust_gameserver_name: "California Build Server"
+    rust_gameserver_description: "Build server — no wipes.\\nWorld Size: {{ rust_gameserver_worldsize }}"
+    rust_gameserver_worldsize: 3000
+    rust_gameserver_maxplayers: 50
+    rust_gameserver_port: 29015
+    rust_gameserver_query_port: 29016
+    rust_gameserver_rcon_port: 29017
+    rust_gameserver_app_port: 29082
+    rust_gameserver_rcon_password: "{{ lookup('community.general.onepassword', 'rust-rcon-password', field='password', vault=onepassword_vault,
+      account_id=onepassword_account_id) }}"
+    # A build server should never wipe on a timer. The cron is removed and rustd.xyz
+    # owns any wipe that does happen, deliberately, from the panel.
+    rust_gameserver_wipe: "monthly"
+    rust_gameserver_manage_wipe_cron: false
+    rust_gameserver_overwrite_env: false
+    # Lets rustd.xyz write in the identity directory without root — see
+    # compscidr/ansible-rust-gameserver#25. Inert until collection 0.2.0 is pinned
+    # (compscidr/iac#486 does that bump).
+    rust_gameserver_manager_users:
+      - jason
+    rust_gameserver_identity_dir_mode: '2775'

--- a/ansible/roles/rust_test_server/defaults/main.yml
+++ b/ansible/roles/rust_test_server/defaults/main.yml
@@ -1,0 +1,30 @@
+---
+# Bare-metal Rust server for exercising rustd.xyz.
+#
+# Deliberately NOT the collection role: compscidr.rust_gameserver deploys a docker
+# container and has no native install path, and the entire point of this server is
+# to be the non-container case — see compscidr/rustd.xyz#340, which needs to observe
+# what the `restart` command does when nothing is supervising the process.
+rust_test_server_user: jason
+rust_test_server_root: /opt/rust-test
+rust_test_server_identity: test
+rust_test_server_name: "rustd.xyz test server"
+rust_test_server_description: "Test server for rustd.xyz. Wipes frequently."
+
+# 1000 is the smallest world Rust accepts. Map generation dominates a wipe, and this
+# server exists to have wipes run against it repeatedly.
+rust_test_server_worldsize: 1000
+rust_test_server_maxplayers: 5
+
+rust_test_server_port: 30015
+rust_test_server_query_port: 30016
+rust_test_server_rcon_port: 30017
+rust_test_server_app_port: 30082
+rust_test_server_seed: 1337
+
+# The systemd unit is installed but left DISABLED and STOPPED on purpose. Enabling it
+# would supervise the process and destroy the property this server exists to test:
+# #340 needs to know what happens to an UNsupervised server when rustd.xyz restarts
+# it. Start it by hand in the foreground for that, or enable the unit once the
+# question is answered and you want it to stay up.
+rust_test_server_service_enabled: false

--- a/ansible/roles/rust_test_server/tasks/main.yml
+++ b/ansible/roles/rust_test_server/tasks/main.yml
@@ -1,0 +1,105 @@
+---
+- name: Install steamcmd prerequisites
+  tags: rust-test
+  become: true
+  ansible.builtin.apt:
+    name:
+      - lib32gcc-s1
+      - lib32stdc++6
+      - ca-certificates
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+# steamcmd is in multiverse and its installer prompts for a licence agreement, which
+# a non-interactive run cannot answer — preseed the acceptance first.
+- name: Accept the steamcmd licence non-interactively
+  tags: rust-test
+  become: true
+  ansible.builtin.debconf:
+    name: steamcmd
+    question: steam/question
+    value: "I AGREE"
+    vtype: select
+
+- name: Install steamcmd
+  tags: rust-test
+  become: true
+  ansible.builtin.apt:
+    name: steamcmd
+    state: present
+
+# Owned by the panel's SSH user directly, rather than the group-membership dance the
+# containerised servers need (compscidr/iac#486). The panel writes here to snapshot,
+# rewrite the seed and delete map files; owning the tree outright is the simplest way
+# to grant that, and this host runs nothing else that needs the directory.
+- name: Create the server directory
+  tags: rust-test
+  become: true
+  ansible.builtin.file:
+    path: "{{ rust_test_server_root }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ rust_test_server_user }}"
+    group: "{{ rust_test_server_user }}"
+
+- name: Install or update the Rust dedicated server
+  tags: rust-test
+  become: true
+  become_user: "{{ rust_test_server_user }}"
+  ansible.builtin.command:
+    cmd: >-
+      /usr/games/steamcmd
+      +force_install_dir {{ rust_test_server_root }}
+      +login anonymous
+      +app_update 258550 validate
+      +quit
+    creates: "{{ rust_test_server_root }}/RustDedicated"
+  register: rust_test_server_install
+  changed_when: rust_test_server_install.rc == 0
+
+# The seed lives in its own file so a wipe can rotate it without rewriting the launch
+# script — the same split the containerised servers use, so rustd.xyz's `sed -i` on
+# seed.env works identically against both.
+- name: Create seed.env (never overwritten — wipes rotate it at runtime)
+  tags: rust-test
+  become: true
+  ansible.builtin.copy:
+    content: "RUST_SERVER_SEED={{ rust_test_server_seed }}\n"
+    dest: "{{ rust_test_server_root }}/seed.env"
+    mode: '0644'
+    owner: "{{ rust_test_server_user }}"
+    group: "{{ rust_test_server_user }}"
+    force: false
+
+- name: Install the launch script
+  tags: rust-test
+  become: true
+  ansible.builtin.template:
+    src: start.sh.j2
+    dest: "{{ rust_test_server_root }}/start.sh"
+    mode: '0755'
+    owner: "{{ rust_test_server_user }}"
+    group: "{{ rust_test_server_user }}"
+
+- name: Install the systemd unit
+  tags: rust-test
+  become: true
+  ansible.builtin.template:
+    src: rust-test.service.j2
+    dest: /etc/systemd/system/rust-test.service
+    mode: '0644'
+    owner: root
+    group: root
+
+# Installed but not enabled or started by default — see the comment on
+# rust_test_server_service_enabled. Supervising this process is the thing #340 is
+# trying to observe the absence of.
+- name: Set the service state
+  tags: rust-test
+  become: true
+  ansible.builtin.systemd_service:
+    name: rust-test
+    enabled: "{{ rust_test_server_service_enabled }}"
+    state: "{{ 'started' if rust_test_server_service_enabled else 'stopped' }}"
+    daemon_reload: true

--- a/ansible/roles/rust_test_server/tasks/main.yml
+++ b/ansible/roles/rust_test_server/tasks/main.yml
@@ -43,6 +43,11 @@
     owner: "{{ rust_test_server_user }}"
     group: "{{ rust_test_server_user }}"
 
+# Deliberately NOT guarded with `creates:`. Rust ships updates that break servers —
+# on 2026-08-06 one removed BasePlayer.violationLevel and killed a plugin outright —
+# so a task that installs once and never updates again is the wrong shape for the
+# thing it manages. `app_update` is a no-op when already current, so running it every
+# time is cheap; the cost is one steamcmd invocation per play.
 - name: Install or update the Rust dedicated server
   tags: rust-test
   become: true
@@ -54,9 +59,12 @@
       +login anonymous
       +app_update 258550 validate
       +quit
-    creates: "{{ rust_test_server_root }}/RustDedicated"
   register: rust_test_server_install
-  changed_when: rust_test_server_install.rc == 0
+  # steamcmd says "already up to date" when it did nothing and "fully installed" when
+  # it actually wrote something, so report changed only in the latter case rather than
+  # claiming a change on every single run.
+  changed_when: "'already up to date' not in rust_test_server_install.stdout"
+  failed_when: rust_test_server_install.rc != 0
 
 # The seed lives in its own file so a wipe can rotate it without rewriting the launch
 # script — the same split the containerised servers use, so rustd.xyz's `sed -i` on

--- a/ansible/roles/rust_test_server/templates/rust-test.service.j2
+++ b/ansible/roles/rust_test_server/templates/rust-test.service.j2
@@ -1,0 +1,25 @@
+# {{ ansible_managed }}
+#
+# Installed but NOT enabled by default (see rust_test_server_service_enabled).
+#
+# Note `Restart=no`: the whole point of this server is to be the unsupervised case
+# for compscidr/rustd.xyz#340. If you enable this unit AND set Restart=always, you
+# have made it a supervised server and it no longer answers that question — which is
+# fine once the question is answered, but should be a deliberate change rather than a
+# copied default.
+[Unit]
+Description=Rust dedicated server (rustd.xyz test)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ rust_test_server_user }}
+WorkingDirectory={{ rust_test_server_root }}
+ExecStart={{ rust_test_server_root }}/start.sh
+Restart=no
+KillSignal=SIGINT
+TimeoutStopSec=120
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/rust_test_server/templates/start.sh.j2
+++ b/ansible/roles/rust_test_server/templates/start.sh.j2
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# {{ ansible_managed }}
+#
+# Bare-metal launcher for the rustd.xyz test server.
+#
+# Deliberately has NO supervision loop. The containerised servers exit and are
+# restarted by docker's policy; this one, run in the foreground, simply exits — which
+# is exactly the case compscidr/rustd.xyz#340 needs to observe. Do not add a
+# `while true` here without reading that issue first: it would silently answer the
+# question this server exists to ask.
+
+set -o allexport
+# Split out so a wipe can rotate the seed without touching this script.
+source {{ rust_test_server_root }}/seed.env
+set +o allexport
+
+exec {{ rust_test_server_root }}/RustDedicated -batchmode -nographics \
+  +server.identity "{{ rust_test_server_identity }}" \
+  +server.hostname "{{ rust_test_server_name }}" \
+  +server.description "{{ rust_test_server_description }}" \
+  +server.port {{ rust_test_server_port }} \
+  +server.queryport {{ rust_test_server_query_port }} \
+  +server.maxplayers {{ rust_test_server_maxplayers }} \
+  +server.worldsize {{ rust_test_server_worldsize }} \
+  +server.seed "${RUST_SERVER_SEED}" \
+  +server.saveinterval 300 \
+  +app.port {{ rust_test_server_app_port }} \
+  +rcon.port {{ rust_test_server_rcon_port }} \
+  +rcon.password "{{ rust_test_server_rcon_password }}" \
+  +rcon.web 1

--- a/ansible/roles/rust_test_server/templates/start.sh.j2
+++ b/ansible/roles/rust_test_server/templates/start.sh.j2
@@ -9,10 +9,29 @@
 # `while true` here without reading that issue first: it would silently answer the
 # question this server exists to ask.
 
+set -euo pipefail
+
+SEED_FILE="{{ rust_test_server_root }}/seed.env"
+
+# Fail loudly rather than booting with an empty seed. Rust picks its own seed when
+# +server.seed is empty, so the running map would silently stop matching what
+# seed.env — and the panel — believe is running. A server that refuses to start is a
+# far cheaper failure than one running a map nobody can identify.
+if [ ! -r "${SEED_FILE}" ]; then
+  echo "FATAL: ${SEED_FILE} is missing or unreadable" >&2
+  exit 1
+fi
+
 set -o allexport
 # Split out so a wipe can rotate the seed without touching this script.
-source {{ rust_test_server_root }}/seed.env
+# shellcheck source=/dev/null
+source "${SEED_FILE}"
 set +o allexport
+
+if [ -z "${RUST_SERVER_SEED:-}" ]; then
+  echo "FATAL: ${SEED_FILE} did not set RUST_SERVER_SEED" >&2
+  exit 1
+fi
 
 exec {{ rust_test_server_root }}/RustDedicated -batchmode -nographics \
   +server.identity "{{ rust_test_server_identity }}" \


### PR DESCRIPTION
Two Rust servers on `ubuntu-cube.local`, neither of them a community server.

| | identity | RCON | deployment | maxplayers |
|---|---|---|---|---|
| California Build Server | `build` | 29017 | docker (collection role) | 50 |
| rustd.xyz test server | `test` | 30017 | **bare metal** | 5 |

## The build server is routine

Another include of `compscidr.rust_gameserver` with its own ports and identity. It never wipes on a timer — `manage_wipe_cron: false` and rustd.xyz owns any deliberate wipe — because a build server that wipes itself is not much use.

It carries `rust_gameserver_manager_users` / `rust_gameserver_identity_dir_mode`, which are inert until the collection `0.2.0` pin lands in #486. Deliberately not bumping `requirements.yml` here to avoid conflicting with that PR.

## The test server needed a new role

**The collection cannot do this.** `compscidr.rust_gameserver` deploys via `community.docker.docker_container` and has no native install path at all, so a bare-metal server is new capability rather than configuration. Hence `rust_test_server` rather than a third include.

Being the non-container case is the entire point: the panel must work against servers that are not in Docker, and compscidr/rustd.xyz#340 needs to observe what Rust's `restart` command does when **nothing supervises the process**. We know the container case — the process exits, `start.sh` has no loop, PID 1 dies and `unless-stopped` brings it back. What we do not know is what happens to someone running `RustDedicated` from a shell, and that is the case that would leave a customer's server down permanently after a scheduled wipe.

So this server is deliberately unsupervised, in three places that all have to agree:

- `start.sh` has **no `while` loop**, with a comment saying why.
- The systemd unit sets **`Restart=no`**.
- The unit is installed but left **disabled and stopped** (`rust_test_server_service_enabled: false`).

Each carries a note pointing at #340, because every one of them looks like an oversight to someone tidying up, and "fixing" any of them silently destroys the property the server exists to demonstrate. Once #340 is answered, flipping the variable turns it into an ordinary supervised server.

## Details worth knowing

- **`worldsize: 1000`**, the minimum Rust accepts. Map generation dominates wipe time and this server exists to have wipes run against it repeatedly.
- **`seed.env` is split out** from the launch script, mirroring the container image, so rustd.xyz's `sed -i` seed rotation works identically against both deployment styles rather than needing a special case.
- **The tree is owned by the panel's SSH user outright**, rather than the group-membership arrangement the containerised servers need (#486). The panel writes here to snapshot, rotate the seed and delete map files; this host runs nothing else that wants the directory, so ownership is the simpler grant.
- steamcmd's licence prompt is preseeded via `debconf`, since a non-interactive run cannot answer it.

`ansible-lint` passes at the production profile.