### PR TITLE
Supervise the rust-test server now that #340 is answered

### DIFF
--- a/ansible/roles/rust_test_server/defaults/main.yml
+++ b/ansible/roles/rust_test_server/defaults/main.yml
@@ -33,4 +33,4 @@ rust_test_server_seed: 1337
 # #340 needs to know what happens to an UNsupervised server when rustd.xyz restarts
 # it. Start it by hand in the foreground for that, or enable the unit once the
 # question is answered and you want it to stay up.
-rust_test_server_service_enabled: false
+rust_test_server_service_enabled: true

--- a/ansible/roles/rust_test_server/defaults/main.yml
+++ b/ansible/roles/rust_test_server/defaults/main.yml
@@ -28,9 +28,15 @@ rust_test_server_rcon_port: 30017
 rust_test_server_app_port: 30082
 rust_test_server_seed: 1337
 
-# The systemd unit is installed but left DISABLED and STOPPED on purpose. Enabling it
-# would supervise the process and destroy the property this server exists to test:
-# #340 needs to know what happens to an UNsupervised server when rustd.xyz restarts
-# it. Start it by hand in the foreground for that, or enable the unit once the
-# question is answered and you want it to stay up.
+# Whether the systemd unit is enabled at boot AND started by this role. True means the
+# server is supervised: it comes back on its own after an RCON `restart`, like a real
+# deployment.
+#
+# This was false on purpose while compscidr/rustd.xyz#340 needed an UNSUPERVISED server
+# to observe -- the question was what happens to one when rustd.xyz restarts it, and the
+# answer is that the process exits and stays down. That is now recorded on the issue, so
+# the server runs supervised.
+#
+# Set this back to false to reproduce the unsupervised case across a deploy. For a
+# one-off, `systemctl stop rust-test` is enough and needs no config change.
 rust_test_server_service_enabled: true

--- a/ansible/roles/rust_test_server/tasks/main.yml
+++ b/ansible/roles/rust_test_server/tasks/main.yml
@@ -147,10 +147,10 @@
     owner: root
     group: root
 
-# Enabled and started by default. This was deliberately NOT the case while #340 needed
-# an unsupervised server to observe; that question is answered (the process exits and
-# stays down), so it now runs like a real deployment. `systemctl stop rust-test`
-# reproduces the unsupervised case on demand.
+# Both the boot-time enablement and the current state follow rust_test_server_service_enabled,
+# which now defaults to true -- so by default this starts the server and enables it at boot.
+# Override the variable to false and this stops it and leaves it disabled instead, which is
+# how the unsupervised case (#340) is reproduced across a deploy.
 - name: Set the service state
   tags: rust-test
   become: true

--- a/ansible/roles/rust_test_server/tasks/main.yml
+++ b/ansible/roles/rust_test_server/tasks/main.yml
@@ -147,9 +147,10 @@
     owner: root
     group: root
 
-# Installed but not enabled or started by default — see the comment on
-# rust_test_server_service_enabled. Supervising this process is the thing #340 is
-# trying to observe the absence of.
+# Enabled and started by default. This was deliberately NOT the case while #340 needed
+# an unsupervised server to observe; that question is answered (the process exits and
+# stays down), so it now runs like a real deployment. `systemctl stop rust-test`
+# reproduces the unsupervised case on demand.
 - name: Set the service state
   tags: rust-test
   become: true

--- a/ansible/roles/rust_test_server/templates/rust-test.service.j2
+++ b/ansible/roles/rust_test_server/templates/rust-test.service.j2
@@ -1,12 +1,18 @@
 # {{ ansible_managed }}
 #
-# Installed but NOT enabled by default (see rust_test_server_service_enabled).
+# Enabled and supervised (see rust_test_server_service_enabled).
 #
-# Note `Restart=no`: the whole point of this server is to be the unsupervised case
-# for compscidr/rustd.xyz#340. If you enable this unit AND set Restart=always, you
-# have made it a supervised server and it no longer answers that question — which is
-# fine once the question is answered, but should be a deliberate change rather than a
-# copied default.
+# This unit used to run `Restart=no`, deliberately, so it could be the UNSUPERVISED case
+# for compscidr/rustd.xyz#340 — "does a Rust server come back on its own after an RCON
+# `restart`?". It does not: the process exits and, with nothing supervising it, stays
+# down. That question is now answered, so the server is supervised like a real one.
+#
+# `always` rather than `on-failure` because #340's remaining unknown is the EXIT CODE:
+# on-failure would not recover a clean exit 0. `always` still respects `systemctl stop`,
+# so manual control is unaffected.
+#
+# Reverting to the unsupervised case for a test is `systemctl stop rust-test` — it no
+# longer needs a config change.
 [Unit]
 Description=Rust dedicated server (rustd.xyz test)
 After=network-online.target
@@ -17,7 +23,10 @@ Type=simple
 User={{ rust_test_server_user }}
 WorkingDirectory={{ rust_test_server_root }}
 ExecStart={{ rust_test_server_root }}/start.sh
-Restart=no
+Restart=always
+# systemd's default is 100ms. A server that dies during boot would otherwise burn
+# through the start-limit burst in under a second and be given up on entirely.
+RestartSec=10
 KillSignal=SIGINT
 TimeoutStopSec=120
 

--- a/ansible/roles/rust_test_server/templates/rust-test.service.j2
+++ b/ansible/roles/rust_test_server/templates/rust-test.service.j2
@@ -1,6 +1,8 @@
 # {{ ansible_managed }}
 #
-# Enabled and supervised (see rust_test_server_service_enabled).
+# Supervised, and enabled at boot BY DEFAULT -- this template only sets the restart
+# policy; whether the unit is enabled and started is rust_test_server_service_enabled,
+# which the role applies separately and which can be overridden to false.
 #
 # This unit used to run `Restart=no`, deliberately, so it could be the UNSUPERVISED case
 # for compscidr/rustd.xyz#340 — "does a Rust server come back on its own after an RCON


### PR DESCRIPTION
`rust-test` on `ubuntu-cube` shipped disabled with `Restart=no`, deliberately: it was the **unsupervised case** for [compscidr/rustd.xyz#340](https://github.com/compscidr/rustd.xyz/issues/340) — *"does a Rust server come back on its own after an RCON `restart`?"*

It does not. The process exits and, with nothing supervising it, stays down until someone intervenes. That is the answer the spike wanted, and keeping the server permanently off no longer buys anything.

## Changes

| | was | now |
|--|--|--|
| `rust_test_server_service_enabled` | `false` | `true` |
| `Restart=` | `no` | `always` |
| `RestartSec=` | (systemd default, 100 ms) | `10` |

Both halves are needed. `service_enabled` alone starts it and enables it at boot, but with `Restart=no` the first RCON `restart` — the exact thing that exits the process — leaves it down until the next reboot. That is "running", not "stays running".

`always` rather than `on-failure` because #340's remaining unknown is the **exit code**: `on-failure` would not recover a clean exit 0. `always` still respects `systemctl stop`, so manual control is unaffected.

`RestartSec=10` because the unit is on systemd's 100 ms default — a server failing during boot would burn through the start-limit burst in under a second and be given up on entirely, which looks identical to the bug this change is meant to remove.

## What we give up, and why it is fine

This leaves no permanently-unsupervised server. That state still matters for exercising the panel's "server didn't come back" paths — the wipe's 5-minute reconnect timeout, and the revert cycle in [rustd.xyz#343](https://github.com/compscidr/rustd.xyz/issues/343)'s blueprint restore.

But `systemctl stop rust-test` reproduces it on demand now, rather than requiring a config change and a deploy. It stops being the default, not the possibility.

The trade is a clear win for testing: a wipe against this server will now complete end to end instead of stranding it, which is what makes it usable for the #343 blueprint verification that still needs doing.

## Notes

- The unit template's own comment anticipated exactly this change and asked that it be deliberate rather than a copied default — it is rewritten to describe the new reality and record why.
- `ansible-lint` passes at the `production` profile.
- The finding is recorded on rustd.xyz#340 so the evidence survives removing the conditions that produced it.