### PR TITLE
Name the account each Rust server runs as, per host

### DIFF
--- a/ansible/cube.yml
+++ b/ansible/cube.yml
@@ -20,6 +20,10 @@
     # place, and each playbook names the ones it wants. The build server only here: the
     # weekly and monthly servers in that role are the ones people actually play on.
     - role: rust_game
+      # A DEDICATED account. The game used to run as jason -- also the manager -- so every
+      # permission the collection sets was a no-op and the manager could read the RCON
+      # password from the game's /proc entry. See rustd.xyz#419.
+      rust_game_runtime_user: rustsvc
       rust_game_servers:
         - build
     - rust_test_server

--- a/ansible/nas.yml
+++ b/ansible/nas.yml
@@ -24,6 +24,9 @@
     # The two production community servers. The build server shares this role but
     # belongs to ubuntu-cube.local — see cube.yml.
     - role: rust_game
+      # The account these servers have always run as. Naming it makes an incidental uid
+      # explicit: without this the collection resolves "whoever is uid 1000 here".
+      rust_game_runtime_user: steam
       rust_game_servers:
         - weekly
         - monthly

--- a/ansible/roles/rust_game/defaults/main.yml
+++ b/ansible/roles/rust_game/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# The account the game runs as, per host. Empty means the collection falls back to its
+# numeric puid/pgid, which resolves to "whoever happens to be uid 1000 here" -- steam on
+# nas, but the MANAGER's own account on ubuntu-cube. Naming it removes that ambiguity.
+#
+# In defaults/ rather than vars/ on purpose: role vars outrank playbook vars, so a value
+# here can be set per playbook while vars/ could not be overridden at all.
+rust_game_runtime_user: ""

--- a/ansible/roles/rust_game/tasks/main.yml
+++ b/ansible/roles/rust_game/tasks/main.yml
@@ -34,6 +34,7 @@
         rust_gameserver_manage_wipe_cron: false
         # Defined once in vars/main.yml — see there for why this is group membership
         # rather than sudo, and why the setgid bit is load-bearing.
+        rust_gameserver_runtime_user: "{{ rust_game_runtime_user }}"
         rust_gameserver_manager_users: "{{ rust_game_manager_users }}"
         rust_gameserver_identity_dir_mode: "{{ rust_game_identity_dir_mode }}"
         rust_gameserver_overwrite_env: false
@@ -108,6 +109,7 @@
         rust_gameserver_manage_wipe_cron: false
         # Defined once in vars/main.yml — see there for why this is group membership
         # rather than sudo, and why the setgid bit is load-bearing.
+        rust_gameserver_runtime_user: "{{ rust_game_runtime_user }}"
         rust_gameserver_manager_users: "{{ rust_game_manager_users }}"
         rust_gameserver_identity_dir_mode: "{{ rust_game_identity_dir_mode }}"
         rust_gameserver_overwrite_env: false
@@ -199,6 +201,7 @@
         # mounted at the container's /steamcmd/rust — no paths appear here because the
         # collection role owns them all; this play picks the layout up purely through the
         # requirements.yml pin).
+        rust_gameserver_runtime_user: "{{ rust_game_runtime_user }}"
         rust_gameserver_manager_users: "{{ rust_game_manager_users }}"
         rust_gameserver_identity_dir_mode: "{{ rust_game_identity_dir_mode }}"
         rust_gameserver_banner_url: "{{ rust_game_banner_url }}"


### PR DESCRIPTION
Required before `cube.yml` can deploy against collection 0.5.0+ — it currently fails by design.

## Why

`rust_gameserver_puid`/`pgid` default to `1000`, which resolves to a different identity per host:

| host | uid 1000 | manager | |
|--|--|--|--|
| `nas.local` | `steam` | `jason` | fine |
| `ubuntu-cube` | `jason` | `jason` | **the game runs as the manager** |

When those collide, every permission the collection sets is a no-op: the manager owns the files outright, so the `660`/`664` modes and the setgid identity directory grant nothing, and adding the manager to "the runtime group" adds it to its own group. The build server has been in that state — working, with none of its security properties.

It also removes the only mitigation for the RCON password being readable from `/proc` ([rustd.xyz#419](https://github.com/compscidr/rustd.xyz/issues/419)): a process cannot be hidden from its own owner, so `hidepid` buys nothing while the game runs as `jason`.

[compscidr/ansible-rust-gameserver#30](https://github.com/compscidr/ansible-rust-gameserver/pull/30) added a guard that refuses this shape, so `cube.yml` fails until this lands. That is the guard working.

## Change

- `nas.yml` → `steam`, the account those servers have always used. No behaviour change; it stops being an inference from "whoever is uid 1000".
- `cube.yml` → `rustsvc`, a dedicated account.

Passed at the role invocation next to `rust_game_servers`, since which account exists is a property of the host. The default lives in `defaults/` rather than `vars/` because role vars outrank playbook vars and could not be overridden per playbook at all.

## Host prep already done on ubuntu-cube

```
user rustsvc:  rustsvc:x:996:988::/home/rustsvc:/usr/sbin/nologin
tree owner:    rustsvc:rustsvc
stragglers still owned by jason: 0
container:     exited
```

`rustsvc`'s primary group is `rustsvc`, and on nas `steam`'s is `steam` — both satisfy the collection's adopt-path check, which refuses to change an existing account's primary group rather than silently rewriting it.

Nothing is needed on nas: `steam` already exists with uid/gid 1000, so the collection adopts it and resolves to exactly the ids in use today.

## After merging

Deploy `cube.yml`. The role adopts `rustsvc`, adds `jason` to its group, applies the setgid directory and the `660`/`664` modes, and recreates the container with the new `PUID`/`PGID`. Then start the container and confirm the panel can still write `rust.env`/`seed.env` — that is the thing this changes from "works because the manager owns the files" to "works because the group grant is real".