### PR TITLE
rust_gameserver 0.4.0: one host tree per server

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -31,7 +31,7 @@ collections:
   - name: compscidr.github_runner
     version: "0.1.5"
   - name: compscidr.rust_gameserver
-    version: "0.3.0"
+    version: "0.3.1"
   - name: compscidr.github_cli
     version: "0.0.16"
   - name: compscidr.onepassword

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -31,7 +31,7 @@ collections:
   - name: compscidr.github_runner
     version: "0.1.5"
   - name: compscidr.rust_gameserver
-    version: "0.3.1"
+    version: "0.4.0"
   - name: compscidr.github_cli
     version: "0.0.16"
   - name: compscidr.onepassword

--- a/ansible/roles/rust_game/tasks/main.yml
+++ b/ansible/roles/rust_game/tasks/main.yml
@@ -43,7 +43,7 @@
     force: "{{ item.force | default(true) }}"
   loop:
     - src: files/oxide.config.json
-      dest: /etc/rust/server/weekly/oxide/oxide.config.json
+      dest: /etc/rust/install/weekly/oxide/oxide.config.json
       force: false
 # only if we want a modded server
 #    - src: files/Oxide.Ext.RustIO.dll
@@ -62,7 +62,7 @@
   tags: rust-weekly
   become: true
   ansible.builtin.file:
-    path: /etc/rust/server/weekly/oxide/plugins/RustadminOnline.cs
+    path: /etc/rust/install/weekly/oxide/plugins/RustadminOnline.cs
     state: absent
 
 - name: Install rust monthly server
@@ -110,7 +110,7 @@
     force: "{{ item.force | default(true) }}"
   loop:
     - src: files/oxide.config.json
-      dest: /etc/rust/server/monthly/oxide/oxide.config.json
+      dest: /etc/rust/install/monthly/oxide/oxide.config.json
       force: false
 # only if we want a modded server
 #    - src: files/Oxide.Ext.RustIO.dll
@@ -129,5 +129,5 @@
   tags: rust-monthly
   become: true
   ansible.builtin.file:
-    path: /etc/rust/server/monthly/oxide/plugins/RustadminOnline.cs
+    path: /etc/rust/install/monthly/oxide/plugins/RustadminOnline.cs
     state: absent

--- a/ansible/roles/rust_game_cube/tasks/main.yml
+++ b/ansible/roles/rust_game_cube/tasks/main.yml
@@ -35,8 +35,11 @@
     rust_gameserver_manage_wipe_cron: false
     rust_gameserver_overwrite_env: false
     # Lets rustd.xyz write in the identity directory without root — see
-    # compscidr/ansible-rust-gameserver#25. Inert until collection 0.2.0 is pinned
-    # (compscidr/iac#486 does that bump).
+    # compscidr/ansible-rust-gameserver#25. Under collection 0.4.0 the identity dir
+    # lives inside the per-server tree: /etc/rust/install/build/server/build (the
+    # whole tree is /etc/rust/install/build, mounted at the container's
+    # /steamcmd/rust — no paths appear here because the collection role owns them
+    # all; this play picks the layout up purely through the requirements.yml pin).
     rust_gameserver_manager_users:
       - jason
     rust_gameserver_identity_dir_mode: '2775'


### PR DESCRIPTION
Bumps the collection past the broken 0.3.0 (never deploy it — its nested install mount crash-loops the container) straight to 0.4.0 (compscidr/ansible-rust-gameserver#27): each server's entire tree — game install, oxide, saves, env files — lives under `/etc/rust/install/<identity>`, bind-mounted at `/steamcmd/rust`.

## What changes where
- **`requirements.yml` pin → 0.4.0** — this alone carries the new layout to **every** deploy that uses the collection: `nas.yml` (weekly, monthly) **and `cube.yml` (build)**. `rust_game_cube` contains no filesystem paths, so there is nothing build-specific to edit — a comment there now says exactly that.
- **`rust_game` oxide copy destinations** move to `/etc/rust/install/{weekly,monthly}/oxide/...` — these are the only literal paths iac owns.

## Runbook (after merging + releasing collection 0.4.0)
Per host, from `~/dev/iac/ansible`: `git pull`, `ansible-galaxy collection install -r requirements.yml --force` (from this directory, so it lands in `./.galaxy-collections` — the path that wins), then **before** running the playbook, migrate each server on that host (commands in the collection CHANGELOG: stop container → move `/etc/rust/server/<id>` into the tree → lift `oxide/`/`RustDedicated_Data/` to the root → on cube, delete the 0.3.0 orphan `install/`). Then:
- ubuntu-cube: `ansible-playbook -i inventory.yml cube.yml` (build)
- nas: `ansible-playbook -i inventory.yml nas.yml` (weekly, monthly)

First boot downloads the game into each tree (~8 GB/server). Finally set the panel's per-server paths: data path `/etc/rust/install/<id>/server/<id>`, map render path `/etc/rust/install/<id>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)