### PR TITLE
sshd_alt_port: bind the alternate port on both address families

### DIFF
--- a/ansible/roles/sshd_alt_port/tasks/main.yml
+++ b/ansible/roles/sshd_alt_port/tasks/main.yml
@@ -56,13 +56,20 @@
 
         # ListenStream entries are ADDITIVE: the stock unit keeps 22, this adds the
         # alternate. (An empty `ListenStream=` line would reset instead — do not add one.)
+        #
+        # BOTH address families, explicitly, like the stock unit's `0.0.0.0:22` + `[::]:22`
+        # pair: a bare `ListenStream={{ sshd_alt_port_number }}` bound ONLY `[::]` and that
+        # socket turned out v6-only in the field — IPv4 to the port was refused even on
+        # loopback, which is precisely the address family the tailnet fetch uses
+        # (found live on ubuntu-cube, 2026-08-13).
         - name: Add the alternate port to ssh.socket
           ansible.builtin.copy:
             dest: /etc/systemd/system/ssh.socket.d/alt-port.conf
             content: |
               # Managed by ansible (sshd_alt_port). See the role for why this exists.
               [Socket]
-              ListenStream={{ sshd_alt_port_number }}
+              ListenStream=0.0.0.0:{{ sshd_alt_port_number }}
+              ListenStream=[::]:{{ sshd_alt_port_number }}
             owner: root
             group: root
             mode: "0644"


### PR DESCRIPTION
Field bug from deploying #505 to ubuntu-cube: the bare `ListenStream=2222` bound only `[::]:2222`, and that socket came up **v6-only** — IPv4 connections to the port were refused even on the box's own loopback. IPv4 is exactly what matters here: the rustd.xyz panel reaches the host at its tailnet IPv4 (`100.126.183.41:2222`), and LAN ssh does too.

Fix mirrors the stock `ssh.socket`, which declares `0.0.0.0:22` and `[::]:22` explicitly for the same reason:

```
ListenStream=0.0.0.0:{{ sshd_alt_port_number }}
ListenStream=[::]:{{ sshd_alt_port_number }}
```

Diagnosis trail: refused on LAN → refused on 127.0.0.1 (so binding, not firewall/tailscale) → `systemctl show ssh.socket -p Listen` showed only `[::]:2222` next to the stock unit's explicit pair. The change is idempotent over the already-deployed override (content differs → copy updates → handler restarts the socket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)