### PR TITLE
rustd backups: ship via the nas rsync daemon (fix the design merged in #499)

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -18,16 +18,36 @@ onepassword_vault: "Infrastructure"
 # need to agree on. Lives here (not in roles/rustd_xyz/defaults/main.yml)
 # because the two ends run in separate playbooks with no shared vars_file:
 # the rustd_xyz role (projects.yml, pushes) and the rustd_backup_nas role
-# (nas.yml, receives + prunes) both read these. Role-local backup settings
-# (local keep count, local dir, the SSH key path) stay in
-# roles/rustd_xyz/defaults/main.yml since only that role needs them.
+# (nas.yml, joins the tailnet + prunes) both read these. Role-local backup
+# settings (local keep count, local dir, the rsync-daemon coordinates and
+# password file) stay in roles/rustd_xyz/defaults/main.yml since only that
+# role needs them.
+#
+# Transport: the droplet pushes each night's backup directory to the nas'
+# BUILT-IN RSYNC DAEMON (UGOS's own service, port 873) - not ssh. Field
+# deploy discovery 2026-08-11 killed the original ssh-forced-command design
+# outright: the nas' vendor-patched rsync rejects every server-side receive
+# regardless of transport, sshd on the appliance has a GLOBAL ForceCommand
+# that overrides any per-key `command=` (no ssh-jail is possible at all),
+# and the admin account gets full passthrough anyway. The vendor rsync
+# daemon sits entirely outside sshd and is the actual supported receive
+# path - proven end-to-end, dump landed on the 91TB array over the
+# tailnet. Enabling it is a MANUAL UGOS UI prerequisite (module `storage`
+# -> /volume1/storage, `auth users = jason:rw`); ansible does not and
+# cannot configure it. See roles/rustd_backup_nas/README.md and
+# roles/rustd_xyz/templates/rustd-db-backup.sh.j2 for the full story.
 rustd_xyz_backup_nas_host: nas # tailnet short name - set via rustd_backup_nas_tailnet_hostname
 # (roles/rustd_backup_nas/defaults/main.yml). Deploy discovery 2026-08-11: the nas had
 # never joined the tailnet - rustd_backup_nas owns a minimal join (vendor appliance;
-# common_cli's full workstation footprint is off-limits there).
-rustd_xyz_backup_nas_user: rustd-backup
+# common_cli's full workstation footprint is off-limits there). The join stays even
+# though the ssh-based receive design that originally motivated the ACL analysis is
+# gone: the rsync daemon is still reached over the tailnet, not the public internet.
 # /volume1 is the nas' real (only) data mount - see media_storage_base_path
 # in roles/media_server/tasks/main.yml and roles/cs2_game/tasks/main.yml.
 # The plan's /volume/backups was a placeholder; there is no /volume share.
+# Read directly off disk by the nas-side prune cron (rustd_backup_nas); the
+# rsync daemon's own module path (module `storage` + subpath
+# `backups/rustd-db`, see roles/rustd_xyz/defaults/main.yml) resolves to
+# this same directory.
 rustd_xyz_backup_nas_path: /volume1/storage/backups/rustd-db
 rustd_xyz_backup_nas_keep: 30

--- a/ansible/nas.yml
+++ b/ansible/nas.yml
@@ -6,9 +6,11 @@
     - vars/user.yml
     - vars/secrets.yml
   pre_tasks:
-    # rustd_backup_nas delegates a task to the "projects" host (a Tailscale
-    # host, per inventory.yml), unlike nas.local itself which is reached
-    # over LAN mDNS regardless of Tailscale state.
+    # nas.local itself is reached over LAN mDNS regardless of Tailscale
+    # state, but rustd_backup_nas's whole job is putting the nas ON the
+    # tailnet (see that role's tasks/main.yml) for the rustd_xyz droplet to
+    # reach it - so the controller having a working Tailscale CLI is worth
+    # checking up front, same as any other Tailscale-touching play here.
     #
     # Tagged 'always' (matches jasonernst_com.yml) so the connectivity check
     # still runs when the play is invoked with --tags, e.g. the runbook's

--- a/ansible/projects.yml
+++ b/ansible/projects.yml
@@ -41,6 +41,13 @@
       account_id=onepassword_account_id) }}"
     rustd_xyz_smtp_password: "{{ lookup('community.general.onepassword', 'SMTP_USER - rustd', field='password', vault=onepassword_vault,
       account_id=onepassword_account_id) }}"
+    # nas rsync-daemon auth: jason's actual nas login password (the daemon's
+    # "auth users" password on this appliance IS the account password, not
+    # a separate secret) - see the `ugnas` item (Infrastructure vault) and
+    # roles/rustd_xyz/defaults/main.yml for why this isn't a dedicated
+    # rsync-only credential.
+    rustd_xyz_backup_nas_rsync_password: "{{ lookup('community.general.onepassword', 'ugnas', field='password', vault=onepassword_vault,
+      account_id=onepassword_account_id) }}"
     www_redirect_domains:
       - { domain: sair.run, letsencrypt_email: "ernstjason1@gmail.com" }
       - { domain: goblog.live, letsencrypt_email: "ernstjason1@gmail.com" }

--- a/ansible/roles/rustd_backup_nas/README.md
+++ b/ansible/roles/rustd_backup_nas/README.md
@@ -7,32 +7,103 @@ the other side.
 
 ## What it does
 
+This role is deliberately small: **join the nas to the tailnet, and prune old dumps.**
+That's it.
+
 - Joins the nas to the tailnet (see "Tailnet membership" below).
-- Installs `rsync` (Debian/Ubuntu, via `apt`) — needed both for the transfer itself and
-  because `rrsync` ships bundled inside the rsync package.
-- Creates a dedicated system user, `rustd-backup` (a real `/bin/bash` shell, not
-  `nologin` — see "Restricted key" below for why).
-- Creates the backup target directory (`rustd_xyz_backup_nas_path`,
-  `/volume1/storage/backups/rustd-db`), owned by `rustd-backup`, mode `0700`.
-- Locates `rrsync` — packaged directly by rsync ≥ 3.2.5 at `/usr/bin/rrsync` or
-  `/usr/local/bin/rrsync`, or as a last resort extracted from the older gzipped-script
-  packaging (`/usr/share/doc/rsync/scripts/rrsync.gz` → `/usr/local/bin/rrsync`).
-  **rrsync is a required dependency of this role**: if it can't be found anywhere, the
-  play fails with a clear message rather than silently falling back to an unrestricted
-  key — see "Restricted key" below.
-- Slurps the backup public key live off the projects droplet (see "Key flow" below) and
-  authorizes it in `rustd-backup`'s `authorized_keys`, restricted to a forced write-only
-  `rrsync` command.
-- Prunes backups older than `rustd_xyz_backup_nas_keep` (30 days) via a `cron` job — the
-  nas is the **sole owner** of nas-side retention. The push script
+- Prunes backups older than `rustd_xyz_backup_nas_keep` (30 days) via a **root** `cron`
+  job — the nas is the **sole owner** of nas-side retention. The push script
   (`rustd-db-backup.sh.j2`, in `rustd_xyz`) never deletes anything remote; it only prunes
   its own local copy. There is exactly one place backups on the nas get deleted from.
+
+That's the whole role. It does **not** create a receiver user, a target directory, an
+SSH key, or any receive-side script — see "Field reality" below for why: the actual
+receive path is the nas' own rsync daemon, which owns all of that itself.
+
+## Manual prerequisite: enable the nas' rsync daemon (UGOS UI)
+
+**Ansible does not and cannot configure this.** The nas is a closed UGREEN vendor
+appliance (UGOS) — there is no ansible module for its web UI, and there is no config
+file on disk this role is allowed to template its way around. Before the backup
+pipeline can receive anything, an operator has to, once, in the UGOS UI:
+
+1. Enable the **Rsync** service (Control Panel → Services, or equivalent — UGOS's own
+   term for it).
+2. Configure a module named `storage` mapped to `/volume1/storage`.
+3. Add an **auth user**: `jason`, with `rw` access to that module
+   (`auth users = jason:rw`, in rsyncd.conf terms).
+
+Confirmed working config, field-verified: module `storage` → `path = /volume1/storage`,
+`auth users = jason:rw`. The daemon listens on port 873. Auth password is `jason`'s
+actual nas login password — see "Security note" below for why that's a real credential-
+sharing problem, not just a curiosity.
+
+## Field reality: why this role used to be much bigger
+
+This role originally implemented an ssh-forced-command receiver: a dedicated user, a
+target directory, `rrsync`, and later a hand-rolled receive script authorized via a
+restricted SSH key. **All of that is dead.** Deploy testing found three independent,
+compounding reasons the ssh-jail design could never have worked on this hardware:
+
+1. **The nas' vendor-patched `rsync` (UGREEN's own 3.4.1 build) rejects every
+   server-side receive**, with a custom `not support path` error regardless of the
+   destination path given. `rrsync` just shells out to that same broken binary, so no
+   packaging of `rrsync` could have worked around it — and there's no stock rsync to
+   fall back to, since installing packages on this vendor appliance is forbidden.
+2. **sshd on the appliance has a GLOBAL `ForceCommand`** that overrides any per-key
+   `command=` in `authorized_keys`. The entire ssh-jail model — "this key can only run
+   this one forced command" — assumes per-key `command=` wins; on this box it doesn't.
+   There is no way to build an ssh-forced-command jail here at all, for any key.
+3. **Admin users get full passthrough** through that global `ForceCommand` anyway, so
+   even accepting (1) and (2), routing through an admin-adjacent account wouldn't have
+   been meaningfully restricted.
+
+None of this was fixable by trying harder at the ssh layer — every layer of the intended
+jail (rsync protocol, forced command, restricted key) was closed off by the vendor
+firmware independently of the others.
+
+**The working path, proven end-to-end** (a real dump landed on the nas' 91TB bcache
+array, over the tailnet, verified on disk): UGOS's own **rsync daemon**, port 873,
+enabled via the UGOS UI as described above. The daemon sits entirely outside sshd —
+none of the three blockers above apply to it, because it was never going through sshd in
+the first place. The droplet pushes with:
+
+```
+rsync -a --mkpath --password-file=<file> <localdir>/ rsync://jason@nas:873/storage/backups/rustd-db/
+```
+
+See `rustd_xyz`'s `templates/rustd-db-backup.sh.j2` for the real templated command.
+
+## Security note: shared credential (follow-up)
+
+The daemon's "auth users" password for `jason` **is `jason`'s actual nas login
+password**, not a separate, scoped rsync-only secret (UGOS doesn't appear to offer a way
+to set a distinct rsync-daemon password for the same auth-user name). That means the
+`rustd_xyz_backup_nas_rsync_password` value the droplet holds (1Password `ugnas` item,
+looked up in `projects.yml`) **is** jason's full nas login credential.
+
+**Consequence:** a compromise of the rustd.xyz droplet — where that password sits in a
+root-owned, mode-0600 file (`rustd_xyz_backup_rsync_password_file`) — leaks full access
+to `jason`'s nas account, not just write access to one backup directory. This is a real
+blast-radius gap versus the (unimplementable) ssh-jail design's intent, and is flagged
+here as a follow-up rather than fixed now, because fixing it means changing the nas
+side, which is manual UGOS-UI work outside this role's reach:
+
+**Recommended follow-up:** create a dedicated, non-admin UGOS user (its own password,
+*not* `jason`'s login) with rsync access scoped to only the `storage` module (or better,
+a module rooted at `backups/rustd-db` directly, so it can't even see the rest of
+`/volume1/storage`). Point `rustd_xyz_backup_nas_rsync_user` /
+`rustd_xyz_backup_nas_rsync_password` at that account instead of `jason`. Until that's
+done, treat the droplet's rsync password file as equivalent in sensitivity to `jason`'s
+nas login, because it is one.
 
 ## Tailnet membership
 
 The backup pipeline design assumed the nas was already a tailnet member; deploy discovery
 found it wasn't — the `tailscale` package was present but `tailscaled` had never been
-enabled and `tailscale up` had never been run. This role owns the join.
+enabled and `tailscale up` had never been run. This role owns the join, and it stays even
+though the ssh-based receive design that originally motivated it is gone: the rsync
+daemon is still reached over the tailnet, not the public internet.
 
 **Why this role, not `common_cli`:** `common_cli` is how every workstation and server in
 this repo joins the tailnet, but it's paired with a general CLI/dotfiles/user-account setup
@@ -52,96 +123,29 @@ contract comments on both variables.
 
 - `--accept-dns=false` — MagicDNS must not rewrite a vendor appliance's `resolv.conf`; DNS
   resolution on the box stays whatever the vendor OS configures.
-- No `--ssh` — the vendor `sshd` stays authoritative for inbound SSH. The droplet pushes
-  backups over plain `sshd` (the restricted `rustd-backup` key below), not Tailscale SSH.
+- No `--ssh` — the vendor `sshd` stays authoritative for admin login. Backups no longer
+  go over sshd at all (see "Field reality" above); Tailscale SSH was never part of this
+  pipeline either way.
 
 **Idempotency:** unlike `common_cli`, which re-runs `tailscale up` on every play
 (`failed_when: false` tolerates the no-op), this role checks `tailscale status --self`
 first and only runs `up` when the nas isn't already logged in (`rc != 0` or a `NeedsLogin`
 status) — preferring not to re-invoke `up` on every run against a vendor appliance.
 
-## Key-flow rationale
-
-The projects droplet generates its own ed25519 keypair the first time the `rustd_xyz`
-role runs (`ssh-keygen ... creates=...` — `community.crypto` isn't in
-`requirements.yml`, so this doesn't use `openssh_keypair`). **The private key is
-generated on the droplet and never leaves it**: not copied to the ansible controller,
-not put in 1Password, not templated anywhere.
-
-This is the opposite of generating the keypair on the ansible controller and templating
-the private half out to the droplet. Controller-side generation would leave private key
-material sitting in a bare file on the operator's own machine with no place in this
-repo's secret model to account for it — it isn't a 1Password item, and unlike every
-other secret in this repo it would exist only as a controller-local artifact, with no
-rotation story and a real risk of an accidental `git add -A`. Droplet-side generation
-means the only copy of the private key lives on the one machine that actually uses it,
-and is never transmitted anywhere — not even over the ansible control channel.
-
-Only the **public** key is ever read off the droplet, and only by this role: the task
-`Read the rustd.xyz backup public key from the projects droplet`
-(`tasks/main.yml`) delegates a live `ansible.builtin.slurp` back to the projects host
-(`rustd_backup_nas_projects_host`, must match the `projects` inventory host) from within
-this (`nas.yml`) play. No cross-playbook fact sharing or combined-invocation requirement
-— `projects.yml` and `nas.yml` stay independently runnable plays; this one just needs the
-key to already exist on disk over on the projects host.
-
-## First-run ordering
-
-**`nas.yml` (this role) must run *after* `projects.yml` has run at least once on the
-projects host.** The slurp task above reads
-`rustd_backup_nas_pubkey_path` (`/root/.ssh/rustd-backup_ed25519.pub`) off the projects
-droplet; that file doesn't exist until the `rustd_xyz` role's key-generation task has run
-there. If `nas.yml` is run first (or against a projects host that has never run
-`rustd_xyz`), the slurp task fails with a missing-file error.
-
-This is not enforced by any `ansible-playbook` ordering or pre-flight check — it's a
-one-time bootstrap dependency between two otherwise-independent playbooks. See the
-deploy runbook in
-`docs/superpowers/specs/2026-08-11-rustd-xyz-prod-deploy-design.md`, which sequences
-`projects.yml` before the `nas.yml` run that authorizes the backup key. After the first
-successful run on both sides, re-running either playbook is idempotent and the ordering
-no longer matters (the key already exists on the droplet and is already authorized on
-the nas).
-
-## Restricted key
-
-The authorized key is restricted with `command="<rrsync> -wo <rustd_xyz_backup_nas_path>",restrict`.
-This confines the key to write-only rsync into the one backups directory — no shell, no
-read-back, no port/agent/X11 forwarding.
-
-`rrsync` is **mandatory**, not a best-effort hardening: if it can't be found in any of
-`rustd_backup_nas_rrsync_paths` and the gz fallback doesn't exist either, the role's
-`Fail if rrsync isn't available anywhere` task aborts the play. There is no unrestricted
-fallback key. Two things depend on that fail-closed behaviour:
-
-1. Security — a plain key on `rustd-backup` would grant a full interactive shell to
-   whoever holds the (droplet-generated) private key, not just a write into one
-   directory.
-2. **Path contract with the push side.** rrsync re-roots an absolute destination path
-   under its own `DIR` argument (`rustd_xyz_backup_nas_path`) instead of treating it as
-   a literal filesystem path — so the push script (`rustd-db-backup.sh.j2`, in
-   `rustd_xyz`) can't rsync to `rustd_xyz_backup_nas_path` again on the wire, that would
-   land at `DIR` + `DIR`. Instead it hardcodes its destination as the bare root (`:/`),
-   which rrsync resolves as "the restricted directory itself". That hardcoding is only
-   safe because the key is *always* rrsync-restricted — under a plain, unrestricted key,
-   `:/` would mean the literal filesystem root. Making rrsync mandatory removes that
-   ambiguity instead of making the push script branch on which kind of key it might be
-   talking to.
-
-`rustd-backup` gets a real shell (`/bin/bash`), not `nologin`: `sshd` runs the
-`authorized_keys` forced `command=` regardless of login shell, but some PAM
-configurations (`pam_shells`) reject the session at the account phase before that if the
-shell isn't listed in `/etc/shells` — which would break the restricted key too, not just
-interactive login.
-
 ## Prune ownership
 
 Nas-side retention (`rustd_xyz_backup_nas_keep`, 30 days) is owned entirely by this
-role's `cron` job:
+role's root `cron` job:
 
 ```
 find {{ rustd_xyz_backup_nas_path }} -maxdepth 1 -name 'rustd-*.dump' -mtime +{{ rustd_xyz_backup_nas_keep }} -delete
 ```
+
+It's a **root** cron, not a per-user one: the rsync daemon writes as whatever Linux user
+the daemon process itself runs as (vendor-configured, opaque to this role), not
+necessarily as `jason` — there's no single non-root account this role can reliably own a
+crontab for, and root can always read/delete regardless of which user owns the dumped
+files.
 
 The push script never deletes anything on the nas — only its own local copy, kept to
 `rustd_xyz_backup_local_keep` (7 days). This keeps exactly one owner per retention
@@ -149,11 +153,11 @@ window: local pruning is the droplet's job, nas pruning is this role's job.
 
 ## Shared coordinates
 
-`rustd_xyz_backup_nas_host`/`_user`/`_path`/`_keep` are shared between this role and
-`rustd_xyz` (they describe the same pipeline from both ends) and live in
-`ansible/group_vars/all.yml`, not in either role's `defaults/main.yml` — `projects.yml`
-and `nas.yml` are separate playbook runs with no common `vars_files`, so neither role's
-own defaults are visible to the other. See the comment in `group_vars/all.yml` for why.
+`rustd_xyz_backup_nas_host`/`_path`/`_keep` are shared between this role and `rustd_xyz`
+(they describe the same pipeline from both ends) and live in `ansible/group_vars/all.yml`,
+not in either role's `defaults/main.yml` — `projects.yml` and `nas.yml` are separate
+playbook runs with no common `vars_files`, so neither role's own defaults are visible to
+the other. See the comment in `group_vars/all.yml` for why.
 
 `rustd_backup_nas_tailnet_hostname` (this role's own `defaults/main.yml`) is a related but
 separately-enforced sync contract: it must match `rustd_xyz_backup_nas_host` above, but

--- a/ansible/roles/rustd_backup_nas/defaults/main.yml
+++ b/ansible/roles/rustd_backup_nas/defaults/main.yml
@@ -1,19 +1,22 @@
 ---
 # rustd_backup_nas role defaults
 #
-# Receiving end of the rustd.xyz nightly pg_dump pipeline: the user, target
-# directory, and prune cron on the nas. The shared coordinates with the
-# pushing end (rustd_xyz role, projects.yml) - host/user/path/keep-count -
-# live in group_vars/all.yml (rustd_xyz_backup_nas_*), not here, since both
-# roles run in separate playbooks with no common vars_file. See the comment
-# there for why.
+# Receiving end of the rustd.xyz nightly pg_dump pipeline: tailnet
+# membership + the nas-side prune cron. That's all this role does now - the
+# actual receive path is the nas' built-in rsync daemon (UGOS UI, port 873,
+# a MANUAL prerequisite; see README.md), which ansible doesn't configure.
+#
+# The shared coordinates with the pushing end (rustd_xyz role,
+# projects.yml) - host/path/keep-count - live in group_vars/all.yml
+# (rustd_xyz_backup_nas_*), not here, since both roles run in separate
+# playbooks with no common vars_file. See the comment there for why.
 #
 # rustd_backup_nas_tailnet_hostname below is the same kind of cross-role
 # sync contract: it MUST match rustd_xyz_backup_nas_host
 # (group_vars/all.yml), the name the droplet-side push script dials. It
 # lives here rather than in group_vars/all.yml because, unlike the
-# host/user/path/keep vars above, only this role ever sets it (the value is
-# an argument to `tailscale up`, not something rustd_xyz reads) - the
+# host/path/keep vars above, only this role ever sets it (the value is an
+# argument to `tailscale up`, not something rustd_xyz reads) - the
 # agreement is enforced by convention/comment, not a shared variable.
 
 # Tailnet hostname this role gives the nas via `tailscale up --hostname`.
@@ -22,28 +25,3 @@
 # tailnet. Set explicitly rather than left to default to the appliance's
 # own hostname (DXP8800PLUS-3F06), which must never become the tailnet name.
 rustd_backup_nas_tailnet_hostname: nas
-
-# Inventory host (in the "projects" play) the backup key is generated on and
-# read back from. Must match the `projects` entry in ansible/inventory.yml.
-rustd_backup_nas_projects_host: projects
-
-# Where the SSH keypair for backups lives on the projects droplet - must
-# match rustd_xyz_backup_ssh_key_path in roles/rustd_xyz/defaults/main.yml.
-#
-# Sync contract: this is that var's path + ".pub". No shared vars_file
-# enforces the two paths agreeing (rustd_xyz runs in projects.yml, this role
-# in nas.yml) - if you change one, change the other.
-rustd_backup_nas_pubkey_path: /root/.ssh/rustd-backup_ed25519.pub
-
-# rrsync (restricted rsync wrapper) is a REQUIRED dependency of this role -
-# see tasks/main.yml ("Fail if rrsync isn't available") and the README
-# ("Restricted key"). rsync >= 3.2.5 (current Debian/Ubuntu) ships it as a
-# real binary in one of these locations; checked in order, first match wins.
-rustd_backup_nas_rrsync_paths:
-  - /usr/bin/rrsync
-  - /usr/local/bin/rrsync
-
-# Last-resort fallback for older rsync packaging that only ships rrsync as a
-# gzipped script alongside the rsync package, not installed as a binary.
-rustd_backup_nas_rrsync_gz: /usr/share/doc/rsync/scripts/rrsync.gz
-rustd_backup_nas_rrsync_bin: /usr/local/bin/rrsync

--- a/ansible/roles/rustd_backup_nas/tasks/main.yml
+++ b/ansible/roles/rustd_backup_nas/tasks/main.yml
@@ -1,9 +1,17 @@
 ---
 # Receiving end of the rustd.xyz nightly pg_dump backup pipeline: tailnet
-# membership, user, target directory, restricted key, and prune cron.
-# rustd_xyz (projects.yml) owns the push side; this role owns everything on
-# the nas, including pruning - see rustd_xyz/templates/rustd-db-backup.sh.j2's
-# header comment.
+# membership + prune cron. That's the whole role now.
+#
+# The actual receive path is the nas' built-in rsync daemon (UGOS's own
+# service, port 873) - a MANUAL prerequisite enabled once in the UGOS UI
+# (module `storage` -> /volume1/storage, `auth users = jason:rw`). This
+# role does not and cannot configure that daemon; there is no ansible
+# module for UGOS's UI and no config file on disk this role is allowed to
+# template (closed vendor appliance). See README.md for the full field
+# story (the earlier ssh-forced-command design this role used to implement
+# is gone - killed by a vendor-patched rsync, a global sshd ForceCommand,
+# and admin-account passthrough, none of which the daemon path is subject
+# to). rustd_xyz (projects.yml) owns the push side.
 
 # Tailscale membership: the backup pipeline design assumed the nas was
 # already a tailnet member (see the ACL analysis in
@@ -59,8 +67,10 @@
     # (rustd_xyz_backup_nas_host) dials.
     # --accept-dns=false: MagicDNS must not rewrite a vendor appliance's
     # resolv.conf.
-    # No --ssh: the vendor sshd stays authoritative - the droplet pushes
-    # backups over plain sshd, not Tailscale SSH.
+    # No --ssh: the vendor sshd stays authoritative for admin login. Backups
+    # no longer go over sshd at all (see the header comment) - the droplet
+    # dials the nas' rsync daemon (port 873) directly over this tailnet
+    # join, which needs no Tailscale SSH involvement either way.
     cmd: >-
       tailscale up --authkey={{ rustd_backup_nas_tailscale_authkey }}
       --hostname={{ rustd_backup_nas_tailnet_hostname }} --accept-dns=false
@@ -78,122 +88,29 @@
     ((rustd_backup_nas_tailscale_status.stdout or '{}') | from_json).BackendState | default('')
     != 'Running'
 
-- name: Ensure rsync is installed (needed for both the transfer and rrsync)
-  become: true
-  ansible.builtin.apt:
-    name: rsync
-    state: present
-  when: ansible_os_family == "Debian"
-
-- name: Create the rustd-backup user
-  become: true
-  ansible.builtin.user:
-    name: "{{ rustd_xyz_backup_nas_user }}"
-    system: true
-    # A real shell, not nologin: sshd runs the authorized_keys `command=`
-    # regardless of login shell, but some PAM configs (pam_shells) reject
-    # the session at the account phase before that if the shell isn't
-    # listed in /etc/shells, which would break the restricted key too.
-    shell: /bin/bash
-    create_home: true
-
-- name: Create the rustd.xyz backup target directory
-  become: true
-  ansible.builtin.file:
-    path: "{{ rustd_xyz_backup_nas_path }}"
-    state: directory
-    owner: "{{ rustd_xyz_backup_nas_user }}"
-    group: "{{ rustd_xyz_backup_nas_user }}"
-    mode: "0700"
-
-- name: Check for rrsync in its packaged locations (rsync >= 3.2.5 ships it directly)
-  become: true
-  ansible.builtin.stat:
-    path: "{{ item }}"
-  register: rustd_backup_nas_rrsync_stat
-  loop: "{{ rustd_backup_nas_rrsync_paths }}"
-
-- name: Check for the rrsync helper script shipped with older rsync packages (last-resort fallback)
-  become: true
-  ansible.builtin.stat:
-    path: "{{ rustd_backup_nas_rrsync_gz }}"
-  register: rustd_backup_nas_rrsync_gz_stat
-
-- name: Install rrsync from the rsync package's bundled script (last-resort fallback)
-  become: true
-  ansible.builtin.shell: |  # noqa: command-instead-of-module
-    set -euo pipefail
-    gunzip -c {{ rustd_backup_nas_rrsync_gz }} > {{ rustd_backup_nas_rrsync_bin }}.tmp
-    chmod 0755 {{ rustd_backup_nas_rrsync_bin }}.tmp
-    mv {{ rustd_backup_nas_rrsync_bin }}.tmp {{ rustd_backup_nas_rrsync_bin }}
-  args:
-    creates: "{{ rustd_backup_nas_rrsync_bin }}"
-    executable: /bin/bash
-  when:
-    - rustd_backup_nas_rrsync_gz_stat.stat.exists
-    - rustd_backup_nas_rrsync_stat.results | selectattr('stat.exists') | list | length == 0
-
-# rrsync is a REQUIRED dependency of this role, not an optional hardening:
-# the push script on the other end (rustd_xyz role's rustd-db-backup.sh.j2)
-# hardcodes its rsync destination as the bare root (":/") on the assumption
-# that the key it pushes with is always rrsync-restricted to
-# rustd_xyz_backup_nas_path - rrsync re-roots that ":/" under its own DIR
-# argument, landing writes exactly there. A silent fallback to an
-# unrestricted key here would both defeat the restriction (full shell access
-# for whoever holds the private key) and break that path contract (":/"
-# would mean the literal filesystem root over an unrestricted connection),
-# so this role fails closed instead of falling back. See the README's
-# "Restricted key" section.
-- name: Resolve the rrsync binary path
-  ansible.builtin.set_fact:
-    rustd_backup_nas_rrsync_path: >-
-      {{ (rustd_backup_nas_rrsync_stat.results | selectattr('stat.exists') | map(attribute='item') | list
-          + ([rustd_backup_nas_rrsync_bin] if rustd_backup_nas_rrsync_gz_stat.stat.exists else []))
-         | first | default('', true) }}
-
-- name: Fail if rrsync isn't available anywhere
-  ansible.builtin.fail:
-    msg: >-
-      rrsync not found at {{ rustd_backup_nas_rrsync_paths | join(', ') }}, and the
-      gz fallback ({{ rustd_backup_nas_rrsync_gz }}) doesn't exist either. rrsync is
-      a required dependency of this role (see README.md, "Restricted key") - install
-      a version of rsync that ships it (>= 3.2.5) or make rrsync available some other
-      way, then re-run.
-  when: rustd_backup_nas_rrsync_path == ''
-
-# The droplet generates its own keypair at deploy time (rustd_xyz role) and
-# never gives up the private half - see that role's tasks/main.yml for why.
-# Only the public key is read back here, live, by delegating to the
-# projects host from within this (nas.yml) play. This keeps the two
-# playbooks independently runnable: nas.yml doesn't need projects.yml to
-# have run in the same ansible-playbook invocation, only that the key
-# already exists on disk over there (true after the first rustd_xyz run).
-- name: Read the rustd.xyz backup public key from the projects droplet
-  become: true
-  delegate_to: "{{ rustd_backup_nas_projects_host }}"
-  ansible.builtin.slurp:
-    src: "{{ rustd_backup_nas_pubkey_path }}"
-  register: rustd_backup_nas_pubkey_slurp
-
-- name: Authorize the rustd.xyz backup key
-  become: true
-  ansible.posix.authorized_key:
-    user: "{{ rustd_xyz_backup_nas_user }}"
-    key: "{{ rustd_backup_nas_pubkey_slurp.content | b64decode }}"
-    # restrict + a forced write-only rrsync command: the key can only push
-    # files into rustd_xyz_backup_nas_path, nothing else (no shell, no
-    # port/agent/X11 forwarding, no read-back). rrsync is now mandatory (see
-    # the fail task above), so there is no unrestricted-key fallback here.
-    key_options: >-
-      command="{{ rustd_backup_nas_rrsync_path }} -wo {{ rustd_xyz_backup_nas_path }}",restrict
+# No user, target-directory, or key task here. The nas' built-in rsync
+# daemon (UGOS UI, port 873) is what actually receives the backups - it
+# manages its own module root (/volume1/storage), its own directory
+# creation under it (rsync --mkpath on the push side), and its own
+# username/password auth entirely separate from Linux accounts and sshd.
+# There is nothing left for ansible to create or authorize on the receive
+# side; see README.md for why every earlier attempt at an ssh-based
+# receiver (dedicated user, target-dir ownership, rrsync, then a
+# forced-command receive script) was abandoned.
 
 - name: Prune rustd.xyz backups older than the retention window
   become: true
   ansible.builtin.cron:
     name: "prune rustd.xyz db backups"
-    user: "{{ rustd_xyz_backup_nas_user }}"
     minute: "30"
     hour: "5"
+    # Root cron, not a per-user one: the rsync daemon writes as whatever
+    # Linux user the daemon process itself runs as (vendor-configured,
+    # opaque to this role) - there's no single non-root account this role
+    # can reliably own a crontab for anymore (the old
+    # rustd_xyz_backup_nas_user var this used to key off of is gone along
+    # with the ssh receiver it named), and root can always read/delete
+    # regardless of which user owns the dumped files.
     job: >-
       find {{ rustd_xyz_backup_nas_path }} -maxdepth 1 -name 'rustd-*.dump'
       -mtime +{{ rustd_xyz_backup_nas_keep }} -delete

--- a/ansible/roles/rustd_backup_nas/tasks/main.yml
+++ b/ansible/roles/rustd_backup_nas/tasks/main.yml
@@ -112,5 +112,5 @@
     # with the ssh receiver it named), and root can always read/delete
     # regardless of which user owns the dumped files.
     job: >-
-      find {{ rustd_xyz_backup_nas_path }} -maxdepth 1 -name 'rustd-*.dump'
+      find {{ rustd_xyz_backup_nas_path }} -maxdepth 1 -type f -name 'rustd-*.dump'
       -mtime +{{ rustd_xyz_backup_nas_keep }} -delete

--- a/ansible/roles/rustd_xyz/README.md
+++ b/ansible/roles/rustd_xyz/README.md
@@ -16,8 +16,8 @@ GHCR-login / container-deploy shape.
   credentials, so the directory isn't world-readable) on the host, plus a
   `rustd-db-backup.timer` (04:30 daily, 15m random delay) that runs
   `rustd-db-backup.sh`: `pg_dump`s `rustd-db`, keeps the newest
-  `rustd_xyz_backup_local_keep` dumps locally, and `rsync`s the whole
-  backups directory to the nas over a dedicated ed25519 key.
+  `rustd_xyz_backup_local_keep` dumps locally, and pushes the whole local
+  backup directory to the nas' built-in rsync daemon (port 873 — not ssh).
 
 ## Rollback
 
@@ -51,57 +51,56 @@ restoring into a fresh/empty `rustd-db`, not a sign the restore failed.
 ## Secrets
 
 All secrets (`rustd_xyz_ghcr_token`, `rustd_xyz_db_password`,
-`rustd_xyz_smtp_username`, `rustd_xyz_smtp_password`) are 1Password lookups
-set as `vars` in `projects.yml` — never hardcoded in `defaults/main.yml`.
-The postgres password comes from the `rustd-db` item (Infrastructure vault),
-created manually by the operator before the first deploy.
+`rustd_xyz_smtp_username`, `rustd_xyz_smtp_password`,
+`rustd_xyz_backup_nas_rsync_password`) are 1Password lookups set as `vars` in
+`projects.yml` — never hardcoded in `defaults/main.yml`. The postgres password
+comes from the `rustd-db` item (Infrastructure vault), created manually by the
+operator before the first deploy. The rsync-daemon backup password comes from
+the `ugnas` item (Infrastructure vault) — see "Nightly backup -> nas" below for
+why that's jason's actual nas login password, not a dedicated secret.
 
 ## Nightly backup -> nas
 
 `rustd-db-backup.sh` (templated to `/opt/rustd/rustd-db-backup.sh`) pg_dumps
 `rustd-db` in custom (`-Fc`) format, prunes local dumps beyond
-`rustd_xyz_backup_local_keep` (7), then `rsync`s the backups directory to
-`rustd_xyz_backup_nas_user@rustd_xyz_backup_nas_host:/` — the bare root, not
-`rustd_xyz_backup_nas_path`; see "Push destination is `:/`" below for why.
-The nas keeps `rustd_xyz_backup_nas_keep` (30) and owns pruning its own copy
-(cron, in the `rustd_backup_nas` role run by `nas.yml`) — the push script
-never deletes anything remote, so there is exactly one owner of nas-side
-retention.
+`rustd_xyz_backup_local_keep` (7), then pushes the whole local backup
+directory to the nas in **one rsync-daemon transfer**:
 
-**Key flow.** The role generates a dedicated ed25519 keypair on this droplet
-the first time it runs (`ssh-keygen ... creates=...` — `community.crypto`
-isn't in `requirements.yml`, so this doesn't use `openssh_keypair`). The
-private key is created here and never leaves this host: not copied to the
-ansible controller, not put in 1Password, not templated anywhere. Only the
-*public* key is ever read off the box — the `rustd_backup_nas` role, running
-`nas.yml` against the nas, delegates a `slurp` task back to this host to
-fetch it live and authorize it in `rustd-backup`'s `authorized_keys`.
+```
+rsync -a --mkpath --password-file={{ rustd_xyz_backup_rsync_password_file }} \
+  {{ rustd_xyz_backup_local_dir }}/ \
+  rsync://{{ rustd_xyz_backup_nas_rsync_user }}@{{ rustd_xyz_backup_nas_host }}:{{ rustd_xyz_backup_nas_rsync_port }}/{{ rustd_xyz_backup_nas_rsync_module }}/{{ rustd_xyz_backup_nas_rsync_subpath }}/
+```
 
-This is the opposite of the design doc's stated default (generate the
-keypair on the ansible controller and template private key -> droplet,
-public key -> nas). That version would leave private key material sitting
-in a file on the operator's own machine with no 1Password entry and no
-place in this repo's secret model to account for it — exactly the kind of
-controller-local artifact this repo otherwise avoids. Generating on the
-droplet means the only copy of the private key lives on the one machine
-that uses it, is never transmitted over the control channel at all, and
-needs no 1Password item.
+No `--delete`: the nas keeps a longer retention window (`rustd_xyz_backup_nas_keep`,
+30 days) than this local directory does (7), so a mirroring sync would prune the nas
+copy down to whatever's still local. The nas owns pruning its own copy (a root cron in
+the `rustd_backup_nas` role, run by `nas.yml`) — the push script never deletes anything
+remote, so there is exactly one owner of nas-side retention.
 
-The authorized key is restricted with `command="<rrsync> -wo <rustd_xyz_backup_nas_path>",restrict`
-(`rustd_backup_nas` role — `rrsync` is a *required* dependency there: the role
-fails its play if it can't find it, rather than falling back to a plain key).
-This confines the key to write-only rsync into the one backups directory —
-no shell, no read-back, no port/agent/X11 forwarding.
+**Transport is the nas' built-in rsync daemon (port 873), not ssh — see
+`rustd_backup_nas`'s README ("Field reality") for the full field story.** In short: the
+original design was an ssh-forced-command jail (dedicated key, restricted
+`authorized_keys` entry, `rrsync` or a hand-rolled receive script). Deploy testing found
+it was unimplementable on this hardware for three independent reasons — the nas'
+vendor-patched `rsync` rejects every server-side receive, `sshd` on the appliance has a
+**global** `ForceCommand` that overrides any per-key `command=` (no ssh-jail is possible
+at all), and admin accounts get full passthrough through that global command anyway.
+None of that applies to the vendor's own rsync daemon, which sits entirely outside sshd
+and turned out to be the actual supported receive path — proven end-to-end, a real dump
+landed on the nas' 91TB bcache array over the tailnet.
 
-**Push destination is `:/`, not the nas-side path.** rrsync re-roots an
-absolute destination path under its own restricted directory instead of
-treating it as a literal filesystem path, so rsyncing to
-`rustd_xyz_backup_nas_path` on the wire would land at `DIR` + `DIR`, not
-`DIR`. `rustd-db-backup.sh.j2` therefore hardcodes its destination as the
-bare root (`:/`), which rrsync resolves as "the restricted directory
-itself". That hardcoding relies on the key always being rrsync-restricted —
-see `rustd_backup_nas`'s README ("Restricted key") for why that's now
-guaranteed rather than best-effort.
+**Auth is a daemon username/password, not a key**, written to
+`rustd_xyz_backup_rsync_password_file` (root-owned, mode `0600`, `no_log`'d) by this
+role's "Write the nas rsync-daemon password file" task. The password is jason's actual
+nas login password (1Password `ugnas` item) — see `rustd_backup_nas`'s README
+("Security note") for the shared-credential blast-radius this creates and the scoped-
+account follow-up it recommends.
+
+**Manual prerequisite:** the nas' rsync daemon has to be enabled once via the UGOS UI —
+module `storage` -> `/volume1/storage`, `auth users = jason:rw`. Ansible does not and
+cannot configure it (closed vendor appliance, no UGOS-UI ansible module). See
+`rustd_backup_nas`'s README for the exact steps.
 
 ## Mailer TLS
 

--- a/ansible/roles/rustd_xyz/defaults/main.yml
+++ b/ansible/roles/rustd_xyz/defaults/main.yml
@@ -26,19 +26,43 @@ rustd_xyz_smtp_username: ""
 rustd_xyz_smtp_password: ""
 
 # Nightly pg_dump -> nas backup (role-local half; the nas-side coordinates
-# of this same pipeline - rustd_xyz_backup_nas_host/_user/_path/_keep - live
+# of this same pipeline - rustd_xyz_backup_nas_host/_path/_keep - live
 # in group_vars/all.yml, because they're also consumed by the
 # rustd_backup_nas role in the separate nas.yml playbook run, which never
 # loads this role's defaults. See group_vars/all.yml for why.)
 rustd_xyz_backup_local_dir: "{{ rustd_xyz_base_path }}/backups"
 rustd_xyz_backup_local_keep: 7
-# ed25519 keypair generated ON THIS DROPLET the first time the role runs
-# (see tasks/main.yml) - private key never leaves this host or touches the
-# ansible controller. Only the public half is ever read off the box, by the
-# nas play delegating a slurp back to this host.
+
+# --- nas rsync-daemon transport ------------------------------------------
 #
-# Sync contract: rustd_backup_nas_pubkey_path (roles/rustd_backup_nas/defaults/main.yml,
-# consumed by nas.yml) must equal this path + ".pub". The two vars live in
-# separate roles/playbooks with no shared vars_file to enforce it in code -
-# if you change this path, update that one too.
-rustd_xyz_backup_ssh_key_path: /root/.ssh/rustd-backup_ed25519
+# Field deploy discovery 2026-08-11 killed the original ssh-forced-command
+# design entirely (see the ship-side template's header comment for the full
+# story). The nas' *built-in rsync daemon* (UGOS's own service, port 873) is
+# the vendor-supported receiver instead - it isn't gated by sshd at all, so
+# neither the vendor's patched rsync-over-ssh nor its global ForceCommand
+# come into play. Auth is a plain rsync-daemon username/password, not a key.
+#
+# rustd_xyz_backup_nas_rsync_user: the rsync daemon "auth users" entry
+# configured in the UGOS UI (module `storage`, `auth users = jason:rw`) -
+# NOT a Linux account, just a name inside the daemon's own auth file.
+rustd_xyz_backup_nas_rsync_user: jason
+rustd_xyz_backup_nas_rsync_port: 873
+# The daemon module name, configured in the UGOS UI, mapped to
+# /volume1/storage on the nas.
+rustd_xyz_backup_nas_rsync_module: storage
+# Path inside the module the dumps land under - full remote path is
+# <module>/<subpath>, i.e. /volume1/storage/backups/rustd-db (matches
+# rustd_xyz_backup_nas_path in group_vars/all.yml, which the nas-side prune
+# cron reads directly off disk rather than through the daemon).
+rustd_xyz_backup_nas_rsync_subpath: backups/rustd-db
+# rsync --password-file for the daemon auth above. Root-owned, mode 0600,
+# written by this role's "Write the nas rsync password file" task - see
+# tasks/main.yml for why a file instead of an env var (rsync's own
+# requirement for --password-file, and it keeps the secret out of the
+# process list / systemd unit).
+rustd_xyz_backup_rsync_password_file: /opt/rustd/.rsync-nas-pass
+# Filled from projects.yml via a 1Password lookup (the `ugnas` item,
+# Infrastructure vault - jason's actual nas login password, since the rsync
+# daemon's "auth users" password on this appliance IS the account password,
+# not a separate secret). no_log'd wherever it's consumed.
+rustd_xyz_backup_nas_rsync_password: ""

--- a/ansible/roles/rustd_xyz/tasks/main.yml
+++ b/ansible/roles/rustd_xyz/tasks/main.yml
@@ -87,33 +87,21 @@
 
 # --- Nightly pg_dump -> nas backup ---------------------------------------
 #
-# Key flow: community.crypto isn't in requirements.yml (checked), so this
-# uses the ssh-keygen fallback the plan allows, not openssh_keypair.
-#
-# The keypair is generated HERE, on the droplet, rather than on the ansible
-# controller. The plan's stated lean was controller-side generation
-# (openssh_keypair at a controller path, then template private -> droplet +
-# pubkey -> nas), but that puts private key material on the operator's own
-# machine: it has to land in *some* file on the controller for the
-# subsequent copy/template task to read, and nothing in this repo's secret
-# model accounts for that file (it isn't a 1Password item, and unlike every
-# other secret here it would exist only as a controller-local artifact -
-# exactly the kind of thing that ends up accidentally `git add -A`'d, or
-# just left behind in a homedir with no rotation/audit story). Generating
-# on the droplet means the private half is created and stays on the one
-# machine that actually needs it, is never transmitted anywhere (not even
-# over the ansible control channel), and only the public half - not
-# sensitive - is ever read off the box, by the nas play's delegated slurp
-# (see roles/rustd_backup_nas/tasks/main.yml). No 1Password item is needed
-# for this key at all.
-- name: Generate the rustd.xyz backup SSH keypair (ed25519) on the droplet
+# The nas is reached over its built-in rsync daemon (UGOS's vendor-supported
+# service, port 873), not ssh. There's no key to generate: auth is the
+# daemon's own username/password scheme, so this role just writes the
+# password out to a file rsync's --password-file can read. See
+# rustd-db-backup.sh.j2's header comment for why the earlier ssh/rrsync/
+# forced-command design was abandoned outright.
+- name: Write the nas rsync-daemon password file
   become: true
-  ansible.builtin.command:
-    cmd: >
-      ssh-keygen -t ed25519 -f {{ rustd_xyz_backup_ssh_key_path }} -N ""
-      -C "rustd-backup@projects"
-  args:
-    creates: "{{ rustd_xyz_backup_ssh_key_path }}"
+  ansible.builtin.copy:
+    dest: "{{ rustd_xyz_backup_rsync_password_file }}"
+    content: "{{ rustd_xyz_backup_nas_rsync_password }}\n"
+    owner: root
+    group: root
+    mode: "0600"
+  no_log: true
 
 - name: Deploy the backup script
   become: true

--- a/ansible/roles/rustd_xyz/templates/rustd-db-backup.sh.j2
+++ b/ansible/roles/rustd_xyz/templates/rustd-db-backup.sh.j2
@@ -56,6 +56,11 @@ ls -1t {{ rustd_xyz_backup_local_dir }}/rustd-*.dump | tail -n +{{ rustd_xyz_bac
 # written by this role's "Write the nas rsync-daemon password file" task -
 # see tasks/main.yml), not an ssh key: the daemon has its own auth scheme
 # entirely separate from sshd.
-rsync -a --mkpath --password-file={{ rustd_xyz_backup_rsync_password_file }} \
+# --contimeout: cap the initial connect (dead daemon / blocked port / down
+# tailnet) so a oneshot run can't hang indefinitely and stall the timer.
+# --timeout: abort a stalled mid-transfer I/O the same way. set -e turns
+# either into a clean unit failure rather than a hung service.
+rsync -a --mkpath --contimeout=30 --timeout=300 \
+  --password-file={{ rustd_xyz_backup_rsync_password_file }} \
   {{ rustd_xyz_backup_local_dir }}/ \
   rsync://{{ rustd_xyz_backup_nas_rsync_user }}@{{ rustd_xyz_backup_nas_host }}:{{ rustd_xyz_backup_nas_rsync_port }}/{{ rustd_xyz_backup_nas_rsync_module }}/{{ rustd_xyz_backup_nas_rsync_subpath }}/

--- a/ansible/roles/rustd_xyz/templates/rustd-db-backup.sh.j2
+++ b/ansible/roles/rustd_xyz/templates/rustd-db-backup.sh.j2
@@ -2,10 +2,28 @@
 # Managed by ansible (rustd_xyz role) - do not edit by hand.
 #
 # Nightly rustd.xyz postgres dump: pg_dump the rustd-db container, prune
-# local dumps beyond {{ rustd_xyz_backup_local_keep }}, then push everything
-# still on disk to the nas over rsync/ssh. Pruning of the *nas* copy is owned
-# by the nas side (cron in the rustd_backup_nas role) - this script never
-# deletes anything remotely.
+# local dumps beyond {{ rustd_xyz_backup_local_keep }}, then push the whole
+# local backup directory to the nas over its built-in rsync daemon (UGOS's
+# vendor-supported service, port 873 - NOT ssh).
+#
+# Field deploy discovery 2026-08-11 killed the original ssh-forced-command
+# design outright: the nas' vendor-patched rsync (UGREEN's own 3.4.1 build)
+# rejects every server-side receive regardless of transport, sshd on the
+# appliance has a GLOBAL ForceCommand that overrides any per-key
+# `command=` (so no ssh-jail is possible at all), and the admin account
+# gets full passthrough anyway. The vendor's own rsync *daemon* (enabled in
+# the UGOS UI, listening on 873, module `storage` -> /volume1/storage,
+# `auth users = jason:rw`) sits entirely outside sshd and turned out to be
+# the actual supported receive path - proven end-to-end, dump landed on the
+# 91TB array over the tailnet. Enabling that daemon is a MANUAL UGOS UI
+# prerequisite; ansible does not and cannot configure it (see
+# rustd_backup_nas's README).
+#
+# The push below is additive (no --delete): the nas keeps a longer
+# retention window ({{ rustd_xyz_backup_nas_keep }} days, pruned by a root
+# cron in the rustd_backup_nas role) than this local directory does, so a
+# sync that mirrors deletions would prune the nas copy down to what's left
+# locally. This script never deletes anything remote.
 set -euo pipefail
 
 STAMP="$(date +%F)"
@@ -20,7 +38,7 @@ rm -f "${TMP}"
 # succeeded (set -e means a non-zero pg_dump exit aborts before the mv).
 # Without this, a pg_dump that dies partway (disk full, container OOM,
 # host reboot) leaves a truncated file at the FINAL name, which the next
-# night's successful run would then happily rsync to the nas as if it
+# night's successful run would then happily ship to the nas as if it
 # were a good backup.
 docker exec rustd-db pg_dump -Fc -U {{ rustd_xyz_db_user }} {{ rustd_xyz_db_name }} > "${TMP}"
 mv "${TMP}" "${OUT}"
@@ -31,22 +49,13 @@ mv "${TMP}" "${OUT}"
 # or pruned out from under itself.
 ls -1t {{ rustd_xyz_backup_local_dir }}/rustd-*.dump | tail -n +{{ rustd_xyz_backup_local_keep | int + 1 }} | xargs -r rm --
 
-# --exclude '*.tmp': belt-and-braces again - even though rm -f above and the
-# rename-on-success above mean a .tmp should never coexist with a completed
-# run of this script, excluding it here means a dump that's mid-write when
-# this script's *own* rsync step runs (e.g. someone manually re-invoking the
-# script while a prior invocation is still dumping) can never ship a partial
-# file to the nas either.
-#
-# Destination is the bare root (":/"), not {{ rustd_xyz_backup_nas_path }} -
-# this key is always rrsync-restricted on the nas side (rustd_backup_nas
-# role, which fails its own play if rrsync isn't available: see that role's
-# README, "Restricted key"). rrsync re-roots absolute destination paths
-# under its own DIR argument (rustd_xyz_backup_nas_path) rather than
-# treating them as literal filesystem paths, so sending the same path here
-# would double it (DIR + DIR) and every push would fail. ":/" is rrsync's
-# contract for "the restricted directory itself".
-rsync -az --timeout=60 --exclude '*.tmp' \
-  -e "ssh -i {{ rustd_xyz_backup_ssh_key_path }} -o StrictHostKeyChecking=accept-new" \
+# One rsync-daemon push of the whole local backup directory - additive
+# (no --delete, see the header comment). --mkpath creates
+# backups/rustd-db/ under the module root on first run if it isn't there
+# yet. Auth is a daemon username/password (--password-file, mode 0600,
+# written by this role's "Write the nas rsync-daemon password file" task -
+# see tasks/main.yml), not an ssh key: the daemon has its own auth scheme
+# entirely separate from sshd.
+rsync -a --mkpath --password-file={{ rustd_xyz_backup_rsync_password_file }} \
   {{ rustd_xyz_backup_local_dir }}/ \
-  {{ rustd_xyz_backup_nas_user }}@{{ rustd_xyz_backup_nas_host }}:/
+  rsync://{{ rustd_xyz_backup_nas_rsync_user }}@{{ rustd_xyz_backup_nas_host }}:{{ rustd_xyz_backup_nas_rsync_port }}/{{ rustd_xyz_backup_nas_rsync_module }}/{{ rustd_xyz_backup_nas_rsync_subpath }}/

--- a/docs/superpowers/specs/2026-08-11-rustd-xyz-prod-deploy-design.md
+++ b/docs/superpowers/specs/2026-08-11-rustd-xyz-prod-deploy-design.md
@@ -204,7 +204,11 @@ repo's own PR, not here — this section covers only the iac-side implementation
   (`set -euo pipefail` means a failed `pg_dump` never reaches the `mv`); added `rm -f` of any
   leftover `.tmp` at the top of the script and excluded `*.tmp` from the rsync push, in case a
   dump is still in flight when the script's own rsync step runs.
-- **Receiver identity on the nas is the vendor account `jason`, not a dedicated
+- **[SUPERSEDED — the entire ssh/forced-command receive design below was later removed; see
+  "The ssh-based receive design was removed outright and replaced with the nas' built-in rsync
+  daemon" further down. This bullet is retained only as field history: `rustd-receive-dump`,
+  the `command=,restrict` key, and `rustd_xyz_backup_nas_user` no longer exist.]**
+  **Receiver identity on the nas is the vendor account `jason`, not a dedicated
   `rustd-backup` user.** The design's assumed shape (and this role's first implementation)
   was a dedicated locked system user, `rustd-backup`, holding the receive-side end of the
   restricted key. Field deploy discovery found the nas appliance's vendor PAM/login stack

--- a/docs/superpowers/specs/2026-08-11-rustd-xyz-prod-deploy-design.md
+++ b/docs/superpowers/specs/2026-08-11-rustd-xyz-prod-deploy-design.md
@@ -82,9 +82,17 @@ Role-managed on the droplet: a script + systemd timer (`rustd-db-backup.timer`, 
 `docker exec`s `pg_dump -Fc` into `/opt/rustd/backups/`, prunes to 7 local dumps, and rsyncs
 the directory to the nas over the tailnet as a dedicated non-root user with a dedicated ed25519
 key. nas side (nas playbook): create the backup user + `authorized_keys` (restricted to rsync),
-target path on the storage pool, prune to 30 days. Network path needs no ACL change today
-(droplets are member devices; the member→`*` grant covers it) — **caveat:** if droplets are
-ever moved to tagged identities, a `projects → nas:22` grant must be added.
+target path on the storage pool, prune to 30 days. **Superseded in deploy, see Implementation
+notes:** this whole ssh-based design (both the original `rrsync` transport and its
+forced-command-receive-script replacement) was unimplementable on the real nas hardware —
+vendor-patched `rsync`, a global sshd `ForceCommand`, and admin-account passthrough closed off
+every layer of the intended ssh jail independently. The final, proven-working transport is the
+nas' own **rsync daemon** (UGOS UI, port 873, manual prerequisite), not ssh at all — see
+Implementation notes for the full field story and the resulting shared-credential security
+follow-up. Network path needs no ACL change today (droplets are member devices; the member→`*`
+grant covers it); the daemon runs on port 873, not 22, so the caveat below is now moot unless a
+future change moves the receive port too — **caveat:** if droplets are ever moved to tagged
+identities, a `projects → nas:873` grant must be added.
 
 ### B4. Mailu: alias support + contact@
 
@@ -96,21 +104,24 @@ bouncing landing-page mailto from rustd.xyz#375.
 ## Runbook (deploy order)
 
 1. Create the `rustd-db` 1Password item (manual).
-2. Terraform resize (tenant downtime window).
-3. Merge the rustd.xyz PR → image appears on GHCR.
-4. Run `ansible-playbook -i inventory.yml jasonernst_com.yml --tags mailu --ask-become-pass`
+2. Enable the nas' rsync daemon in the UGOS UI (manual, one-time): Rsync service on,
+   module `storage` → `/volume1/storage`, auth user `jason:rw`. See
+   `ansible/roles/rustd_backup_nas/README.md` ("Manual prerequisite") — ansible cannot do
+   this step, it's a closed vendor UI.
+3. Terraform resize (tenant downtime window).
+4. Merge the rustd.xyz PR → image appears on GHCR.
+5. Run `ansible-playbook -i inventory.yml jasonernst_com.yml --tags mailu --ask-become-pass`
    (the mailu role lives in `jasonernst_com.yml`, hosts `www`) → `contact@` alias live.
-5. Run `projects.yml` (rustd tags) → postgres + app up, TLS issued, Flyway migrates.
-6. Run `nas.yml` (rustd-backup tags) → authorizes the backup key on the nas. **Must run
-   after step 5, not before**: the `rustd_backup_nas` role slurps the backup public key
-   live off the projects droplet, which doesn't exist until `projects.yml` has generated
-   it there. This is a one-time bootstrap ordering constraint, not enforced by tooling —
-   see `ansible/roles/rustd_backup_nas/README.md` ("First-run ordering"). After both
-   playbooks have run once, re-running either is idempotent and the ordering no longer
-   matters.
-7. `docker logs rustd-xyz` → claim URL → claim the panel.
-8. Add servers/credentials in the panel; flip demo/signup switches when ready to go public.
-9. Confirm first nightly backup landed on the nas.
+6. Run `projects.yml` (rustd tags) → postgres + app up, TLS issued, Flyway migrates, backup
+   timer installed (first push happens at the next 04:30 window, or run the timer's unit
+   manually to test sooner).
+7. Run `nas.yml` (rustd-backup tags) → joins the nas to the tailnet and installs the
+   prune cron. No key-authorization step, no bootstrap ordering constraint against step 6
+   — the rsync daemon (step 2) is independent of anything either playbook generates, so
+   steps 6 and 7 can run in either order, and both are idempotent on re-run.
+8. `docker logs rustd-xyz` → claim URL → claim the panel.
+9. Add servers/credentials in the panel; flip demo/signup switches when ready to go public.
+10. Confirm first nightly backup landed on the nas.
 
 ## Error handling / operational notes
 
@@ -128,7 +139,7 @@ bouncing landing-page mailto from rustd.xyz#375.
   the workflow (container starts, `/q/health`-less — hit `/login` for 200) before push.
 - iac repo: `ansible-lint`/molecule per repo convention; the role's first real run IS the
   deploy (matches how every other role here is validated).
-- Backup restore drill: after step 9, `pg_restore` the nas dump into a scratch container once,
+- Backup restore drill: after step 10, `pg_restore` the nas dump into a scratch container once,
   documented in the role README.
 
 ## Out of scope
@@ -193,6 +204,26 @@ repo's own PR, not here — this section covers only the iac-side implementation
   (`set -euo pipefail` means a failed `pg_dump` never reaches the `mv`); added `rm -f` of any
   leftover `.tmp` at the top of the script and excluded `*.tmp` from the rsync push, in case a
   dump is still in flight when the script's own rsync step runs.
+- **Receiver identity on the nas is the vendor account `jason`, not a dedicated
+  `rustd-backup` user.** The design's assumed shape (and this role's first implementation)
+  was a dedicated locked system user, `rustd-backup`, holding the receive-side end of the
+  restricted key. Field deploy discovery found the nas appliance's vendor PAM/login stack
+  refuses to run the forced command for a locked account at all ("This account is currently
+  not available"), independent of the shell-in-`/etc/shells` issue the design already
+  anticipated (hence the earlier decision to give `rustd-backup` a real `/bin/bash` shell
+  instead of `nologin`). Unlocking a dedicated system account wasn't a fix this role wanted
+  to own on a vendor-managed appliance, so the receiver identity is instead `jason` — the
+  appliance's real, unlocked, vendor-managed account — with `rustd_xyz_backup_nas_user`
+  (`group_vars/all.yml`) repointed at it. The forced command remains the actual security
+  boundary either way: `command="/usr/local/bin/rustd-receive-dump",restrict` on the
+  authorized key means nothing about the underlying account's broader privileges is
+  reachable through that key, so this is the standard deploy-key pattern (jail a shared or
+  third-party account down to one script) rather than a weakening of the original design.
+  `rustd_backup_nas` now has no user-creation task at all — Ansible only appends to
+  `jason`'s `authorized_keys` and never touches the account itself — and carries a one-time
+  cleanup block that removes the abandoned `rustd-backup` authorized_key entry and account
+  on any host that still has it. Full rationale in `ansible/roles/rustd_backup_nas/README.md`
+  ("Restricted key").
 
 None of the above required changing this design's Decisions table or Part A; they're
 implementation-detail resolutions of things the design flagged as needing verification, plus one
@@ -209,3 +240,93 @@ bug fix (atomic dumps) found in review.
   through `common_cli` (the repo's usual tailnet-join path), since the nas is a vendor-managed
   UGREEN appliance where package/config changes are kept to the minimum this pipeline needs. See
   `ansible/roles/rustd_backup_nas/README.md` ("Tailnet membership") for the full rationale.
+- **The nas' vendor rsync can't receive, so the `rrsync` design (§B3) was replaced with a
+  forced-command receive script.** With the tailnet join working, deploy testing hit a second,
+  unrelated blocker: the nas' `/usr/bin/rsync` is a vendor-patched build (UGREEN, version 3.4.1)
+  that rejects every server-side receive with a custom `not support path` error, regardless of
+  the destination path given. There is no stock rsync to install as a workaround — this is a
+  closed vendor appliance and installing packages on it is forbidden — and `rrsync` itself just
+  shells out to that same broken `rsync` binary, so no packaging of `rrsync` (real binary or the
+  gzipped-script fallback) could have worked around it. The rrsync-based forced-command design
+  in `rustd_backup_nas` (rsync install, rrsync discovery/extract/resolve, and the `:/`
+  destination contract on the push side) was therefore unimplementable on this hardware and was
+  removed outright, not patched around.
+  Replacement protocol: the droplet ships each dump as
+  `ssh <nas-key> rustd-<date>.dump < dumpfile` — one `ssh` connection per file, the bare
+  filename as the (sole) remote command, the dump itself on stdin. The nas' authorized key is
+  now restricted to `command="/home/<user>/receive-dump.sh",restrict`, a small script deployed
+  by `rustd_backup_nas` (owned `root:root`, mode `0755` — deliberately not owned by the backup
+  user whose key it constrains) that validates `SSH_ORIGINAL_COMMAND` against a strict
+  `^rustd-[0-9]{4}-[0-9]{2}-[0-9]{2}\.dump$` filename regex (no `/`, so no path traversal),
+  then streams stdin to `<name>.tmp` and `mv`s it into place. This needs only `sshd` and `bash`
+  on the nas — no rsync protocol surface at all — and is arguably tighter than the original
+  `rrsync` design: the client controls nothing but which of a fixed filename pattern it's
+  writing, there's no read/list/delete verb to expose, and the receiver can't itself be broken
+  by a vendor rsync build. The push script now re-ships *every* local dump each night (not just
+  the newest one) rather than a single rsync of the whole directory — each dump is ~50KB, so
+  resending all `rustd_xyz_backup_local_keep` (7) nightly is cheap, and since the receive script
+  overwrites via an atomic `mv`, re-sending a dump the nas already has is an idempotent no-op
+  rather than a duplicate; this also makes the pipeline self-healing after a missed night. The
+  nas-side prune cron (`rustd_backup_nas`) additionally sweeps `*.dump.tmp` leftovers (from a
+  dead/interrupted upload) older than 1 day. Full rationale in
+  `ansible/roles/rustd_backup_nas/README.md` ("Restricted key") and
+  `ansible/roles/rustd_xyz/README.md` ("Receive protocol").
+- **The forced-command receive script above was itself defeated, and the entire
+  ssh-based receive design (§B3, and every note above about `rrsync`, restricted keys,
+  `receive-dump.sh`, and the dedicated `rustd-backup`/`jason` receiver identity) was
+  removed outright and replaced with the nas' built-in rsync daemon.** Real-world
+  deploy testing of the forced-command receiver (this doc's previous entry) uncovered
+  two further blockers that, together with the already-known broken vendor `rsync`,
+  made *any* ssh-jail design on this hardware unimplementable, not just the specific
+  `rrsync` variant:
+  1. **`sshd` on the appliance has a GLOBAL `ForceCommand`** that overrides any per-key
+     `command=` in `authorized_keys`. The forced-command receiver's entire security
+     model — "this key can only ever run `rustd-receive-dump`" — assumed per-key
+     `command=` takes precedence, which is the normal OpenSSH behavior but is not what
+     this vendor sshd config does. On this box, the global directive wins regardless of
+     what an individual key's `authorized_keys` entry says, so a key that ssh's in gets
+     whatever the global `ForceCommand` runs, not the receive script.
+  2. **Admin-privileged accounts get full command passthrough** through that global
+     `ForceCommand` anyway (a common vendor-appliance pattern: the forced command is a
+     restricted shell for ordinary users but a no-op for admins) — so even if per-key
+     restriction had worked, routing the receiver through an account with any admin
+     adjacency would not have contained it the way the design intended.
+  Combined with the earlier-documented vendor-`rsync` breakage, every layer of the
+  intended jail (rsync protocol, forced command, restricted key) turned out to be
+  closed off independently by the vendor firmware — no amount of patching the receive
+  script or picking a different receiver account could have worked, because the
+  vulnerability wasn't in this repo's script, it was in assuming sshd on this appliance
+  behaves like stock OpenSSH.
+  **The working replacement, proven end-to-end** (a real `pg_dump` landed on the nas'
+  91TB bcache array, over the tailnet, verified present on disk): UGOS's own **rsync
+  daemon**, port 873, entirely outside sshd — none of the three sshd-side blockers
+  apply to it, because it was never going through sshd. Enabling it is a **manual UGOS
+  UI prerequisite** ansible cannot perform (closed vendor appliance, no UI automation
+  path): enable the Rsync service, define a module named `storage` mapped to
+  `/volume1/storage`, and add an auth user `jason` with `rw` access
+  (`auth users = jason:rw`). The droplet now pushes the whole local backup directory in
+  one additive (no `--delete`) transfer per night:
+  ```
+  rsync -a --mkpath --password-file=<file> <localdir>/ rsync://jason@nas:873/storage/backups/rustd-db/
+  ```
+  replacing the previous per-file `ssh ... < dumpfile` loop entirely. `rustd_backup_nas`
+  shrank drastically as a result — it now only joins the tailnet and runs a root prune
+  cron; the dedicated user, target-directory ownership, `getent` group lookup,
+  `receive-dump.sh.j2` forced-command script, restricted `authorized_keys` entry, and
+  the legacy-`rustd-backup`-user cleanup tasks were all removed, and
+  `templates/receive-dump.sh.j2` was deleted from the repo. `rustd_xyz` lost its
+  droplet-side ed25519 keypair generation entirely (no key exists in this design at
+  all) and gained a single task writing the rsync daemon's password to a root-owned,
+  mode-`0600`, `no_log`'d file instead.
+  **Security note (flagged, not fixed):** the daemon's auth password for `jason` is
+  `jason`'s actual nas login password, not a separate rsync-scoped secret — UGOS
+  doesn't appear to offer distinct daemon-only credentials for the same auth-user name.
+  This means a compromise of the rustd.xyz droplet leaks full access to `jason`'s nas
+  account, not just write access to one backup directory — a real blast-radius
+  regression versus the (unimplementable) ssh-jail design's intent. Recommended
+  follow-up, not yet done: a dedicated non-admin UGOS user with its own password and
+  rsync access scoped to a narrower module (ideally rooted at `backups/rustd-db`
+  directly rather than all of `storage`), so a droplet compromise can't reach anything
+  beyond the backup pipeline itself. Full rationale, including the field evidence for
+  each blocker, in `ansible/roles/rustd_backup_nas/README.md` ("Field reality" and
+  "Security note") and `ansible/roles/rustd_xyz/README.md` ("Nightly backup -> nas").


### PR DESCRIPTION
**Follow-up to #499**, which merged the tailnet-join work at its reviewed head — but the backup *receive* design it carried (ssh forced-command + rrsync) **does not work on the UGREEN appliance**. That was discovered and rewritten during live deployment, and the rewrite landed after the merge, so it never reached main. This PR carries it in. The live infrastructure is already running the corrected design (deployed via this branch during testing); main is currently the only place with the broken code.

## Why the ssh/rrsync design was unimplementable

Discovered on the real hardware, in order:
1. The appliance ships a **vendor-patched rsync** that rejects all server-side receives (`not support path`) — no path/config makes it work; it exists only to serve the vendor rsync service.
2. sshd has a **global `ForceCommand`** wrapper that overrides any per-key `command=` in authorized_keys — so an ssh forced-command jail is structurally impossible.
3. That wrapper gives **admin-group users full command passthrough** and restricts non-admin users to rsync/sftp/scp — and a synthetic locked system user isn’t honored at all.

## The working path (vendor-supported)

UGOS’s **built-in rsync daemon** (port 873), enabled once in the UI — a documented manual prerequisite; ansible can’t configure a closed appliance. Module `storage` → `/volume1/storage`, `auth users = jason:rw`. The droplet pushes its whole local dump dir with `rsync --mkpath --password-file … rsync://jason@nas:873/storage/backups/rustd-db/` over the tailnet. The `rustd_backup_nas` role shrinks to **tailnet-join + a root prune cron** (all the user/key/rrsync/receiver machinery is deleted). Proven end to end — dumps land on the 91 TB bcache array, and the nightly `systemctl start rustd-db-backup.service` was verified live.

## Security follow-up (documented in both role READMEs + the spec)

The daemon auth is **jason’s full nas login password**, so a droplet compromise would leak nas access. A dedicated non-admin rsync-service account (its own password, module-scoped) would contain that — flagged as the next hardening step, not done here since you configured the service under jason.

`ansible-lint` + `--syntax-check` green; `verify.yml` left at main’s ansible 14.3.0 (the branch’s stale 14.2.0 was excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)