### PR TITLE
Bump compscidr.rust_gameserver to 0.4.1 for the env-file permissions fix

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -31,7 +31,7 @@ collections:
   - name: compscidr.github_runner
     version: "0.1.5"
   - name: compscidr.rust_gameserver
-    version: "0.4.0"
+    version: "0.4.1"
   - name: compscidr.github_cli
     version: "0.0.16"
   - name: compscidr.onepassword

--- a/ansible/roles/rust_game_cube/tasks/main.yml
+++ b/ansible/roles/rust_game_cube/tasks/main.yml
@@ -35,7 +35,11 @@
     rust_gameserver_manage_wipe_cron: false
     rust_gameserver_overwrite_env: false
     # Lets rustd.xyz write in the identity directory without root — see
-    # compscidr/ansible-rust-gameserver#25. Under collection 0.4.0 the identity dir
+    # compscidr/ansible-rust-gameserver#25. The directory grant is necessary but NOT
+    # sufficient: rust.env and seed.env are bind-mounted into the container as single
+    # files, so rustd.xyz has to rewrite them in place rather than replace them, which
+    # needs group write on the files themselves (collection 0.4.1,
+    # compscidr/ansible-rust-gameserver#28). Under collection 0.4.0+ the identity dir
     # lives inside the per-server tree: /etc/rust/install/build/server/build (the
     # whole tree is /etc/rust/install/build, mounted at the container's
     # /steamcmd/rust — no paths appear here because the collection role owns them


### PR DESCRIPTION
Picks up [compscidr/ansible-rust-gameserver#28](https://github.com/compscidr/ansible-rust-gameserver/pull/28), which makes `rust.env` (`660`) and `seed.env` (`664`) group-writable for the runtime group.

## Why it matters

Both files are bind-mounted into the container as **single files**, and a single-file bind mount follows the **inode**, not the path. Rewriting one the easy way — `sed -i`, or anything that writes a temp and renames over the target — only needs write on the *directory*, but it replaces the inode and orphans the mount. The container then reads the original file forever while the write keeps reporting success.

That is not theoretical. On `rust-weekly`, after the 2026-08-13 wipe:

| | host inode | container inode |
|--|--|--|
| `seed.env` | 1441942 (`RUST_SERVER_SEED=1074800640`) | 1479079 (`RUST_SERVER_SEED=688899028`) |

Confirmed by the map the wipe generated, which encodes the seed in its name — `proceduralmap.3000.688899028.287.map`. **Every seed change rustd.xyz ever made was discarded**, so wipes kept regenerating the same map.

The panel now writes in place ([rustd.xyz#410](https://github.com/compscidr/rustd.xyz/pull/410)), which needs write on the *file* — hence this bump.

## Scope

Only the version pin. All three call sites (`rust_game` ×2, `rust_game_cube`) already pass `rust_gameserver_manager_users` and `rust_gameserver_identity_dir_mode`, so the manager user is already in the runtime group; 0.4.1 adds the file grant on top of the directory grant.

Also corrects a comment in `rust_game_cube` that credited the directory grant with letting rustd.xyz write. It is necessary but not sufficient, which is exactly the gap that caused the bug.

## Verified

`0.4.1` is published on Galaxy, and I installed the published artifact to confirm it carries the fix rather than trusting the tag:

```
compscidr.rust_gameserver:0.4.1 was installed successfully

116:    mode: '660'      # rust.env template
129:    mode: '660'      # rust.env enforcement
144:    mode: '664'      # seed.env template
152:- name: Enforce seed.env permissions
157:    mode: '664'
```

The `Enforce seed.env permissions` task is the one that matters for the existing servers: `force: false` skips mode and group on a file that already exists, so without it weekly and monthly would stay on `644 root:root` and the fix would only reach new installs.

## After applying

`rust-weekly`'s `seed.env` mount is currently orphaned again (the container chowned the file back to `steam:steam` on last night's restart). One `docker restart rust-weekly` re-binds it — Docker re-resolves the bind source on every start, verified. A plain playbook run will not do it, because `docker_container` only recreates on a config difference and an orphaned inode is invisible to that comparison.

Worth confirming afterwards:

```
docker exec rust-weekly grep RUST_SERVER_SEED /etc/rust/seed.env   # must match the host file
stat -c '%a %U:%G' /etc/rust/install/weekly/server/weekly/{rust,seed}.env   # 660 / 664
```