### PR TITLE
fix(rust-test): link steamclient.so where Steamworks looks for it

### DIFF
--- a/ansible/roles/rust_test_server/defaults/main.yml
+++ b/ansible/roles/rust_test_server/defaults/main.yml
@@ -8,6 +8,11 @@
 rust_test_server_user: jason
 rust_test_server_root: /opt/rust-test
 rust_test_server_steamcmd_dir: /opt/steamcmd
+
+# Where the Steamworks loader looks for steamclient.so — it resolves the path from the
+# SERVER PROCESS's $HOME, not from the install directory, so this has to track the user
+# above rather than rust_test_server_root.
+rust_test_server_home: "/home/{{ rust_test_server_user }}"
 rust_test_server_identity: test
 rust_test_server_name: "rustd.xyz test server"
 rust_test_server_description: "Test server for rustd.xyz. Wipes frequently."

--- a/ansible/roles/rust_test_server/tasks/main.yml
+++ b/ansible/roles/rust_test_server/tasks/main.yml
@@ -77,6 +77,42 @@
   changed_when: "'already up to date' not in rust_test_server_install.stdout"
   failed_when: rust_test_server_install.rc != 0
 
+# RustDedicated aborts on boot without this. Steamworks resolves steamclient.so from
+# ~/.steam/sdk64 and, when it is missing, InitGameServer returns false and Rust then
+# dereferences the null platform in SteamInventory.LoadItemDefinitions:
+#
+#   Couldn't initialize Steam Server (InitGameServer(0,30015,30016,3,"2632") returned
+#   false - error: Failed to load module '/home/jason/.steam/sdk64/steamclient.so')
+#   NullReferenceException at Steamworks.SteamInventory.GetDefinitions ()
+#
+# The failure is a long way from its cause: map generation runs to completion first, so
+# the server looks like it is booting normally for minutes before dying. The container
+# image provides this path already, which is why only the bare-metal server needs it.
+#
+# sdk64 ONLY: RustDedicated is 64-bit and the loader named sdk64. A 32-bit link is what
+# 32-bit dedicated servers need and would be cargo cult here.
+- name: Create the Steam SDK directory
+  tags: rust-test
+  become: true
+  become_user: "{{ rust_test_server_user }}"
+  ansible.builtin.file:
+    path: "{{ rust_test_server_home }}/.steam/sdk64"
+    state: directory
+    mode: '0755'
+
+- name: Link steamclient.so where the Steamworks loader looks for it
+  tags: rust-test
+  become: true
+  become_user: "{{ rust_test_server_user }}"
+  ansible.builtin.file:
+    src: "{{ rust_test_server_steamcmd_dir }}/linux64/steamclient.so"
+    dest: "{{ rust_test_server_home }}/.steam/sdk64/steamclient.so"
+    state: link
+    # steamcmd unpacks the library on first run, not at unarchive time, so on a first
+    # play this link is created before its target exists.
+    force: true
+    follow: false
+
 # The seed lives in its own file so a wipe can rotate it without rewriting the launch
 # script — the same split the containerised servers use, so rustd.xyz's `sed -i` on
 # seed.env works identically against both.


### PR DESCRIPTION
The bare-metal test server on `ubuntu-cube` installed cleanly and then died on every boot. It had in fact never started successfully — no journal entries, and no `server/` identity directory, which Rust creates on first boot.

## Root cause

RustDedicated resolves `steamclient.so` from the **server process's `$HOME`**, not from the install directory:

```
Couldn't initialize Steam Server (InitGameServer(0,30015,30016,3,"2632") returned false
  - error: Failed to load module '/home/jason/.steam/sdk64/steamclient.so')
NullReferenceException at Steamworks.SteamInventory.GetDefinitions ()
```

`~/.steam` did not exist at all. `InitGameServer` returned false, and Rust then dereferenced the null platform while loading item definitions.

What makes this expensive to diagnose is the **distance between the failure and its cause**: map generation runs to completion first, so the server looks like a perfectly healthy boot for several minutes before dying. The container image already provides this path, which is why only the bare-metal role was affected.

## Fix

Create `~/.steam/sdk64` and link it at `{{ rust_test_server_steamcmd_dir }}/linux64/steamclient.so`. A new `rust_test_server_home` default carries the path, since it has to track the *user* rather than `rust_test_server_root`.

`force: true` on the link is deliberate: steamcmd unpacks the library on first run rather than at unarchive time, so on a first play the link is created before its target exists.

**sdk64 only.** RustDedicated is 64-bit and the loader named sdk64; a 32-bit link is what 32-bit dedicated servers need and would be cargo cult here.

## Verification

Applied by hand on ubuntu-cube, then **removed the sdk32 link** I had initially created so the host matches exactly what this role produces — otherwise the role would ship untested. With sdk64 alone the server reaches `SteamServer Initialized` and binds all four ports:

```
UNCONN  0.0.0.0:30015   (game)     UNCONN  0.0.0.0:30016   (query)
LISTEN  0.0.0.0:30017   (rcon)     LISTEN  0.0.0.0:30082   (app)
```

The server is currently up and joinable at `ubuntu-cube.local:30015`. It remains deliberately unsupervised (unit installed but disabled) so compscidr/rustd.xyz#340 can still observe what `restart` does with nothing supervising the process.