### PR TITLE
sshd_alt_port for UGOS: clean second sshd on the NAS (:2222)

### DIFF
--- a/ansible/nas.yml
+++ b/ansible/nas.yml
@@ -33,3 +33,7 @@
     # - cs2_game
     - dyndns
     - { role: rustd_backup_nas, tags: [rustd, rustd-backup] }
+    # Real sshd on :2222 (the UGOS counterpart of sshd_alt_port): the vendor sshd's
+    # SFTP is chrooted to the share view, which broke the rustd.xyz panel's file
+    # reads for the servers above — see the role README and rustd.xyz#456.
+    - { role: sshd_alt_port_ugos, tags: [rustd, ssh-alt] }

--- a/ansible/roles/sshd_alt_port_ugos/README.md
+++ b/ansible/roles/sshd_alt_port_ugos/README.md
@@ -1,0 +1,31 @@
+# sshd_alt_port_ugos Role
+
+`sshd_alt_port` for the UGREEN NAS: a **second, stock OpenSSH instance** on port 2222
+(`ssh-alt.service`, config `/etc/ssh/sshd_config_alt`), because on UGOS the Ubuntu
+role's approach — extending the stock sshd's listen config — isn't available. The
+vendor owns `sshd_config`, wraps shells/commands globally, and chroots the SFTP
+subsystem to a share view (`/docker`, `/home`, `/storage`) that does not contain the
+real filesystem.
+
+## Why
+
+Diagnosed live 2026-08-18 (rustd.xyz#456): the rustd.xyz panel's SSH credential for the
+NAS-hosted game servers could run every exec command (wipes, snapshots, seed rewrites all
+work through the wrapper), but every SFTP operation against a real path failed — Mina
+reports `SFTP error (-2): Operation unsupported`, OpenSSH's sftp shows the path simply
+absent from its chrooted view. That silently broke the panel's moderator roster, snapshot
+listing, blueprint-preservation scan, vanilla map fetch and file browser for those
+servers.
+
+A second sshd instance with a clean config keeps the same account, groups, shell
+environment and filesystem the panel's exec commands already use — only SFTP changes,
+from the vendor's share view to the real filesystem. Port 2222 matches `sshd_alt_port`
+everywhere else in the estate, and also pre-empts the Tailscale-SSH-owns-port-22 problem
+that role exists for, should the badge ever be enabled on the NAS.
+
+## What it deliberately does not do
+
+- Touch the vendor sshd, its config, or port 22 in any way.
+- Allow password auth, root, or any user beyond `sshd_alt_port_ugos_allow_users`.
+
+After deploying, point the panel's SSH credential for the NAS servers at port 2222.

--- a/ansible/roles/sshd_alt_port_ugos/defaults/main.yml
+++ b/ansible/roles/sshd_alt_port_ugos/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# Same number as sshd_alt_port's, on purpose: 2222 everywhere means one port to
+# remember, and automation credentials (the rustd.xyz panel's SSH credentials)
+# already carry a port field.
+sshd_alt_port_ugos_number: 2222
+# The only account the alternate sshd admits. Key-only, so this is belt and
+# braces, but a NAS holding every backup deserves both.
+sshd_alt_port_ugos_allow_users: jason

--- a/ansible/roles/sshd_alt_port_ugos/handlers/main.yml
+++ b/ansible/roles/sshd_alt_port_ugos/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+# Handler for the alternate-port sshd instance (ssh-alt.service); the vendor's
+# own sshd on :22 is never touched by this role.
+- name: Restart ssh-alt
+  become: true
+  ansible.builtin.systemd_service:
+    name: ssh-alt
+    state: restarted
+    daemon_reload: true

--- a/ansible/roles/sshd_alt_port_ugos/tasks/main.yml
+++ b/ansible/roles/sshd_alt_port_ugos/tasks/main.yml
@@ -1,0 +1,79 @@
+---
+# Real sshd on an alternate port, UGOS (UGREEN NAS) flavor.
+#
+# The Ubuntu hosts get their alternate port from sshd_alt_port by extending the stock
+# sshd's listen config. That approach is closed on UGOS: the vendor owns sshd_config
+# (global ForceCommand wrapper, admin-account passthrough — see rustd_backup_nas's
+# README for the field story), and its SFTP subsystem serves a chrooted share view
+# (/docker, /home, /storage) instead of the real filesystem. Shell exec passes through
+# the wrapper fine, so the rustd.xyz panel's command features (wipes, snapshots) work —
+# but every SFTP read against a real path fails ("Operation unsupported"), which is what
+# broke the panel's moderator roster, snapshot listing, blueprint scan and map fetch on
+# NAS-hosted servers (rustd.xyz#456).
+#
+# So instead of extending the vendor sshd, this runs a SECOND stock sshd instance with
+# its own clean config on the same port number sshd_alt_port uses everywhere else:
+#
+#   :22   -> vendor sshd, untouched (UGOS UI, wrapper, and whatever the vendor patches)
+#   :2222 -> stock OpenSSH: key-only auth, one allowed user, normal internal-sftp
+#
+# Same account, same groups, same filesystem as the wrapper shell — so pointing the
+# panel's credential at :2222 changes nothing about exec behaviour and simply makes
+# SFTP see the real filesystem. It also future-proofs the NAS against the Tailscale SSH
+# badge ever being enabled here (the exact port-22 interception sshd_alt_port exists for).
+#
+# The vendor config is never read or written; a firmware update that stomps
+# /etc/systemd/system or /etc/ssh/sshd_config_alt is repaired by re-running this role.
+
+- name: Install the alternate sshd config
+  become: true
+  ansible.builtin.copy:
+    dest: /etc/ssh/sshd_config_alt
+    content: |
+      # Managed by ansible (sshd_alt_port_ugos). See the role for why this exists.
+      Port {{ sshd_alt_port_ugos_number }}
+      PidFile /run/sshd-alt.pid
+      PermitRootLogin no
+      PasswordAuthentication no
+      KbdInteractiveAuthentication no
+      UsePAM yes
+      AllowUsers {{ sshd_alt_port_ugos_allow_users }}
+      X11Forwarding no
+      Subsystem sftp internal-sftp
+    owner: root
+    group: root
+    mode: "0644"
+    validate: /usr/sbin/sshd -t -f %s
+  notify: Restart ssh-alt
+
+- name: Install the ssh-alt systemd unit
+  become: true
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/ssh-alt.service
+    content: |
+      # Managed by ansible (sshd_alt_port_ugos). See the role for why this exists.
+      [Unit]
+      Description=OpenSSH on the alternate port (clean config, no UGOS wrapper)
+      After=network.target
+
+      [Service]
+      ExecStartPre=/usr/sbin/sshd -t -f /etc/ssh/sshd_config_alt
+      ExecStart=/usr/sbin/sshd -D -f /etc/ssh/sshd_config_alt
+      ExecReload=/bin/kill -HUP $MAINPID
+      KillMode=process
+      Restart=on-failure
+
+      [Install]
+      WantedBy=multi-user.target
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart ssh-alt
+
+- name: Enable and start ssh-alt
+  become: true
+  ansible.builtin.systemd_service:
+    name: ssh-alt
+    enabled: true
+    state: started
+    daemon_reload: true


### PR DESCRIPTION
Companion to rustd.xyz#456. The UGOS sshd's SFTP subsystem serves a chrooted share view (`/docker`, `/home`, `/storage`) that doesn't contain `/etc/rust`, so every panel SFTP read against the NAS-hosted servers fails (`SFTP error (-2): Operation unsupported`) while exec passes through the wrapper fine — silently breaking the moderator roster, snapshot listing, blueprint scan, map fetch and file browser for servers 1/2.

The vendor config can't be extended (global wrapper, vendor-managed sshd_config — see rustd_backup_nas's README), so this is `sshd_alt_port`'s idea in UGOS form: a second stock OpenSSH instance (`ssh-alt.service`, `/etc/ssh/sshd_config_alt`) on the estate-standard port 2222. Key-only auth, `AllowUsers jason`, normal `internal-sftp`, vendor sshd untouched. Same account/groups/filesystem as the wrapper shell, so the panel's exec behaviour is unchanged when its credential moves to :2222 — SFTP just starts seeing the real filesystem. Also pre-empts the Tailscale-SSH-owns-:22 interception if that badge is ever enabled on the NAS.

Deploy: `ansible-playbook -i inventory.yml nas.yml --tags ssh-alt --ask-become-pass`, then point the panel's NAS credential at port 2222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)