### PR TITLE
Bump compscidr.rust_gameserver to 0.4.2 for the repo-hosted default banner

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -31,7 +31,7 @@ collections:
   - name: compscidr.github_runner
     version: "0.1.5"
   - name: compscidr.rust_gameserver
-    version: "0.4.1"
+    version: "0.4.2"
   - name: compscidr.github_cli
     version: "0.0.16"
   - name: compscidr.onepassword


### PR DESCRIPTION
0.4.2 ([compscidr/ansible-rust-gameserver#29](https://github.com/compscidr/ansible-rust-gameserver/pull/29)) moves the collection's default `rust_gameserver_banner_url` off imgbox — which went down — onto an image served from the collection repo itself.

Only the **California build server** changes: it's the one server here that takes the default banner, so it's been showing a broken image in the server browser. The weekly and monthly servers on nas.local set `rust_gameserver_banner_url` explicitly to `california-rust.jpg` and are untouched.

Verified before opening: 0.4.2 is published on Galaxy, and the new default URL returns 200 on `main`.

Deploy with the `rust-build` tag against `cube.yml` to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)