### PR TITLE
rustd.xyz production deployment: droplet resize, panel+postgres role, contact@ alias, nightly backups to the nas

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -13,3 +13,18 @@ onepassword_vault: "Infrastructure"
 
 # Note: Use --ask-become-pass when running playbooks to provide sudo password
 # Automatic 1Password lookup causes too many desktop app prompts
+
+# rustd.xyz nightly DB backup -> nas: the coordinates both ends of the pipeline
+# need to agree on. Lives here (not in roles/rustd_xyz/defaults/main.yml)
+# because the two ends run in separate playbooks with no shared vars_file:
+# the rustd_xyz role (projects.yml, pushes) and the rustd_backup_nas role
+# (nas.yml, receives + prunes) both read these. Role-local backup settings
+# (local keep count, local dir, the SSH key path) stay in
+# roles/rustd_xyz/defaults/main.yml since only that role needs them.
+rustd_xyz_backup_nas_host: nas # tailnet short name (nas.local also joins the tailnet - see common.yml)
+rustd_xyz_backup_nas_user: rustd-backup
+# /volume1 is the nas' real (only) data mount - see media_storage_base_path
+# in roles/media_server/tasks/main.yml and roles/cs2_game/tasks/main.yml.
+# The plan's /volume/backups was a placeholder; there is no /volume share.
+rustd_xyz_backup_nas_path: /volume1/storage/backups/rustd-db
+rustd_xyz_backup_nas_keep: 30

--- a/ansible/nas.yml
+++ b/ansible/nas.yml
@@ -5,9 +5,16 @@
     - vars/deb_arch.yml
     - vars/user.yml
     - vars/secrets.yml
+  pre_tasks:
+    # rustd_backup_nas delegates a task to the "projects" host (a Tailscale
+    # host, per inventory.yml), unlike nas.local itself which is reached
+    # over LAN mDNS regardless of Tailscale state.
+    - name: Check Tailscale connectivity
+      ansible.builtin.include_tasks: tailscale_check.yml
   roles:
     - media_server
     - home_assistant
     - rust_game
     # - cs2_game
     - dyndns
+    - { role: rustd_backup_nas, tags: [rustd, rustd-backup] }

--- a/ansible/nas.yml
+++ b/ansible/nas.yml
@@ -9,7 +9,12 @@
     # rustd_backup_nas delegates a task to the "projects" host (a Tailscale
     # host, per inventory.yml), unlike nas.local itself which is reached
     # over LAN mDNS regardless of Tailscale state.
+    #
+    # Tagged 'always' (matches jasonernst_com.yml) so the connectivity check
+    # still runs when the play is invoked with --tags, e.g. the runbook's
+    # `--tags rustd-backup` (untagged tasks are otherwise skipped).
     - name: Check Tailscale connectivity
+      tags: always
       ansible.builtin.include_tasks: tailscale_check.yml
   roles:
     - media_server

--- a/ansible/projects.yml
+++ b/ansible/projects.yml
@@ -32,6 +32,15 @@
       account_id=onepassword_account_id) }}"
     sair_portal_stripe_solo_price_id: "{{ lookup('community.general.onepassword', 'STRIPE_SOLO_PRICE_ID', field='credential', vault=onepassword_vault,
       account_id=onepassword_account_id) }}"
+    # rustd.xyz
+    rustd_xyz_ghcr_token: "{{ lookup('community.general.onepassword', 'gh-actions-runner-pat', field='credential', vault=onepassword_vault,
+      account_id=onepassword_account_id) }}"
+    rustd_xyz_db_password: "{{ lookup('community.general.onepassword', 'rustd-db', field='password', vault=onepassword_vault,
+      account_id=onepassword_account_id) }}"
+    rustd_xyz_smtp_username: "{{ lookup('community.general.onepassword', 'SMTP_USER - rustd', field='username', vault=onepassword_vault,
+      account_id=onepassword_account_id) }}"
+    rustd_xyz_smtp_password: "{{ lookup('community.general.onepassword', 'SMTP_USER - rustd', field='password', vault=onepassword_vault,
+      account_id=onepassword_account_id) }}"
     www_redirect_domains:
       - { domain: sair.run, letsencrypt_email: "ernstjason1@gmail.com" }
       - { domain: goblog.live, letsencrypt_email: "ernstjason1@gmail.com" }
@@ -46,4 +55,5 @@
     - { role: projects, tags: [projects] }
     - { role: sair_orchestrator, tags: [sair-orchestrator, sair] }
     - { role: sair_portal, tags: [sair-portal, sair] }
+    - { role: rustd_xyz, tags: [rustd, rustd-xyz] }
     - { role: fail2ban, tags: [fail2ban] }

--- a/ansible/roles/mailu/defaults/main.yml
+++ b/ansible/roles/mailu/defaults/main.yml
@@ -56,6 +56,13 @@ mailu_additional_domains:
         password: "{{ lookup('community.general.onepassword', 'SMTP_USER - rustd', field='password', vault='Infrastructure',
           account_id=onepassword_account_id) }}"
 
+# Mail aliases (local@domain -> destination). Created idempotently at deploy;
+# Mailu's CLI errors on existing aliases, tolerated the same way user creation is.
+mailu_aliases:
+  - local: contact
+    domain: rustd.xyz
+    destination: jason@rustd.xyz
+
 # Features
 mailu_webmail: roundcube # roundcube, snappymail, or none
 mailu_antivirus: false # ClamAV uses lots of RAM

--- a/ansible/roles/mailu/tasks/main.yml
+++ b/ansible/roles/mailu/tasks/main.yml
@@ -166,6 +166,22 @@
   failed_when: false # May fail if user exists
   no_log: true # Hide passwords
 
+- name: Create mail aliases
+  become: true
+  ansible.builtin.command:
+    cmd: >
+      docker compose exec -T admin flask mailu alias
+      {{ item.local }} {{ item.domain }} {{ item.destination }}
+  args:
+    chdir: "{{ mailu_install_path }}"
+  loop: "{{ mailu_aliases | default([]) }}"
+  register: mailu_alias_result
+  changed_when: false # Can't reliably detect from looped command
+  failed_when: false # May fail if alias exists
+  # No no_log here, unlike the user-creation tasks above: local/domain/destination
+  # are an alias routing rule, not a credential - nothing here is a secret worth
+  # hiding from the run output.
+
 # `<domain>.dkim.key` is the PRIVATE key. These tasks used to cat it and print
 # the result labelled "add this to DNS", which both leaked the signing key to
 # stdout/CI logs and was useless as a DNS value. Derive the public half

--- a/ansible/roles/rustd_backup_nas/README.md
+++ b/ansible/roles/rustd_backup_nas/README.md
@@ -1,0 +1,104 @@
+# rustd_backup_nas Role
+
+Receiving end of the rustd.xyz nightly `pg_dump` pipeline. Runs in `nas.yml`, against
+`nas.local`. The pushing end is the `rustd_xyz` role (`projects.yml`) — see that role's
+README for the "Nightly backup -> nas" section, which documents the same pipeline from
+the other side.
+
+## What it does
+
+- Installs `rsync` (Debian/Ubuntu, via `apt`) — needed both for the transfer itself and
+  because `rrsync` ships bundled inside the rsync package.
+- Creates a dedicated system user, `rustd-backup` (a real `/bin/bash` shell, not
+  `nologin` — see "Restricted key" below for why).
+- Creates the backup target directory (`rustd_xyz_backup_nas_path`,
+  `/volume1/storage/backups/rustd-db`), owned by `rustd-backup`, mode `0700`.
+- Installs `rrsync` from the rsync package's bundled gzipped script
+  (`/usr/share/doc/rsync/scripts/rrsync.gz` → `/usr/local/bin/rrsync`) if not already
+  present.
+- Slurps the backup public key live off the projects droplet (see "Key flow" below) and
+  authorizes it in `rustd-backup`'s `authorized_keys`, restricted to a forced write-only
+  `rrsync` command when available.
+- Prunes backups older than `rustd_xyz_backup_nas_keep` (30 days) via a `cron` job — the
+  nas is the **sole owner** of nas-side retention. The push script
+  (`rustd-db-backup.sh.j2`, in `rustd_xyz`) never deletes anything remote; it only prunes
+  its own local copy. There is exactly one place backups on the nas get deleted from.
+
+## Key-flow rationale
+
+The projects droplet generates its own ed25519 keypair the first time the `rustd_xyz`
+role runs (`ssh-keygen ... creates=...` — `community.crypto` isn't in
+`requirements.yml`, so this doesn't use `openssh_keypair`). **The private key is
+generated on the droplet and never leaves it**: not copied to the ansible controller,
+not put in 1Password, not templated anywhere.
+
+This is the opposite of generating the keypair on the ansible controller and templating
+the private half out to the droplet. Controller-side generation would leave private key
+material sitting in a bare file on the operator's own machine with no place in this
+repo's secret model to account for it — it isn't a 1Password item, and unlike every
+other secret in this repo it would exist only as a controller-local artifact, with no
+rotation story and a real risk of an accidental `git add -A`. Droplet-side generation
+means the only copy of the private key lives on the one machine that actually uses it,
+and is never transmitted anywhere — not even over the ansible control channel.
+
+Only the **public** key is ever read off the droplet, and only by this role: the task
+`Read the rustd.xyz backup public key from the projects droplet`
+(`tasks/main.yml`) delegates a live `ansible.builtin.slurp` back to the projects host
+(`rustd_backup_nas_projects_host`, must match the `projects` inventory host) from within
+this (`nas.yml`) play. No cross-playbook fact sharing or combined-invocation requirement
+— `projects.yml` and `nas.yml` stay independently runnable plays; this one just needs the
+key to already exist on disk over on the projects host.
+
+## First-run ordering
+
+**`nas.yml` (this role) must run *after* `projects.yml` has run at least once on the
+projects host.** The slurp task above reads
+`rustd_backup_nas_pubkey_path` (`/root/.ssh/rustd-backup_ed25519.pub`) off the projects
+droplet; that file doesn't exist until the `rustd_xyz` role's key-generation task has run
+there. If `nas.yml` is run first (or against a projects host that has never run
+`rustd_xyz`), the slurp task fails with a missing-file error.
+
+This is not enforced by any `ansible-playbook` ordering or pre-flight check — it's a
+one-time bootstrap dependency between two otherwise-independent playbooks. See the
+deploy runbook in
+`docs/superpowers/specs/2026-08-11-rustd-xyz-prod-deploy-design.md`, which sequences
+`projects.yml` before the `nas.yml` run that authorizes the backup key. After the first
+successful run on both sides, re-running either playbook is idempotent and the ordering
+no longer matters (the key already exists on the droplet and is already authorized on
+the nas).
+
+## Restricted key
+
+The authorized key is restricted with `command="rrsync -wo <path>",restrict` when
+`rrsync` is available (it is, on Debian/Ubuntu). This confines the key to write-only
+rsync into the one backups directory — no shell, no read-back, no port/agent/X11
+forwarding. If `rrsync` were ever unavailable, the role falls back to a plain
+(unrestricted) key on the same dedicated, single-purpose system user — weaker, but still
+scoped to a user with no other role on the box.
+
+`rustd-backup` gets a real shell (`/bin/bash`), not `nologin`: `sshd` runs the
+`authorized_keys` forced `command=` regardless of login shell, but some PAM
+configurations (`pam_shells`) reject the session at the account phase before that if the
+shell isn't listed in `/etc/shells` — which would break the restricted key too, not just
+interactive login.
+
+## Prune ownership
+
+Nas-side retention (`rustd_xyz_backup_nas_keep`, 30 days) is owned entirely by this
+role's `cron` job:
+
+```
+find {{ rustd_xyz_backup_nas_path }} -maxdepth 1 -name 'rustd-*.dump' -mtime +{{ rustd_xyz_backup_nas_keep }} -delete
+```
+
+The push script never deletes anything on the nas — only its own local copy, kept to
+`rustd_xyz_backup_local_keep` (7 days). This keeps exactly one owner per retention
+window: local pruning is the droplet's job, nas pruning is this role's job.
+
+## Shared coordinates
+
+`rustd_xyz_backup_nas_host`/`_user`/`_path`/`_keep` are shared between this role and
+`rustd_xyz` (they describe the same pipeline from both ends) and live in
+`ansible/group_vars/all.yml`, not in either role's `defaults/main.yml` — `projects.yml`
+and `nas.yml` are separate playbook runs with no common `vars_files`, so neither role's
+own defaults are visible to the other. See the comment in `group_vars/all.yml` for why.

--- a/ansible/roles/rustd_backup_nas/README.md
+++ b/ansible/roles/rustd_backup_nas/README.md
@@ -13,12 +13,15 @@ the other side.
   `nologin` — see "Restricted key" below for why).
 - Creates the backup target directory (`rustd_xyz_backup_nas_path`,
   `/volume1/storage/backups/rustd-db`), owned by `rustd-backup`, mode `0700`.
-- Installs `rrsync` from the rsync package's bundled gzipped script
-  (`/usr/share/doc/rsync/scripts/rrsync.gz` → `/usr/local/bin/rrsync`) if not already
-  present.
+- Locates `rrsync` — packaged directly by rsync ≥ 3.2.5 at `/usr/bin/rrsync` or
+  `/usr/local/bin/rrsync`, or as a last resort extracted from the older gzipped-script
+  packaging (`/usr/share/doc/rsync/scripts/rrsync.gz` → `/usr/local/bin/rrsync`).
+  **rrsync is a required dependency of this role**: if it can't be found anywhere, the
+  play fails with a clear message rather than silently falling back to an unrestricted
+  key — see "Restricted key" below.
 - Slurps the backup public key live off the projects droplet (see "Key flow" below) and
   authorizes it in `rustd-backup`'s `authorized_keys`, restricted to a forced write-only
-  `rrsync` command when available.
+  `rrsync` command.
 - Prunes backups older than `rustd_xyz_backup_nas_keep` (30 days) via a `cron` job — the
   nas is the **sole owner** of nas-side retention. The push script
   (`rustd-db-backup.sh.j2`, in `rustd_xyz`) never deletes anything remote; it only prunes
@@ -69,12 +72,28 @@ the nas).
 
 ## Restricted key
 
-The authorized key is restricted with `command="rrsync -wo <path>",restrict` when
-`rrsync` is available (it is, on Debian/Ubuntu). This confines the key to write-only
-rsync into the one backups directory — no shell, no read-back, no port/agent/X11
-forwarding. If `rrsync` were ever unavailable, the role falls back to a plain
-(unrestricted) key on the same dedicated, single-purpose system user — weaker, but still
-scoped to a user with no other role on the box.
+The authorized key is restricted with `command="<rrsync> -wo <rustd_xyz_backup_nas_path>",restrict`.
+This confines the key to write-only rsync into the one backups directory — no shell, no
+read-back, no port/agent/X11 forwarding.
+
+`rrsync` is **mandatory**, not a best-effort hardening: if it can't be found in any of
+`rustd_backup_nas_rrsync_paths` and the gz fallback doesn't exist either, the role's
+`Fail if rrsync isn't available anywhere` task aborts the play. There is no unrestricted
+fallback key. Two things depend on that fail-closed behaviour:
+
+1. Security — a plain key on `rustd-backup` would grant a full interactive shell to
+   whoever holds the (droplet-generated) private key, not just a write into one
+   directory.
+2. **Path contract with the push side.** rrsync re-roots an absolute destination path
+   under its own `DIR` argument (`rustd_xyz_backup_nas_path`) instead of treating it as
+   a literal filesystem path — so the push script (`rustd-db-backup.sh.j2`, in
+   `rustd_xyz`) can't rsync to `rustd_xyz_backup_nas_path` again on the wire, that would
+   land at `DIR` + `DIR`. Instead it hardcodes its destination as the bare root (`:/`),
+   which rrsync resolves as "the restricted directory itself". That hardcoding is only
+   safe because the key is *always* rrsync-restricted — under a plain, unrestricted key,
+   `:/` would mean the literal filesystem root. Making rrsync mandatory removes that
+   ambiguity instead of making the push script branch on which kind of key it might be
+   talking to.
 
 `rustd-backup` gets a real shell (`/bin/bash`), not `nologin`: `sshd` runs the
 `authorized_keys` forced `command=` regardless of login shell, but some PAM

--- a/ansible/roles/rustd_backup_nas/defaults/main.yml
+++ b/ansible/roles/rustd_backup_nas/defaults/main.yml
@@ -14,6 +14,10 @@ rustd_backup_nas_projects_host: projects
 
 # Where the SSH keypair for backups lives on the projects droplet - must
 # match rustd_xyz_backup_ssh_key_path in roles/rustd_xyz/defaults/main.yml.
+#
+# Sync contract: this is that var's path + ".pub". No shared vars_file
+# enforces the two paths agreeing (rustd_xyz runs in projects.yml, this role
+# in nas.yml) - if you change one, change the other.
 rustd_backup_nas_pubkey_path: /root/.ssh/rustd-backup_ed25519.pub
 
 # rrsync (restricted rsync wrapper) - shipped as a gzipped script alongside

--- a/ansible/roles/rustd_backup_nas/defaults/main.yml
+++ b/ansible/roles/rustd_backup_nas/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+# rustd_backup_nas role defaults
+#
+# Receiving end of the rustd.xyz nightly pg_dump pipeline: the user, target
+# directory, and prune cron on the nas. The shared coordinates with the
+# pushing end (rustd_xyz role, projects.yml) - host/user/path/keep-count -
+# live in group_vars/all.yml (rustd_xyz_backup_nas_*), not here, since both
+# roles run in separate playbooks with no common vars_file. See the comment
+# there for why.
+
+# Inventory host (in the "projects" play) the backup key is generated on and
+# read back from. Must match the `projects` entry in ansible/inventory.yml.
+rustd_backup_nas_projects_host: projects
+
+# Where the SSH keypair for backups lives on the projects droplet - must
+# match rustd_xyz_backup_ssh_key_path in roles/rustd_xyz/defaults/main.yml.
+rustd_backup_nas_pubkey_path: /root/.ssh/rustd-backup_ed25519.pub
+
+# rrsync (restricted rsync wrapper) - shipped as a gzipped script alongside
+# the rsync package on Debian/Ubuntu, not installed as a binary by default.
+rustd_backup_nas_rrsync_gz: /usr/share/doc/rsync/scripts/rrsync.gz
+rustd_backup_nas_rrsync_bin: /usr/local/bin/rrsync

--- a/ansible/roles/rustd_backup_nas/defaults/main.yml
+++ b/ansible/roles/rustd_backup_nas/defaults/main.yml
@@ -20,7 +20,15 @@ rustd_backup_nas_projects_host: projects
 # in nas.yml) - if you change one, change the other.
 rustd_backup_nas_pubkey_path: /root/.ssh/rustd-backup_ed25519.pub
 
-# rrsync (restricted rsync wrapper) - shipped as a gzipped script alongside
-# the rsync package on Debian/Ubuntu, not installed as a binary by default.
+# rrsync (restricted rsync wrapper) is a REQUIRED dependency of this role -
+# see tasks/main.yml ("Fail if rrsync isn't available") and the README
+# ("Restricted key"). rsync >= 3.2.5 (current Debian/Ubuntu) ships it as a
+# real binary in one of these locations; checked in order, first match wins.
+rustd_backup_nas_rrsync_paths:
+  - /usr/bin/rrsync
+  - /usr/local/bin/rrsync
+
+# Last-resort fallback for older rsync packaging that only ships rrsync as a
+# gzipped script alongside the rsync package, not installed as a binary.
 rustd_backup_nas_rrsync_gz: /usr/share/doc/rsync/scripts/rrsync.gz
 rustd_backup_nas_rrsync_bin: /usr/local/bin/rrsync

--- a/ansible/roles/rustd_backup_nas/tasks/main.yml
+++ b/ansible/roles/rustd_backup_nas/tasks/main.yml
@@ -32,19 +32,20 @@
     group: "{{ rustd_xyz_backup_nas_user }}"
     mode: "0700"
 
-- name: Check for the rrsync helper script shipped with rsync
+- name: Check for rrsync in its packaged locations (rsync >= 3.2.5 ships it directly)
+  become: true
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  register: rustd_backup_nas_rrsync_stat
+  loop: "{{ rustd_backup_nas_rrsync_paths }}"
+
+- name: Check for the rrsync helper script shipped with older rsync packages (last-resort fallback)
   become: true
   ansible.builtin.stat:
     path: "{{ rustd_backup_nas_rrsync_gz }}"
   register: rustd_backup_nas_rrsync_gz_stat
 
-- name: Check whether rrsync is already installed
-  become: true
-  ansible.builtin.stat:
-    path: "{{ rustd_backup_nas_rrsync_bin }}"
-  register: rustd_backup_nas_rrsync_bin_stat
-
-- name: Install rrsync from the rsync package's bundled script
+- name: Install rrsync from the rsync package's bundled script (last-resort fallback)
   become: true
   ansible.builtin.shell: |  # noqa: command-instead-of-module
     set -o pipefail
@@ -53,15 +54,37 @@
   args:
     creates: "{{ rustd_backup_nas_rrsync_bin }}"
     executable: /bin/bash
-  when: rustd_backup_nas_rrsync_gz_stat.stat.exists
+  when:
+    - rustd_backup_nas_rrsync_gz_stat.stat.exists
+    - rustd_backup_nas_rrsync_stat.results | selectattr('stat.exists') | list | length == 0
 
-# rrsync availability is a repo/OS-packaging fact, not a secret, so this is
-# safe to compute unconditionally (used below to pick the authorized_keys
-# restriction).
-- name: Determine rrsync availability
+# rrsync is a REQUIRED dependency of this role, not an optional hardening:
+# the push script on the other end (rustd_xyz role's rustd-db-backup.sh.j2)
+# hardcodes its rsync destination as the bare root (":/") on the assumption
+# that the key it pushes with is always rrsync-restricted to
+# rustd_xyz_backup_nas_path - rrsync re-roots that ":/" under its own DIR
+# argument, landing writes exactly there. A silent fallback to an
+# unrestricted key here would both defeat the restriction (full shell access
+# for whoever holds the private key) and break that path contract (":/"
+# would mean the literal filesystem root over an unrestricted connection),
+# so this role fails closed instead of falling back. See the README's
+# "Restricted key" section.
+- name: Resolve the rrsync binary path
   ansible.builtin.set_fact:
-    rustd_backup_nas_rrsync_available: >-
-      {{ rustd_backup_nas_rrsync_gz_stat.stat.exists or rustd_backup_nas_rrsync_bin_stat.stat.exists }}
+    rustd_backup_nas_rrsync_path: >-
+      {{ (rustd_backup_nas_rrsync_stat.results | selectattr('stat.exists') | map(attribute='item') | list
+          + ([rustd_backup_nas_rrsync_bin] if rustd_backup_nas_rrsync_gz_stat.stat.exists else []))
+         | first | default('', true) }}
+
+- name: Fail if rrsync isn't available anywhere
+  ansible.builtin.fail:
+    msg: >-
+      rrsync not found at {{ rustd_backup_nas_rrsync_paths | join(', ') }}, and the
+      gz fallback ({{ rustd_backup_nas_rrsync_gz }}) doesn't exist either. rrsync is
+      a required dependency of this role (see README.md, "Restricted key") - install
+      a version of rsync that ships it (>= 3.2.5) or make rrsync available some other
+      way, then re-run.
+  when: rustd_backup_nas_rrsync_path == ''
 
 # The droplet generates its own keypair at deploy time (rustd_xyz role) and
 # never gives up the private half - see that role's tasks/main.yml for why.
@@ -84,15 +107,13 @@
     key: "{{ rustd_backup_nas_pubkey_slurp.content | b64decode }}"
     # restrict + a forced write-only rrsync command: the key can only push
     # files into rustd_xyz_backup_nas_path, nothing else (no shell, no
-    # port/agent/X11 forwarding, no read-back). Falls back to a plain key
-    # (still a dedicated, single-purpose system user, but capable of a full
-    # interactive session) if rrsync isn't available on this nas - see the
-    # role README for the tradeoff.
+    # port/agent/X11 forwarding, no read-back). rrsync is now mandatory (see
+    # the fail task above), so there is no unrestricted-key fallback here.
     key_options: >-
-      {{ 'command="' + rustd_backup_nas_rrsync_bin + ' -wo ' + rustd_xyz_backup_nas_path + '",restrict'
-         if rustd_backup_nas_rrsync_available else omit }}
+      command="{{ rustd_backup_nas_rrsync_path }} -wo {{ rustd_xyz_backup_nas_path }}",restrict
 
 - name: Prune rustd.xyz backups older than the retention window
+  become: true
   ansible.builtin.cron:
     name: "prune rustd.xyz db backups"
     user: "{{ rustd_xyz_backup_nas_user }}"

--- a/ansible/roles/rustd_backup_nas/tasks/main.yml
+++ b/ansible/roles/rustd_backup_nas/tasks/main.yml
@@ -1,0 +1,103 @@
+---
+# Receiving end of the rustd.xyz nightly pg_dump backup pipeline: user,
+# target directory, restricted key, and prune cron. rustd_xyz (projects.yml)
+# owns the push side; this role owns everything on the nas, including
+# pruning - see rustd_xyz/templates/rustd-db-backup.sh.j2's header comment.
+
+- name: Ensure rsync is installed (needed for both the transfer and rrsync)
+  become: true
+  ansible.builtin.apt:
+    name: rsync
+    state: present
+  when: ansible_os_family == "Debian"
+
+- name: Create the rustd-backup user
+  become: true
+  ansible.builtin.user:
+    name: "{{ rustd_xyz_backup_nas_user }}"
+    system: true
+    # A real shell, not nologin: sshd runs the authorized_keys `command=`
+    # regardless of login shell, but some PAM configs (pam_shells) reject
+    # the session at the account phase before that if the shell isn't
+    # listed in /etc/shells, which would break the restricted key too.
+    shell: /bin/bash
+    create_home: true
+
+- name: Create the rustd.xyz backup target directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ rustd_xyz_backup_nas_path }}"
+    state: directory
+    owner: "{{ rustd_xyz_backup_nas_user }}"
+    group: "{{ rustd_xyz_backup_nas_user }}"
+    mode: "0700"
+
+- name: Check for the rrsync helper script shipped with rsync
+  become: true
+  ansible.builtin.stat:
+    path: "{{ rustd_backup_nas_rrsync_gz }}"
+  register: rustd_backup_nas_rrsync_gz_stat
+
+- name: Check whether rrsync is already installed
+  become: true
+  ansible.builtin.stat:
+    path: "{{ rustd_backup_nas_rrsync_bin }}"
+  register: rustd_backup_nas_rrsync_bin_stat
+
+- name: Install rrsync from the rsync package's bundled script
+  become: true
+  ansible.builtin.shell: |  # noqa: command-instead-of-module
+    set -o pipefail
+    gunzip -c {{ rustd_backup_nas_rrsync_gz }} > {{ rustd_backup_nas_rrsync_bin }}
+    chmod 0755 {{ rustd_backup_nas_rrsync_bin }}
+  args:
+    creates: "{{ rustd_backup_nas_rrsync_bin }}"
+    executable: /bin/bash
+  when: rustd_backup_nas_rrsync_gz_stat.stat.exists
+
+# rrsync availability is a repo/OS-packaging fact, not a secret, so this is
+# safe to compute unconditionally (used below to pick the authorized_keys
+# restriction).
+- name: Determine rrsync availability
+  ansible.builtin.set_fact:
+    rustd_backup_nas_rrsync_available: >-
+      {{ rustd_backup_nas_rrsync_gz_stat.stat.exists or rustd_backup_nas_rrsync_bin_stat.stat.exists }}
+
+# The droplet generates its own keypair at deploy time (rustd_xyz role) and
+# never gives up the private half - see that role's tasks/main.yml for why.
+# Only the public key is read back here, live, by delegating to the
+# projects host from within this (nas.yml) play. This keeps the two
+# playbooks independently runnable: nas.yml doesn't need projects.yml to
+# have run in the same ansible-playbook invocation, only that the key
+# already exists on disk over there (true after the first rustd_xyz run).
+- name: Read the rustd.xyz backup public key from the projects droplet
+  become: true
+  delegate_to: "{{ rustd_backup_nas_projects_host }}"
+  ansible.builtin.slurp:
+    src: "{{ rustd_backup_nas_pubkey_path }}"
+  register: rustd_backup_nas_pubkey_slurp
+
+- name: Authorize the rustd.xyz backup key
+  become: true
+  ansible.posix.authorized_key:
+    user: "{{ rustd_xyz_backup_nas_user }}"
+    key: "{{ rustd_backup_nas_pubkey_slurp.content | b64decode }}"
+    # restrict + a forced write-only rrsync command: the key can only push
+    # files into rustd_xyz_backup_nas_path, nothing else (no shell, no
+    # port/agent/X11 forwarding, no read-back). Falls back to a plain key
+    # (still a dedicated, single-purpose system user, but capable of a full
+    # interactive session) if rrsync isn't available on this nas - see the
+    # role README for the tradeoff.
+    key_options: >-
+      {{ 'command="' + rustd_backup_nas_rrsync_bin + ' -wo ' + rustd_xyz_backup_nas_path + '",restrict'
+         if rustd_backup_nas_rrsync_available else omit }}
+
+- name: Prune rustd.xyz backups older than the retention window
+  ansible.builtin.cron:
+    name: "prune rustd.xyz db backups"
+    user: "{{ rustd_xyz_backup_nas_user }}"
+    minute: "30"
+    hour: "5"
+    job: >-
+      find {{ rustd_xyz_backup_nas_path }} -maxdepth 1 -name 'rustd-*.dump'
+      -mtime +{{ rustd_xyz_backup_nas_keep }} -delete

--- a/ansible/roles/rustd_backup_nas/tasks/main.yml
+++ b/ansible/roles/rustd_backup_nas/tasks/main.yml
@@ -48,9 +48,10 @@
 - name: Install rrsync from the rsync package's bundled script (last-resort fallback)
   become: true
   ansible.builtin.shell: |  # noqa: command-instead-of-module
-    set -o pipefail
-    gunzip -c {{ rustd_backup_nas_rrsync_gz }} > {{ rustd_backup_nas_rrsync_bin }}
-    chmod 0755 {{ rustd_backup_nas_rrsync_bin }}
+    set -euo pipefail
+    gunzip -c {{ rustd_backup_nas_rrsync_gz }} > {{ rustd_backup_nas_rrsync_bin }}.tmp
+    chmod 0755 {{ rustd_backup_nas_rrsync_bin }}.tmp
+    mv {{ rustd_backup_nas_rrsync_bin }}.tmp {{ rustd_backup_nas_rrsync_bin }}
   args:
     creates: "{{ rustd_backup_nas_rrsync_bin }}"
     executable: /bin/bash

--- a/ansible/roles/rustd_xyz/README.md
+++ b/ansible/roles/rustd_xyz/README.md
@@ -12,7 +12,8 @@ GHCR-login / container-deploy shape.
   and `rustd-db` (to reach postgres). `VIRTUAL_HOST`/`LETSENCRYPT_HOST` are the
   **apex domain only** (`rustd.xyz`) — never add `www`, it breaks the
   `__Host-` prefixed auth cookie.
-- `/opt/rustd` and `/opt/rustd/backups` on the host, plus a
+- `/opt/rustd` (`0755`) and `/opt/rustd/backups` (`0700` — dumps hold RCON
+  credentials, so the directory isn't world-readable) on the host, plus a
   `rustd-db-backup.timer` (04:30 daily, 15m random delay) that runs
   `rustd-db-backup.sh`: `pg_dump`s `rustd-db`, keeps the newest
   `rustd_xyz_backup_local_keep` dumps locally, and `rsync`s the whole
@@ -39,8 +40,13 @@ Given a `pg_dump -Fc` dump (see the backup script), restore into a running
 `rustd-db` container with:
 
 ```bash
-docker exec -i rustd-db pg_restore -U rustd -d rustd --clean < dump.dump
+docker exec -i rustd-db pg_restore -U rustd -d rustd --clean --if-exists < dump.dump
 ```
+
+`--if-exists` (paired with `--clean`) suppresses the "does not exist" errors
+`pg_restore` would otherwise print for every object it tries to drop before
+recreating on a database that doesn't already have them — expected when
+restoring into a fresh/empty `rustd-db`, not a sign the restore failed.
 
 ## Secrets
 
@@ -55,7 +61,8 @@ created manually by the operator before the first deploy.
 `rustd-db-backup.sh` (templated to `/opt/rustd/rustd-db-backup.sh`) pg_dumps
 `rustd-db` in custom (`-Fc`) format, prunes local dumps beyond
 `rustd_xyz_backup_local_keep` (7), then `rsync`s the backups directory to
-`rustd_xyz_backup_nas_user@rustd_xyz_backup_nas_host:rustd_xyz_backup_nas_path`.
+`rustd_xyz_backup_nas_user@rustd_xyz_backup_nas_host:/` — the bare root, not
+`rustd_xyz_backup_nas_path`; see "Push destination is `:/`" below for why.
 The nas keeps `rustd_xyz_backup_nas_keep` (30) and owns pruning its own copy
 (cron, in the `rustd_backup_nas` role run by `nas.yml`) — the push script
 never deletes anything remote, so there is exactly one owner of nas-side
@@ -80,14 +87,21 @@ droplet means the only copy of the private key lives on the one machine
 that uses it, is never transmitted over the control channel at all, and
 needs no 1Password item.
 
-The authorized key is restricted with `command="rrsync -wo <path>",restrict`
-when `rrsync` is available (it is, on Debian/Ubuntu — shipped gzipped at
-`/usr/share/doc/rsync/scripts/rrsync.gz`, installed to `/usr/local/bin/rrsync`
-by the `rustd_backup_nas` role). This confines the key to write-only rsync
-into the one backups directory — no shell, no read-back, no port/agent/X11
-forwarding. If `rrsync` were ever unavailable, the role falls back to a
-plain (unrestricted) key on the same dedicated, single-purpose system user —
-weaker, but still scoped to a user with no other role on the box.
+The authorized key is restricted with `command="<rrsync> -wo <rustd_xyz_backup_nas_path>",restrict`
+(`rustd_backup_nas` role — `rrsync` is a *required* dependency there: the role
+fails its play if it can't find it, rather than falling back to a plain key).
+This confines the key to write-only rsync into the one backups directory —
+no shell, no read-back, no port/agent/X11 forwarding.
+
+**Push destination is `:/`, not the nas-side path.** rrsync re-roots an
+absolute destination path under its own restricted directory instead of
+treating it as a literal filesystem path, so rsyncing to
+`rustd_xyz_backup_nas_path` on the wire would land at `DIR` + `DIR`, not
+`DIR`. `rustd-db-backup.sh.j2` therefore hardcodes its destination as the
+bare root (`:/`), which rrsync resolves as "the restricted directory
+itself". That hardcoding relies on the key always being rrsync-restricted —
+see `rustd_backup_nas`'s README ("Restricted key") for why that's now
+guaranteed rather than best-effort.
 
 ## Mailer TLS
 

--- a/ansible/roles/rustd_xyz/README.md
+++ b/ansible/roles/rustd_xyz/README.md
@@ -1,0 +1,56 @@
+# rustd_xyz Role
+
+Deploys the rustd.xyz panel (Quarkus app, GHCR image) and its postgres database
+on the projects droplet, behind `nginx-proxy`. Mirrors `sair_portal`'s
+GHCR-login / container-deploy shape.
+
+## What it deploys
+
+- `rustd-db` — `postgres:17`, on a private `rustd-db` docker network, data on
+  the named volume `rustd-db-data`. Not reachable from `nginx-proxy`.
+- `rustd-xyz` — the panel container, on both `nginx-proxy` (for TLS routing)
+  and `rustd-db` (to reach postgres). `VIRTUAL_HOST`/`LETSENCRYPT_HOST` are the
+  **apex domain only** (`rustd.xyz`) — never add `www`, it breaks the
+  `__Host-` prefixed auth cookie.
+- `/opt/rustd` and `/opt/rustd/backups` on the host (the backups directory is
+  populated by the nightly pg_dump timer added in a later change).
+
+## Rollback
+
+Pin `rustd_xyz_image` to a specific tag, e.g. `ghcr.io/compscidr/rustd.xyz:sha-<sha>`,
+and re-run the play. `recreate: true` on the container task means the next run
+picks up the pin immediately.
+
+## First deploy / claim flow
+
+rustd.xyz's first-boot flow issues a one-time claim token instead of a seeded
+admin password. After the first deploy, check the container logs for it:
+
+```bash
+docker logs rustd-xyz
+```
+
+## Restore drill
+
+Given a `pg_dump -Fc` dump (see the backup script), restore into a running
+`rustd-db` container with:
+
+```bash
+docker exec -i rustd-db pg_restore -U rustd -d rustd --clean < dump.dump
+```
+
+## Secrets
+
+All secrets (`rustd_xyz_ghcr_token`, `rustd_xyz_db_password`,
+`rustd_xyz_smtp_username`, `rustd_xyz_smtp_password`) are 1Password lookups
+set as `vars` in `projects.yml` — never hardcoded in `defaults/main.yml`.
+The postgres password comes from the `rustd-db` item (Infrastructure vault),
+created manually by the operator before the first deploy.
+
+## Mailer TLS
+
+`rustd_xyz_smtp_port` is `465` — Mailu's implicit-TLS submissions port. The
+app container sets `QUARKUS_MAILER_TLS=true` (not `QUARKUS_MAILER_SSL`, the
+deprecated alias, and not `QUARKUS_MAILER_START_TLS`, which is a different,
+opt-in-STARTTLS-on-a-plaintext-connection knob). See `tasks/main.yml` for the
+version-specific evidence.

--- a/ansible/roles/rustd_xyz/README.md
+++ b/ansible/roles/rustd_xyz/README.md
@@ -12,8 +12,11 @@ GHCR-login / container-deploy shape.
   and `rustd-db` (to reach postgres). `VIRTUAL_HOST`/`LETSENCRYPT_HOST` are the
   **apex domain only** (`rustd.xyz`) — never add `www`, it breaks the
   `__Host-` prefixed auth cookie.
-- `/opt/rustd` and `/opt/rustd/backups` on the host (the backups directory is
-  populated by the nightly pg_dump timer added in a later change).
+- `/opt/rustd` and `/opt/rustd/backups` on the host, plus a
+  `rustd-db-backup.timer` (04:30 daily, 15m random delay) that runs
+  `rustd-db-backup.sh`: `pg_dump`s `rustd-db`, keeps the newest
+  `rustd_xyz_backup_local_keep` dumps locally, and `rsync`s the whole
+  backups directory to the nas over a dedicated ed25519 key.
 
 ## Rollback
 
@@ -46,6 +49,45 @@ All secrets (`rustd_xyz_ghcr_token`, `rustd_xyz_db_password`,
 set as `vars` in `projects.yml` — never hardcoded in `defaults/main.yml`.
 The postgres password comes from the `rustd-db` item (Infrastructure vault),
 created manually by the operator before the first deploy.
+
+## Nightly backup -> nas
+
+`rustd-db-backup.sh` (templated to `/opt/rustd/rustd-db-backup.sh`) pg_dumps
+`rustd-db` in custom (`-Fc`) format, prunes local dumps beyond
+`rustd_xyz_backup_local_keep` (7), then `rsync`s the backups directory to
+`rustd_xyz_backup_nas_user@rustd_xyz_backup_nas_host:rustd_xyz_backup_nas_path`.
+The nas keeps `rustd_xyz_backup_nas_keep` (30) and owns pruning its own copy
+(cron, in the `rustd_backup_nas` role run by `nas.yml`) — the push script
+never deletes anything remote, so there is exactly one owner of nas-side
+retention.
+
+**Key flow.** The role generates a dedicated ed25519 keypair on this droplet
+the first time it runs (`ssh-keygen ... creates=...` — `community.crypto`
+isn't in `requirements.yml`, so this doesn't use `openssh_keypair`). The
+private key is created here and never leaves this host: not copied to the
+ansible controller, not put in 1Password, not templated anywhere. Only the
+*public* key is ever read off the box — the `rustd_backup_nas` role, running
+`nas.yml` against the nas, delegates a `slurp` task back to this host to
+fetch it live and authorize it in `rustd-backup`'s `authorized_keys`.
+
+This is the opposite of the design doc's stated default (generate the
+keypair on the ansible controller and template private key -> droplet,
+public key -> nas). That version would leave private key material sitting
+in a file on the operator's own machine with no 1Password entry and no
+place in this repo's secret model to account for it — exactly the kind of
+controller-local artifact this repo otherwise avoids. Generating on the
+droplet means the only copy of the private key lives on the one machine
+that uses it, is never transmitted over the control channel at all, and
+needs no 1Password item.
+
+The authorized key is restricted with `command="rrsync -wo <path>",restrict`
+when `rrsync` is available (it is, on Debian/Ubuntu — shipped gzipped at
+`/usr/share/doc/rsync/scripts/rrsync.gz`, installed to `/usr/local/bin/rrsync`
+by the `rustd_backup_nas` role). This confines the key to write-only rsync
+into the one backups directory — no shell, no read-back, no port/agent/X11
+forwarding. If `rrsync` were ever unavailable, the role falls back to a
+plain (unrestricted) key on the same dedicated, single-purpose system user —
+weaker, but still scoped to a user with no other role on the box.
 
 ## Mailer TLS
 

--- a/ansible/roles/rustd_xyz/defaults/main.yml
+++ b/ansible/roles/rustd_xyz/defaults/main.yml
@@ -24,3 +24,16 @@ rustd_xyz_smtp_host: "mail.rustd.xyz"
 rustd_xyz_smtp_port: 465
 rustd_xyz_smtp_username: ""
 rustd_xyz_smtp_password: ""
+
+# Nightly pg_dump -> nas backup (role-local half; the nas-side coordinates
+# of this same pipeline - rustd_xyz_backup_nas_host/_user/_path/_keep - live
+# in group_vars/all.yml, because they're also consumed by the
+# rustd_backup_nas role in the separate nas.yml playbook run, which never
+# loads this role's defaults. See group_vars/all.yml for why.)
+rustd_xyz_backup_local_dir: "{{ rustd_xyz_base_path }}/backups"
+rustd_xyz_backup_local_keep: 7
+# ed25519 keypair generated ON THIS DROPLET the first time the role runs
+# (see tasks/main.yml) - private key never leaves this host or touches the
+# ansible controller. Only the public half is ever read off the box, by the
+# nas play delegating a slurp back to this host.
+rustd_xyz_backup_ssh_key_path: /root/.ssh/rustd-backup_ed25519

--- a/ansible/roles/rustd_xyz/defaults/main.yml
+++ b/ansible/roles/rustd_xyz/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+# rustd.xyz role defaults
+# Panel + postgres for rustd.xyz on the projects droplet. Mirrors sair_portal:
+# GHCR image, nginx-proxy VIRTUAL_HOST TLS, secrets injected from projects.yml vars.
+
+rustd_xyz_image: "ghcr.io/compscidr/rustd.xyz:latest" # pin :sha-<sha> to roll back
+rustd_xyz_port: 8080
+rustd_xyz_domain: "rustd.xyz" # apex ONLY - the __Host- auth cookie forbids www
+rustd_xyz_letsencrypt_email: "ernstjason1@gmail.com"
+rustd_xyz_ghcr_token: ""
+rustd_xyz_ghcr_user: "compscidr"
+
+# Base directory on the droplet (config/backups live under here)
+rustd_xyz_base_path: "/opt/rustd"
+
+# Postgres
+rustd_xyz_db_image: "postgres:17"
+rustd_xyz_db_name: "rustd"
+rustd_xyz_db_user: "rustd"
+rustd_xyz_db_password: "" # from projects.yml (1Password item rustd-db)
+
+# SMTP for account claim / notification mail
+rustd_xyz_smtp_host: "mail.rustd.xyz"
+rustd_xyz_smtp_port: 465
+rustd_xyz_smtp_username: ""
+rustd_xyz_smtp_password: ""

--- a/ansible/roles/rustd_xyz/defaults/main.yml
+++ b/ansible/roles/rustd_xyz/defaults/main.yml
@@ -36,4 +36,9 @@ rustd_xyz_backup_local_keep: 7
 # (see tasks/main.yml) - private key never leaves this host or touches the
 # ansible controller. Only the public half is ever read off the box, by the
 # nas play delegating a slurp back to this host.
+#
+# Sync contract: rustd_backup_nas_pubkey_path (roles/rustd_backup_nas/defaults/main.yml,
+# consumed by nas.yml) must equal this path + ".pub". The two vars live in
+# separate roles/playbooks with no shared vars_file to enforce it in code -
+# if you change this path, update that one too.
 rustd_xyz_backup_ssh_key_path: /root/.ssh/rustd-backup_ed25519

--- a/ansible/roles/rustd_xyz/tasks/main.yml
+++ b/ansible/roles/rustd_xyz/tasks/main.yml
@@ -18,7 +18,7 @@
     mode: "0755"
   loop:
     - "{{ rustd_xyz_base_path }}"
-    - "{{ rustd_xyz_base_path }}/backups"
+    - "{{ rustd_xyz_backup_local_dir }}"
 
 - name: Create rustd-db network
   become: true
@@ -78,3 +78,62 @@
       VIRTUAL_PORT: "{{ rustd_xyz_port | string }}"
       LETSENCRYPT_HOST: "{{ rustd_xyz_domain }}"
       LETSENCRYPT_EMAIL: "{{ rustd_xyz_letsencrypt_email }}"
+
+# --- Nightly pg_dump -> nas backup ---------------------------------------
+#
+# Key flow: community.crypto isn't in requirements.yml (checked), so this
+# uses the ssh-keygen fallback the plan allows, not openssh_keypair.
+#
+# The keypair is generated HERE, on the droplet, rather than on the ansible
+# controller. The plan's stated lean was controller-side generation
+# (openssh_keypair at a controller path, then template private -> droplet +
+# pubkey -> nas), but that puts private key material on the operator's own
+# machine: it has to land in *some* file on the controller for the
+# subsequent copy/template task to read, and nothing in this repo's secret
+# model accounts for that file (it isn't a 1Password item, and unlike every
+# other secret here it would exist only as a controller-local artifact -
+# exactly the kind of thing that ends up accidentally `git add -A`'d, or
+# just left behind in a homedir with no rotation/audit story). Generating
+# on the droplet means the private half is created and stays on the one
+# machine that actually needs it, is never transmitted anywhere (not even
+# over the ansible control channel), and only the public half - not
+# sensitive - is ever read off the box, by the nas play's delegated slurp
+# (see roles/rustd_backup_nas/tasks/main.yml). No 1Password item is needed
+# for this key at all.
+- name: Generate the rustd.xyz backup SSH keypair (ed25519) on the droplet
+  become: true
+  ansible.builtin.command:
+    cmd: >
+      ssh-keygen -t ed25519 -f {{ rustd_xyz_backup_ssh_key_path }} -N ""
+      -C "rustd-backup@projects"
+  args:
+    creates: "{{ rustd_xyz_backup_ssh_key_path }}"
+
+- name: Deploy the backup script
+  become: true
+  ansible.builtin.template:
+    src: rustd-db-backup.sh.j2
+    dest: "{{ rustd_xyz_base_path }}/rustd-db-backup.sh"
+    mode: "0700"
+
+- name: Deploy the backup systemd service
+  become: true
+  ansible.builtin.template:
+    src: rustd-db-backup.service.j2
+    dest: /etc/systemd/system/rustd-db-backup.service
+    mode: "0644"
+
+- name: Deploy the backup systemd timer
+  become: true
+  ansible.builtin.template:
+    src: rustd-db-backup.timer.j2
+    dest: /etc/systemd/system/rustd-db-backup.timer
+    mode: "0644"
+
+- name: Enable and start the backup timer
+  become: true
+  ansible.builtin.systemd_service:
+    name: rustd-db-backup.timer
+    enabled: true
+    state: started
+    daemon_reload: true

--- a/ansible/roles/rustd_xyz/tasks/main.yml
+++ b/ansible/roles/rustd_xyz/tasks/main.yml
@@ -1,0 +1,80 @@
+---
+# Deploy rustd.xyz panel + postgres on the projects droplet
+
+- name: Log in to GHCR
+  become: true
+  community.docker.docker_login:
+    registry: ghcr.io
+    username: "{{ rustd_xyz_ghcr_user }}"
+    password: "{{ rustd_xyz_ghcr_token }}"
+  when: rustd_xyz_ghcr_token | length > 0
+  no_log: true
+
+- name: Create rustd base directories
+  become: true
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - "{{ rustd_xyz_base_path }}"
+    - "{{ rustd_xyz_base_path }}/backups"
+
+- name: Create rustd-db network
+  become: true
+  community.docker.docker_network:
+    name: rustd-db
+    state: present
+
+- name: Create rustd-db data volume
+  become: true
+  community.docker.docker_volume:
+    name: rustd-db-data
+
+- name: Deploy rustd postgres
+  become: true
+  no_log: true
+  community.docker.docker_container:
+    name: rustd-db
+    image: "{{ rustd_xyz_db_image }}"
+    restart_policy: unless-stopped
+    networks:
+      - name: rustd-db
+    volumes:
+      - "rustd-db-data:/var/lib/postgresql/data"
+    env:
+      POSTGRES_DB: "{{ rustd_xyz_db_name }}"
+      POSTGRES_USER: "{{ rustd_xyz_db_user }}"
+      POSTGRES_PASSWORD: "{{ rustd_xyz_db_password }}"
+
+- name: Deploy rustd.xyz panel
+  become: true
+  no_log: true
+  community.docker.docker_container:
+    name: rustd-xyz
+    image: "{{ rustd_xyz_image }}"
+    pull: true
+    recreate: true
+    restart_policy: unless-stopped
+    networks:
+      - name: nginx-proxy
+      - name: rustd-db
+    env:
+      QUARKUS_DATASOURCE_JDBC_URL: "jdbc:postgresql://rustd-db:5432/{{ rustd_xyz_db_name }}"
+      QUARKUS_DATASOURCE_USERNAME: "{{ rustd_xyz_db_user }}"
+      QUARKUS_DATASOURCE_PASSWORD: "{{ rustd_xyz_db_password }}"
+      QUARKUS_MAILER_HOST: "{{ rustd_xyz_smtp_host }}"
+      QUARKUS_MAILER_PORT: "{{ rustd_xyz_smtp_port | string }}"
+      QUARKUS_MAILER_USERNAME: "{{ rustd_xyz_smtp_username }}"
+      QUARKUS_MAILER_PASSWORD: "{{ rustd_xyz_smtp_password }}"
+      # Port 465 is Mailu's implicit-TLS submissions port. In Quarkus 3.38.x
+      # (io.quarkus:quarkus-mailer) quarkus.mailer.tls maps to
+      # Vert.x MailConfig#setSsl(true) - i.e. wrap-in-TLS-from-connect, which
+      # is what implicit TLS needs. quarkus.mailer.ssl is the deprecated
+      # alias for the same thing; quarkus.mailer.start-tls is a *different*
+      # knob (STARTTLS upgrade of a plaintext connection) and is wrong here.
+      QUARKUS_MAILER_TLS: "true"
+      VIRTUAL_HOST: "{{ rustd_xyz_domain }}"
+      VIRTUAL_PORT: "{{ rustd_xyz_port | string }}"
+      LETSENCRYPT_HOST: "{{ rustd_xyz_domain }}"
+      LETSENCRYPT_EMAIL: "{{ rustd_xyz_letsencrypt_email }}"

--- a/ansible/roles/rustd_xyz/tasks/main.yml
+++ b/ansible/roles/rustd_xyz/tasks/main.yml
@@ -10,15 +10,21 @@
   when: rustd_xyz_ghcr_token | length > 0
   no_log: true
 
-- name: Create rustd base directories
+- name: Create rustd base directory
   become: true
   ansible.builtin.file:
-    path: "{{ item }}"
+    path: "{{ rustd_xyz_base_path }}"
     state: directory
     mode: "0755"
-  loop:
-    - "{{ rustd_xyz_base_path }}"
-    - "{{ rustd_xyz_backup_local_dir }}"
+
+# 0700, not 0755: pg_dump dumps hold RCON credentials (and other rustd.xyz
+# secrets), so the directory they land in shouldn't be world-readable.
+- name: Create rustd backup directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ rustd_xyz_backup_local_dir }}"
+    state: directory
+    mode: "0700"
 
 - name: Create rustd-db network
   become: true

--- a/ansible/roles/rustd_xyz/templates/rustd-db-backup.service.j2
+++ b/ansible/roles/rustd_xyz/templates/rustd-db-backup.service.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=rustd.xyz nightly postgres dump, shipped to the nas
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart={{ rustd_xyz_base_path }}/rustd-db-backup.sh

--- a/ansible/roles/rustd_xyz/templates/rustd-db-backup.sh.j2
+++ b/ansible/roles/rustd_xyz/templates/rustd-db-backup.sh.j2
@@ -37,7 +37,16 @@ ls -1t {{ rustd_xyz_backup_local_dir }}/rustd-*.dump | tail -n +{{ rustd_xyz_bac
 # this script's *own* rsync step runs (e.g. someone manually re-invoking the
 # script while a prior invocation is still dumping) can never ship a partial
 # file to the nas either.
+#
+# Destination is the bare root (":/"), not {{ rustd_xyz_backup_nas_path }} -
+# this key is always rrsync-restricted on the nas side (rustd_backup_nas
+# role, which fails its own play if rrsync isn't available: see that role's
+# README, "Restricted key"). rrsync re-roots absolute destination paths
+# under its own DIR argument (rustd_xyz_backup_nas_path) rather than
+# treating them as literal filesystem paths, so sending the same path here
+# would double it (DIR + DIR) and every push would fail. ":/" is rrsync's
+# contract for "the restricted directory itself".
 rsync -az --timeout=60 --exclude '*.tmp' \
   -e "ssh -i {{ rustd_xyz_backup_ssh_key_path }} -o StrictHostKeyChecking=accept-new" \
   {{ rustd_xyz_backup_local_dir }}/ \
-  {{ rustd_xyz_backup_nas_user }}@{{ rustd_xyz_backup_nas_host }}:{{ rustd_xyz_backup_nas_path }}/
+  {{ rustd_xyz_backup_nas_user }}@{{ rustd_xyz_backup_nas_host }}:/

--- a/ansible/roles/rustd_xyz/templates/rustd-db-backup.sh.j2
+++ b/ansible/roles/rustd_xyz/templates/rustd-db-backup.sh.j2
@@ -10,13 +10,34 @@ set -euo pipefail
 
 STAMP="$(date +%F)"
 OUT="{{ rustd_xyz_backup_local_dir }}/rustd-${STAMP}.dump"
+TMP="${OUT}.tmp"
 
-docker exec rustd-db pg_dump -Fc -U {{ rustd_xyz_db_user }} {{ rustd_xyz_db_name }} > "${OUT}"
+# Belt-and-braces: a leftover .tmp from a previous killed/failed run must
+# not be mistaken for a valid dump, and must not silently accumulate.
+rm -f "${TMP}"
 
-# Keep the newest {{ rustd_xyz_backup_local_keep }} local dumps.
+# Dump to a temp name and only rename into place once pg_dump has fully
+# succeeded (set -e means a non-zero pg_dump exit aborts before the mv).
+# Without this, a pg_dump that dies partway (disk full, container OOM,
+# host reboot) leaves a truncated file at the FINAL name, which the next
+# night's successful run would then happily rsync to the nas as if it
+# were a good backup.
+docker exec rustd-db pg_dump -Fc -U {{ rustd_xyz_db_user }} {{ rustd_xyz_db_name }} > "${TMP}"
+mv "${TMP}" "${OUT}"
+
+# Keep the newest {{ rustd_xyz_backup_local_keep }} local dumps. Glob is
+# scoped to *.dump (not *.dump.tmp), so an in-progress dump from a
+# concurrent/overlapping run is never counted against the retention window
+# or pruned out from under itself.
 ls -1t {{ rustd_xyz_backup_local_dir }}/rustd-*.dump | tail -n +{{ rustd_xyz_backup_local_keep | int + 1 }} | xargs -r rm --
 
-rsync -az --timeout=60 \
+# --exclude '*.tmp': belt-and-braces again - even though rm -f above and the
+# rename-on-success above mean a .tmp should never coexist with a completed
+# run of this script, excluding it here means a dump that's mid-write when
+# this script's *own* rsync step runs (e.g. someone manually re-invoking the
+# script while a prior invocation is still dumping) can never ship a partial
+# file to the nas either.
+rsync -az --timeout=60 --exclude '*.tmp' \
   -e "ssh -i {{ rustd_xyz_backup_ssh_key_path }} -o StrictHostKeyChecking=accept-new" \
   {{ rustd_xyz_backup_local_dir }}/ \
   {{ rustd_xyz_backup_nas_user }}@{{ rustd_xyz_backup_nas_host }}:{{ rustd_xyz_backup_nas_path }}/

--- a/ansible/roles/rustd_xyz/templates/rustd-db-backup.sh.j2
+++ b/ansible/roles/rustd_xyz/templates/rustd-db-backup.sh.j2
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Managed by ansible (rustd_xyz role) - do not edit by hand.
+#
+# Nightly rustd.xyz postgres dump: pg_dump the rustd-db container, prune
+# local dumps beyond {{ rustd_xyz_backup_local_keep }}, then push everything
+# still on disk to the nas over rsync/ssh. Pruning of the *nas* copy is owned
+# by the nas side (cron in the rustd_backup_nas role) - this script never
+# deletes anything remotely.
+set -euo pipefail
+
+STAMP="$(date +%F)"
+OUT="{{ rustd_xyz_backup_local_dir }}/rustd-${STAMP}.dump"
+
+docker exec rustd-db pg_dump -Fc -U {{ rustd_xyz_db_user }} {{ rustd_xyz_db_name }} > "${OUT}"
+
+# Keep the newest {{ rustd_xyz_backup_local_keep }} local dumps.
+ls -1t {{ rustd_xyz_backup_local_dir }}/rustd-*.dump | tail -n +{{ rustd_xyz_backup_local_keep | int + 1 }} | xargs -r rm --
+
+rsync -az --timeout=60 \
+  -e "ssh -i {{ rustd_xyz_backup_ssh_key_path }} -o StrictHostKeyChecking=accept-new" \
+  {{ rustd_xyz_backup_local_dir }}/ \
+  {{ rustd_xyz_backup_nas_user }}@{{ rustd_xyz_backup_nas_host }}:{{ rustd_xyz_backup_nas_path }}/

--- a/ansible/roles/rustd_xyz/templates/rustd-db-backup.timer.j2
+++ b/ansible/roles/rustd_xyz/templates/rustd-db-backup.timer.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Nightly rustd.xyz postgres dump, shipped to the nas
+
+[Timer]
+OnCalendar=*-*-* 04:30:00
+Persistent=true
+RandomizedDelaySec=15m
+
+[Install]
+WantedBy=timers.target

--- a/docs/superpowers/specs/2026-08-11-rustd-xyz-prod-deploy-design.md
+++ b/docs/superpowers/specs/2026-08-11-rustd-xyz-prod-deploy-design.md
@@ -98,7 +98,8 @@ bouncing landing-page mailto from rustd.xyz#375.
 1. Create the `rustd-db` 1Password item (manual).
 2. Terraform resize (tenant downtime window).
 3. Merge the rustd.xyz PR → image appears on GHCR.
-4. Run the mail playbook → `contact@` alias live.
+4. Run `ansible-playbook -i inventory.yml jasonernst_com.yml --tags mailu --ask-become-pass`
+   (the mailu role lives in `jasonernst_com.yml`, hosts `www`) → `contact@` alias live.
 5. Run `projects.yml` (rustd tags) → postgres + app up, TLS issued, Flyway migrates.
 6. Run `nas.yml` (rustd-backup tags) → authorizes the backup key on the nas. **Must run
    after step 5, not before**: the `rustd_backup_nas` role slurps the backup public key

--- a/docs/superpowers/specs/2026-08-11-rustd-xyz-prod-deploy-design.md
+++ b/docs/superpowers/specs/2026-08-11-rustd-xyz-prod-deploy-design.md
@@ -1,0 +1,131 @@
+# rustd.xyz production deployment — design
+
+**Date:** 2026-08-11
+**Status:** Approved (brainstormed with Jason; all four forks decided by him)
+**Repos touched:** `compscidr/rustd.xyz` (image + prod config + publish workflow) and this repo (terraform resize, new ansible role, mailu alias, backups)
+**Prior art:** `docs/superpowers/specs/2026-08-05-rustd-xyz-dns-mail-design.md` (DNS/mail, #481 — apex already points at the projects droplet; `jason@` and `noreply@rustd.xyz` Mailu users already exist), the `sair_portal` role (the deployment shape this mirrors).
+
+## Goal
+
+rustd.xyz runs in production on the projects droplet: containerized Quarkus app behind the
+existing nginx-proxy/LetsEncrypt pair, postgres alongside it, magic-link mail through Mailu,
+nightly DB dumps to the nas, and a working `contact@rustd.xyz` (the landing page has linked it
+since rustd.xyz#375 — it currently bounces).
+
+## Decisions (made 2026-08-11)
+
+| Fork | Decision | Rejected alternatives |
+|---|---|---|
+| Capacity | Resize projects droplet to `s-2vcpu-4gb` (~$24/mo) | GraalVM native (Mina SSHD/krcon reflection risk), tuned-JVM-on-2GB (OOM risk with 7 tenant containers), separate droplet (more hosts) |
+| Image publish | Every merge to main → `ghcr.io/compscidr/rustd.xyz:latest` + `:<sha>` | Tagged releases (adds a release step to a merge-to-main project) |
+| Database | `postgres:17` container, named volume, nightly `pg_dump` shipped off-box | DO managed postgres ($15/mo), no-backup container |
+| Backup destination | nas over the tailnet (rsync over SSH, dedicated key) | DO Spaces (new bill + s3 plumbing), droplet-local only |
+
+## Part A — rustd.xyz repo
+
+### A1. Dockerfile
+
+Quarkus JVM fast-jar, two stages: `gradle build` (tests run in CI before this) → copy
+`build/quarkus-app` onto `eclipse-temurin:21-jre`, non-root user, `EXPOSE 8080`,
+`java -jar quarkus-run.jar`. No native image.
+
+### A2. Prod configuration
+
+Everything host-specific arrives as environment variables (Quarkus maps
+`QUARKUS_DATASOURCE_JDBC_URL`, `QUARKUS_DATASOURCE_USERNAME`, `QUARKUS_DATASOURCE_PASSWORD`,
+`QUARKUS_MAILER_HOST/PORT/USERNAME/PASSWORD/TLS` natively — no properties changes needed for
+those). `application.properties` gains only `%prod` entries that aren't env-shaped (audit at
+implementation time; expected: none or near-none — `rustd.auth.trust-forwarded-for` is already
+`%prod=true`, correct behind nginx-proxy's `X-Forwarded-For`; mailer mock is already dev/test-only).
+Flyway migrates on startup, so an empty prod DB self-initializes; the first-boot claim URL
+prints to the container log (`docker logs rustd-xyz`), and the panel starts private (demo and
+signup are DB-backed runtime switches, default off).
+
+### A3. Publish workflow
+
+`.github/workflows/publish.yml`: on push to `main` — gradle build (tests included), docker
+build, push `:latest` + `:<sha>` to GHCR. `:<sha>` tags are the rollback mechanism (set
+`rustd_xyz_image` to a pinned sha in ansible and re-run). Deploys remain explicit playbook runs
+— no watchtower, same as sair.
+
+## Part B — this repo
+
+### B1. Terraform: droplet resize
+
+`projects.tf`: `size = "s-1vcpu-2gb"` → `"s-2vcpu-4gb"`. In-place resize; **disk grows too and
+that is one-way** (can never resize back below the disk size). Requires a shutdown window of a
+few minutes for every tenant on the droplet.
+
+### B2. Ansible: new `rustd_xyz` role (mirrors `sair_portal`)
+
+- GHCR login (same PAT lookup as sair).
+- Private docker network `rustd-db` (the DB is never on `nginx-proxy`).
+- `postgres:17` container: named volume `rustd-db-data`, env from a **new 1Password item**
+  (`Infrastructure` vault, suggested name `rustd-db`) — the one manual pre-step.
+- App container `rustd-xyz`: image `ghcr.io/compscidr/rustd.xyz:latest` (var-overridable for
+  rollback), networks `nginx-proxy` + `rustd-db`, `pull: true`, `recreate: true`,
+  `restart_policy: unless-stopped`, env:
+  - `VIRTUAL_HOST=rustd.xyz`, `VIRTUAL_PORT=8080`, `LETSENCRYPT_HOST=rustd.xyz` — **apex only,
+    never www** (the `__Host-` auth cookie is pinned to the apex; #481's spec already documents
+    the no-www rule, and rustd.xyz must never be added to `www_redirect_domains`).
+  - `QUARKUS_DATASOURCE_*` pointing at the `rustd-db` network alias.
+  - `QUARKUS_MAILER_*` from the existing `SMTP_USER - rustd` 1Password item; host
+    `mail.rustd.xyz`, port 465 (sair's pattern is `mail.<domain>`:465 against the same Mailu —
+    the mail hostname is already on Mailu's SAN cert per #481).
+  - No `RUSTD_AUTH_BASE_URL` needed: `rustd.auth.base-url` already defaults to
+    `https://rustd.xyz` with dev/test overrides — the prod default is the prod value.
+- Wired into `projects.yml` after `www_redirect`, alongside the other roles.
+
+### B3. Backups
+
+Role-managed on the droplet: a script + systemd timer (`rustd-db-backup.timer`, nightly) that
+`docker exec`s `pg_dump -Fc` into `/opt/rustd/backups/`, prunes to 7 local dumps, and rsyncs
+the directory to the nas over the tailnet as a dedicated non-root user with a dedicated ed25519
+key. nas side (nas playbook): create the backup user + `authorized_keys` (restricted to rsync),
+target path on the storage pool, prune to 30 days. Network path needs no ACL change today
+(droplets are member devices; the member→`*` grant covers it) — **caveat:** if droplets are
+ever moved to tagged identities, a `projects → nas:22` grant must be added.
+
+### B4. Mailu: alias support + contact@
+
+The mailu role manages users but not aliases. Add an alias task (`flask mailu alias <local>
+<domain> <destination>`, same idempotent failed_when-tolerant shape as user creation) driven by
+a `mailu_aliases`-style var, and define `contact@rustd.xyz → jason@rustd.xyz`. This closes the
+bouncing landing-page mailto from rustd.xyz#375.
+
+## Runbook (deploy order)
+
+1. Create the `rustd-db` 1Password item (manual).
+2. Terraform resize (tenant downtime window).
+3. Merge the rustd.xyz PR → image appears on GHCR.
+4. Run the mail playbook → `contact@` alias live.
+5. Run `projects.yml` (rustd tags) → postgres + app up, TLS issued, Flyway migrates.
+6. `docker logs rustd-xyz` → claim URL → claim the panel.
+7. Add servers/credentials in the panel; flip demo/signup switches when ready to go public.
+8. Confirm first nightly backup landed on the nas.
+
+## Error handling / operational notes
+
+- App crash-loops (bad DB creds, Mailu unreachable): `restart_policy: unless-stopped` retries;
+  diagnosis via `docker logs`. Flyway failure aborts startup by design — never boots on a
+  half-migrated schema.
+- LetsEncrypt: apex cert issuance follows the same companion flow as every other tenant; DNS
+  already resolves, so no ordering hazard.
+- The panel dials OUT to game servers (RCON websocket, SSH) — no inbound ports beyond 443/80.
+- Postgres is reachable only on the `rustd-db` docker network; no published port.
+
+## Testing
+
+- rustd repo: existing full suite in CI gates the publish job; the Dockerfile is smoke-tested in
+  the workflow (container starts, `/q/health`-less — hit `/login` for 200) before push.
+- iac repo: `ansible-lint`/molecule per repo convention; the role's first real run IS the
+  deploy (matches how every other role here is validated).
+- Backup restore drill: after step 8, `pg_restore` the nas dump into a scratch container once,
+  documented in the role README.
+
+## Out of scope
+
+- Footer Privacy/Terms/GitHub placeholders (deferred separately).
+- Monitoring/alerting beyond fail2ban + docker restart policies (nothing else on the droplet
+  has it either).
+- Zero-downtime deploys (recreate = seconds of downtime; acceptable for this panel).

--- a/docs/superpowers/specs/2026-08-11-rustd-xyz-prod-deploy-design.md
+++ b/docs/superpowers/specs/2026-08-11-rustd-xyz-prod-deploy-design.md
@@ -100,9 +100,16 @@ bouncing landing-page mailto from rustd.xyz#375.
 3. Merge the rustd.xyz PR → image appears on GHCR.
 4. Run the mail playbook → `contact@` alias live.
 5. Run `projects.yml` (rustd tags) → postgres + app up, TLS issued, Flyway migrates.
-6. `docker logs rustd-xyz` → claim URL → claim the panel.
-7. Add servers/credentials in the panel; flip demo/signup switches when ready to go public.
-8. Confirm first nightly backup landed on the nas.
+6. Run `nas.yml` (rustd-backup tags) → authorizes the backup key on the nas. **Must run
+   after step 5, not before**: the `rustd_backup_nas` role slurps the backup public key
+   live off the projects droplet, which doesn't exist until `projects.yml` has generated
+   it there. This is a one-time bootstrap ordering constraint, not enforced by tooling —
+   see `ansible/roles/rustd_backup_nas/README.md` ("First-run ordering"). After both
+   playbooks have run once, re-running either is idempotent and the ordering no longer
+   matters.
+7. `docker logs rustd-xyz` → claim URL → claim the panel.
+8. Add servers/credentials in the panel; flip demo/signup switches when ready to go public.
+9. Confirm first nightly backup landed on the nas.
 
 ## Error handling / operational notes
 
@@ -120,7 +127,7 @@ bouncing landing-page mailto from rustd.xyz#375.
   the workflow (container starts, `/q/health`-less — hit `/login` for 200) before push.
 - iac repo: `ansible-lint`/molecule per repo convention; the role's first real run IS the
   deploy (matches how every other role here is validated).
-- Backup restore drill: after step 8, `pg_restore` the nas dump into a scratch container once,
+- Backup restore drill: after step 9, `pg_restore` the nas dump into a scratch container once,
   documented in the role README.
 
 ## Out of scope
@@ -129,3 +136,63 @@ bouncing landing-page mailto from rustd.xyz#375.
 - Monitoring/alerting beyond fail2ban + docker restart policies (nothing else on the droplet
   has it either).
 - Zero-downtime deploys (recreate = seconds of downtime; acceptable for this panel).
+
+## Implementation notes
+
+Deviations from this design, accumulated across the implementation tasks. Deviations that
+belong to the `rustd.xyz` repo (Part A, e.g. `.dockerignore` adjustments) are recorded in that
+repo's own PR, not here — this section covers only the iac-side implementation (Part B).
+
+- **Backup keypair generated on the droplet, not the ansible controller.** The design's stated
+  default (§B3, implicit) was controller-side `community.crypto.openssh_keypair` generation,
+  templating the private key out to the droplet and the public key out to the nas. Implemented
+  the opposite: the droplet generates its own ed25519 keypair on first run
+  (`ssh-keygen -f ... -N "" `, gated by `creates:`) and the private half never leaves it — not
+  copied to the controller, not put in 1Password, not templated anywhere. A controller-generated
+  private key would have to land in some file on the operator's own machine with no place in this
+  repo's secret model to account for it (not a 1Password item, not otherwise version-controlled),
+  which is exactly the kind of stray artifact this repo's "secrets are 1Password lookups, never
+  files" convention exists to avoid. Only the public key is ever read off the droplet, via a live
+  `slurp` delegated from `nas.yml`. Full rationale in
+  `ansible/roles/rustd_xyz/README.md` ("Key flow") and `ansible/roles/rustd_backup_nas/README.md`
+  ("Key-flow rationale"). This also means **`nas.yml` must run after `projects.yml` has run at
+  least once** — added as runbook step 6 above (was implicit/undocumented before this note).
+- **`community.crypto` is not in `requirements.yml`**, so the design's assumed
+  `openssh_keypair` module wasn't available regardless of the generation-location decision above;
+  used the plan's allowed `ansible.builtin.command: ssh-keygen ... creates:` fallback instead.
+- **Nas storage root is `/volume1/storage/backups/rustd-db`**, not the design/plan's placeholder
+  `/volume/backups/rustd-db` — `/volume1` is the nas' actual (only) data mount, confirmed from
+  `roles/media_server` (`media_storage_base_path: /volume1/storage`) and `roles/cs2_game`
+  (`/volume1/storage/cs2`); there is no `/volume` share on the real box.
+- **`mailu_install_path`, not `mailu_base_path`.** The design/plan's illustrative alias task used
+  `chdir: "{{ mailu_base_path }}"`; the role's real variable (used throughout `tasks/main.yml`) is
+  `mailu_install_path`. Used the real one. Likewise `changed_when` on the alias task follows the
+  existing `Create mail users` task's idiom (`changed_when: false`, with a comment that a looped
+  command's register doesn't give a reliable single-instance `rc` to key off), not the plan's
+  illustrative `changed_when: mailu_alias_result.rc == 0`.
+- **Dropped the droplet's stale `# $12/mo` cost comment** when resizing (Task 1) rather than
+  updating it to a new figure — it described the old `s-1vcpu-2gb` size and would have been
+  actively misleading left in place next to the new `s-2vcpu-4gb` line; the new required comment
+  already explains the resize.
+- **`QUARKUS_MAILER_TLS=true` confirmed by disassembly, not assumption.** The design flagged this
+  as needing verification against the pinned Quarkus version. Extracted
+  `quarkus-mailer-3.38.1.jar` from the local Gradle cache (the exact artifact rustd.xyz's build
+  resolves, per its `libs.versions.toml`) and read the bytecode with `javap`: both
+  `quarkus.mailer.tls` and the deprecated `quarkus.mailer.ssl` feed the same Vert.x
+  `MailConfig#setSsl(true)` (implicit TLS, wrap-from-connect) — the correct mechanism for Mailu's
+  port 465. `quarkus.mailer.start-tls` is a separate, inapplicable STARTTLS-upgrade knob. Evidence
+  recorded in `ansible/roles/rustd_xyz/tasks/main.yml` (inline comment) and the role README
+  ("Mailer TLS").
+- **Atomic backup dumps** (fixed after initial review): the backup script originally wrote
+  `pg_dump` output straight to its final filename
+  (`rustd-<date>.dump`). A `pg_dump` that dies partway (disk full, OOM, host reboot mid-run)
+  would leave a truncated file at that name — which the *next* night's successful run would then
+  rsync to the nas indistinguishably from a good backup, silently corrupting the offsite copy.
+  Fixed by dumping to `<name>.dump.tmp` and `mv`-ing into place only after `pg_dump` exits 0
+  (`set -euo pipefail` means a failed `pg_dump` never reaches the `mv`); added `rm -f` of any
+  leftover `.tmp` at the top of the script and excluded `*.tmp` from the rsync push, in case a
+  dump is still in flight when the script's own rsync step runs.
+
+None of the above required changing this design's Decisions table or Part A; they're
+implementation-detail resolutions of things the design flagged as needing verification, plus one
+bug fix (atomic dumps) found in review.

--- a/terraform/projects.tf
+++ b/terraform/projects.tf
@@ -14,10 +14,11 @@ resource "digitalocean_vpc" "sfo3-vpc" {
 }
 
 resource "digitalocean_droplet" "projects" {
-  image    = "ubuntu-24-04-x64"
-  name     = "projects"
-  region   = "sfo3"
-  size     = "s-1vcpu-2gb" # $12/mo - room for multiple containerized services
+  image  = "ubuntu-24-04-x64"
+  name   = "projects"
+  region = "sfo3"
+  # 4GB: rustd.xyz adds a JVM app + postgres to this droplet (see 2026-08-11 spec). Disk resize is one-way.
+  size     = "s-2vcpu-4gb"
   ipv6     = true
   vpc_uuid = digitalocean_vpc.sfo3-vpc.id
   ssh_keys = [digitalocean_ssh_key.github.fingerprint]


### PR DESCRIPTION
Part B of the rustd.xyz production-deployment design — the spec (with runbook and implementation notes) is the first commit: `docs/superpowers/specs/2026-08-11-rustd-xyz-prod-deploy-design.md`. Part A (Dockerfile + GHCR publish workflow) is rustd.xyz#377.

## What

- **Terraform**: projects droplet `s-1vcpu-2gb` → `s-2vcpu-4gb` (JVM app + postgres joining seven tenant containers). In-place resize; the disk half is one-way. Apply is an operator step per the runbook — nothing here has touched live infra.
- **`rustd_xyz` role** (mirrors `sair_portal`): `postgres:17` on a private `rustd-db` network (named volume, never on `nginx-proxy`, no published ports) + the panel from `ghcr.io/compscidr/rustd.xyz:latest` (`:sha-` pin = rollback knob) with apex-only `VIRTUAL_HOST`/`LETSENCRYPT_HOST=rustd.xyz` — the `__Host-` cookie rule from #481 holds; rustd.xyz stays out of `www_redirect_domains`. Secrets via 1Password lookups in `projects.yml` (one NEW item to create first: `rustd-db`). Mailer runs against Mailu at `mail.rustd.xyz:465` — implicit TLS verified against the pinned quarkus-mailer jar.
- **Mailu**: the role learns aliases (`flask mailu alias`, CLI signature verified against the pinned 2024.06 tag) and `contact@rustd.xyz → jason@rustd.xyz` closes the bouncing landing-page mailto from rustd.xyz#375.
- **Backups**: nightly systemd timer on the droplet — atomic `pg_dump -Fc` (tmp+mv, a truncated dump can never ship), 7 kept locally (0700 — dumps hold RCON credentials), rsync over the tailnet to `/volume1/storage/backups/rustd-db` on the nas. The backup key is generated ON the droplet (private material never touches the controller or 1Password); the new `rustd_backup_nas` role slurps the pubkey and authorizes it **rrsync-restricted, mandatorily** — if rrsync is missing the play fails rather than authorizing an unrestricted key. nas owns pruning (30 days).

## Review trail worth reading

The adversarial final review caught three deploy-day failures lint can never see, all fixed in the last commit: the rrsync forced-command re-roots absolute rsync destinations (the push now targets `:/`, verified against the installed rrsync source), modern rsync packaging ships `/usr/bin/rrsync` where the old discovery looked elsewhere (silent unrestricted-key fallback — now fail-closed), and the nas prune cron lacked `become`. Also fixed: the runbook now names the real mailu invocation (`jasonernst_com.yml --tags mailu`) and `nas.yml`'s tailscale pre-task carries `tags: always` so `--tags rustd-backup` can't skip it.

## Operator notes (also in the runbook)

1. Create the `rustd-db` 1Password item before running anything.
2. `projects.yml` must run before `nas.yml` once (the nas play slurps the droplet-generated pubkey); idempotent afterwards.
3. First boot: claim URL via `docker logs rustd-xyz`; panel starts private.

`ansible-lint` (CI-pinned versions) and `terraform fmt` green throughout; every task independently reviewed, plus the whole-branch review above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)