### PR TITLE
rust: fix the cube deploy — rcon web port, and steamcmd without i386

### DIFF
--- a/ansible/roles/rust_game_cube/tasks/main.yml
+++ b/ansible/roles/rust_game_cube/tasks/main.yml
@@ -22,6 +22,11 @@
     rust_gameserver_query_port: 29016
     rust_gameserver_rcon_port: 29017
     rust_gameserver_app_port: 29082
+    # Continues the estate-wide sequence: 8000 weekly, 8001 monthly, 8002 here. This maps a
+    # host port to the image's web UI on container port 8080, so leaving it at the collection
+    # default (8080) collides with anything already on 8080 — which is exactly what failed on
+    # ubuntu-cube, where something else already holds it.
+    rust_gameserver_rcon_web_port: 8002
     rust_gameserver_rcon_password: "{{ lookup('community.general.onepassword', 'rust-rcon-password', field='password', vault=onepassword_vault,
       account_id=onepassword_account_id) }}"
     # A build server should never wipe on a timer. The cron is removed and rustd.xyz


### PR DESCRIPTION
The `cube.yml` deploy failed at container start:

```
failed to bind host port 0.0.0.0:8080/tcp: address already in use
```

## Cause

I omitted `rust_gameserver_rcon_web_port` for the build server, so it took the collection default of **8080**. That variable maps a *host* port to the image's web UI on container port 8080 (`"{{ rust_gameserver_rcon_web_port }}:8080"`), and something already holds 8080 on `ubuntu-cube.local`.

The existing servers each set it explicitly and continue a sequence — **8000** weekly, **8001** monthly — so the build server takes **8002**. That is the pattern; the default was never meant to be used.

## Verified before committing

On `ubuntu-cube.local`: 8002 is free, as are all the 290xx/300xx ports these two servers use (29015/29016/29017/29082, 30015/30016/30017/30082).

The bare-metal test server needs no equivalent: it has no container port mapping, and its RCON is Rust's own websocket on `rcon.port 30017`. The container's 8080 is the image's nginx UI, which does not exist there.

## To apply

```
ansible-playbook -i inventory.yml cube.yml --tags rust-build
```

The earlier run got as far as creating the container, so this replaces it. Everything before that step succeeded and is idempotent.