### PR TITLE
fix(sair): restart services when install script updates binaries

### DIFF
--- a/ansible/roles/sair/handlers/main.yml
+++ b/ansible/roles/sair/handlers/main.yml
@@ -4,9 +4,11 @@
   ansible.builtin.systemd:
     name: sair-device-source
     state: restarted
+  when: not sair_adb_only
 
 - name: Restart proxy
   become: true
   ansible.builtin.systemd:
     name: sair-proxy
     state: restarted
+  when: not sair_adb_only

--- a/ansible/roles/sair/tasks/main.yml
+++ b/ansible/roles/sair/tasks/main.yml
@@ -28,6 +28,11 @@
       {{ '--version ' ~ sair_version if sair_version | length > 0 else '' }}
   register: sair_install
   changed_when: sair_install.stdout is search('Installed|Updated')
+  # install.sh only writes binaries and daemon-reloads; running services keep
+  # the old build until restarted, so notify on any install/update
+  notify:
+    - Restart device source
+    - Restart proxy
 
 - name: Clean up install script
   become: true


### PR DESCRIPTION
The `sair` role's install task registers changed-when on `Installed|Updated` but notifies nothing, and `install.sh` itself only writes binaries + `systemctl daemon-reload`. Result: after a version bump, `sair-proxy`/`sair-device-source` keep running the old build until something else restarts them.

This bit today on ubuntu-cube: the v0.0.12 binaries landed on disk at 18:59, but the proxy process from Aug 10 kept serving — silently ignoring the new `--count` lock parameter, so count-1 acquires locked the whole pool and `connectedCheck` ran on both phones.

The install task now notifies both restart handlers, with `when: not sair_adb_only` guards on the handlers since adb-only hosts (ubuntu-silverstone) run neither service.

`ansible-lint` passes on the role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)