### PR TITLE
Give rustd.xyz's panel a GeoLite2 key and somewhere to keep the database

### DIFF
--- a/ansible/projects.yml
+++ b/ansible/projects.yml
@@ -37,6 +37,11 @@
       account_id=onepassword_account_id) }}"
     rustd_xyz_db_password: "{{ lookup('community.general.onepassword', 'rustd-db', field='password', vault=onepassword_vault,
       account_id=onepassword_account_id) }}"
+    # MaxMind GeoLite2 key for country-by-IP on player profiles. The item must exist
+    # before this playbook runs - a onepassword lookup for a missing item is a hard
+    # failure, not an empty string.
+    rustd_xyz_geoip_license_key: "{{ lookup('community.general.onepassword', 'maxmind-geolite2', field='credential', vault=onepassword_vault,
+      account_id=onepassword_account_id) }}"
     rustd_xyz_smtp_username: "{{ lookup('community.general.onepassword', 'SMTP_USER - rustd', field='username', vault=onepassword_vault,
       account_id=onepassword_account_id) }}"
     rustd_xyz_smtp_password: "{{ lookup('community.general.onepassword', 'SMTP_USER - rustd', field='password', vault=onepassword_vault,

--- a/ansible/roles/rustd_xyz/defaults/main.yml
+++ b/ansible/roles/rustd_xyz/defaults/main.yml
@@ -19,6 +19,13 @@ rustd_xyz_db_name: "rustd"
 rustd_xyz_db_user: "rustd"
 rustd_xyz_db_password: "" # from projects.yml (1Password item rustd-db)
 
+# MaxMind GeoLite2 license key - enables country-by-IP on player profiles.
+# The panel keeps a LOCAL copy of the country database and looks IPs up in it;
+# nothing about a player leaves the instance. Blank means the feature runs dark
+# (every lookup returns no country), which is what production did until now -
+# see compscidr/rustd.xyz#455. From projects.yml (1Password item maxmind-geolite2).
+rustd_xyz_geoip_license_key: ""
+
 # SMTP for account claim / notification mail
 rustd_xyz_smtp_host: "mail.rustd.xyz"
 rustd_xyz_smtp_port: 465

--- a/ansible/roles/rustd_xyz/tasks/main.yml
+++ b/ansible/roles/rustd_xyz/tasks/main.yml
@@ -37,6 +37,16 @@
   community.docker.docker_volume:
     name: rustd-db-data
 
+# The panel downloads a ~9MB GeoLite2 country database into /app/data and refreshes
+# it weekly. Without a volume that download is repeated after every restart; with one
+# it survives. A fresh volume inherits /app/data's ownership from the image, which is
+# the runtime user (compscidr/rustd.xyz#455) - do NOT mount it anywhere else, /app
+# itself is root-owned and the container runs unprivileged.
+- name: Create rustd geoip data volume
+  become: true
+  community.docker.docker_volume:
+    name: rustd-geoip-data
+
 - name: Deploy rustd postgres
   become: true
   no_log: true
@@ -65,6 +75,8 @@
     networks:
       - name: nginx-proxy
       - name: rustd-db
+    volumes:
+      - "rustd-geoip-data:/app/data"
     env:
       QUARKUS_DATASOURCE_JDBC_URL: "jdbc:postgresql://rustd-db:5432/{{ rustd_xyz_db_name }}"
       QUARKUS_DATASOURCE_USERNAME: "{{ rustd_xyz_db_user }}"
@@ -80,6 +92,9 @@
       # alias for the same thing; quarkus.mailer.start-tls is a *different*
       # knob (STARTTLS upgrade of a plaintext connection) and is wrong here.
       QUARKUS_MAILER_TLS: "true"
+      # Quarkus maps this to rustd.geoip.license-key. Absent, the panel serves no
+      # player countries at all and (before rustd.xyz#455) said nothing about why.
+      RUSTD_GEOIP_LICENSE_KEY: "{{ rustd_xyz_geoip_license_key }}"
       VIRTUAL_HOST: "{{ rustd_xyz_domain }}"
       VIRTUAL_PORT: "{{ rustd_xyz_port | string }}"
       LETSENCRYPT_HOST: "{{ rustd_xyz_domain }}"

--- a/ansible/roles/rustd_xyz/tasks/main.yml
+++ b/ansible/roles/rustd_xyz/tasks/main.yml
@@ -40,7 +40,7 @@
 # The panel downloads a ~9MB GeoLite2 country database into /app/data and refreshes
 # it weekly. Without a volume that download is repeated after every restart; with one
 # it survives. A fresh volume inherits /app/data's ownership from the image, which is
-# the runtime user (compscidr/rustd.xyz#455) - do NOT mount it anywhere else, /app
+# the runtime user (compscidr/rustd.xyz#464) - do NOT mount it anywhere else, /app
 # itself is root-owned and the container runs unprivileged.
 - name: Create rustd geoip data volume
   become: true
@@ -93,7 +93,7 @@
       # knob (STARTTLS upgrade of a plaintext connection) and is wrong here.
       QUARKUS_MAILER_TLS: "true"
       # Quarkus maps this to rustd.geoip.license-key. Absent, the panel serves no
-      # player countries at all and (before rustd.xyz#455) said nothing about why.
+      # player countries at all and (before rustd.xyz#464) said nothing about why.
       RUSTD_GEOIP_LICENSE_KEY: "{{ rustd_xyz_geoip_license_key }}"
       VIRTUAL_HOST: "{{ rustd_xyz_domain }}"
       VIRTUAL_PORT: "{{ rustd_xyz_port | string }}"


### PR DESCRIPTION
Deploy-side half of compscidr/rustd.xyz#455 — player country/location has never worked in production. The app-side half is compscidr/rustd.xyz#464.

## Why it was broken

The `rustd_xyz` role passes the panel only datasource, mailer and nginx-proxy vars. `grep -rn GEOIP` over this repo returned nothing, so `RUSTD_GEOIP_LICENSE_KEY` was never set. With a blank key the panel skips the GeoLite2 download at startup, its weekly refresh returns immediately, and every country lookup returns null — silently, until rustd.xyz#464 taught it to say so.

## Changes

- **`RUSTD_GEOIP_LICENSE_KEY`** passed to the panel container, sourced in `projects.yml` from 1Password like the other secrets.
- **`rustd-geoip-data` named volume at `/app/data`**, where the panel keeps the ~9MB country database it downloads and refreshes weekly. Without it that download repeats after every restart.

## Before merging

⚠️ **Create the 1Password item first.** `maxmind-geolite2` in the Infrastructure vault, license key in the `credential` field (Jason has the key — it's the one in his local `.env`). A `community.general.onepassword` lookup for a missing item is a hard failure, so this playbook will not run until the item exists.

If a different item name or field suits your vault layout better, that's a one-line change in `projects.yml`.

## Ordering

⚠️ **rustd.xyz#464 must be merged and its image published before this is applied.** `/app` is root-owned and the container runs as uid 1001, so until the image creates `/app/data` owned by the runtime user, nothing can write there — volume or not. Verified against the real image:

```
old image:  mkdir /app/data  -> Permission denied
#464 image: /app/data drwxr-xr-x rustd root, writes OK
            fresh named volume mounted there inherits that ownership
```

Applied in the wrong order the panel stays dark, but now logs exactly why:
```
WARN GeoIpService  Cannot create the GeoIP database directory /app/data — country lookups stay disabled
```

## Verification

`ansible-lint` clean (`0 failure(s), 0 warning(s) on 20 files`, production profile). Not applied to live infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)