### PR TITLE
Bump rust_gameserver collection to 0.3.0 for the host-visible install root

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -31,7 +31,7 @@ collections:
   - name: compscidr.github_runner
     version: "0.1.5"
   - name: compscidr.rust_gameserver
-    version: "0.2.0"
+    version: "0.3.0"
   - name: compscidr.github_cli
     version: "0.0.16"
   - name: compscidr.onepassword


### PR DESCRIPTION
Picks up compscidr/ansible-rust-gameserver#26 (released as 0.3.0): the game install root is now bind-mounted at `/etc/rust/server/<identity>/install`, so files the game writes to its root — vanilla `world.rendermap` output that rustd.xyz fetches over SSH — are host-visible.

Notes for the next deploy of the NAS servers (weekly/monthly):
- Containers are recreated and steamcmd re-downloads the game into the new `install/` dir once (~8 GB each, brief downtime).
- Saves, plugins, and env files are untouched — the existing narrower mounts nest on top of the new one.
- Weekly/monthly serve their maps via the Oxide plugin, so this is consistency/future-proofing for them; the vanilla-fetch path is what the build server needs (deployed outside this repo — redeploy it with the updated collection separately, then set its rustd.xyz "Map render path on host" to `/etc/rust/server/build/install`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)