### PR TITLE
Let rustd.xyz install plugins on the Rust servers

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -31,7 +31,7 @@ collections:
   - name: compscidr.github_runner
     version: "0.1.5"
   - name: compscidr.rust_gameserver
-    version: "0.6.0"
+    version: "0.6.1"
   - name: compscidr.github_cli
     version: "0.0.16"
   - name: compscidr.onepassword

--- a/ansible/roles/rust_game/tasks/main.yml
+++ b/ansible/roles/rust_game/tasks/main.yml
@@ -83,6 +83,31 @@
         path: /etc/rust/install/weekly/oxide/plugins/RustadminOnline.cs
         state: absent
 
+    # rustd.xyz owns RustdMap now, but the copy on this host was written by an older
+    # revision of this role, so it is owned by the runtime user at 0644 and the panel --
+    # which connects as a manager user, not as the owner -- cannot replace it. Collection
+    # 0.6.1 makes the plugins DIRECTORY writable for manager users, which is enough to
+    # create a plugin but not to overwrite this one: an existing file's own mode governs
+    # that. See compscidr/rustd.xyz#469.
+    #
+    # Group write rather than `state: absent`, which would also unblock the panel: deleting
+    # it drops map rendering until somebody clicks Install, and nothing installs the plugin
+    # automatically. This leaves the server exactly as it is and lets the next panel-driven
+    # update land.
+    - name: Check for the RustdMap plugin an older revision of this role installed (weekly)
+      become: true
+      ansible.builtin.stat:
+        path: /etc/rust/install/weekly/oxide/plugins/RustdMap.cs
+      register: rust_game_weekly_rustdmap
+
+    - name: Let rustd.xyz replace that RustdMap copy (weekly)
+      become: true
+      when: rust_game_weekly_rustdmap.stat.exists
+      ansible.builtin.file:
+        path: /etc/rust/install/weekly/oxide/plugins/RustdMap.cs
+        state: file
+        mode: '0664'
+
 - name: Rust monthly server
   when: "'monthly' in rust_game_servers"
   tags: rust-monthly
@@ -154,6 +179,31 @@
       ansible.builtin.file:
         path: /etc/rust/install/monthly/oxide/plugins/RustadminOnline.cs
         state: absent
+
+    # rustd.xyz owns RustdMap now, but the copy on this host was written by an older
+    # revision of this role, so it is owned by the runtime user at 0644 and the panel --
+    # which connects as a manager user, not as the owner -- cannot replace it. Collection
+    # 0.6.1 makes the plugins DIRECTORY writable for manager users, which is enough to
+    # create a plugin but not to overwrite this one: an existing file's own mode governs
+    # that. See compscidr/rustd.xyz#469.
+    #
+    # Group write rather than `state: absent`, which would also unblock the panel: deleting
+    # it drops map rendering until somebody clicks Install, and nothing installs the plugin
+    # automatically. This leaves the server exactly as it is and lets the next panel-driven
+    # update land.
+    - name: Check for the RustdMap plugin an older revision of this role installed (monthly)
+      become: true
+      ansible.builtin.stat:
+        path: /etc/rust/install/monthly/oxide/plugins/RustdMap.cs
+      register: rust_game_monthly_rustdmap
+
+    - name: Let rustd.xyz replace that RustdMap copy (monthly)
+      become: true
+      when: rust_game_monthly_rustdmap.stat.exists
+      ansible.builtin.file:
+        path: /etc/rust/install/monthly/oxide/plugins/RustdMap.cs
+        state: file
+        mode: '0664'
 
 # ubuntu-cube.local. Not a production community server: it exists for base design, so
 # nobody but us plays on it and it never wipes on a timer. Only the host selection


### PR DESCRIPTION
compscidr/ansible-rust-gameserver#33 is merged and 0.6.1 is published on Galaxy — the pin resolves (verified by installing 0.6.1 and confirming the artifact carries `rust_gameserver_plugins_dir_mode` and the task that uses it).

Part of compscidr/rustd.xyz#469.

## Why

The panel's plugin install has never worked against these servers. `oxide/plugins` is created `0755` owned by the runtime user, so the manager account the panel connects as — in the runtime group, with no group-write bit to use — cannot create a file there. Reproduced as that account:

```
sftp> put probe.cs /etc/rust/install/build/oxide/plugins/probe.cs
dest open ".../probe.cs": Permission denied
```

Collection 0.6.1 gives that directory the same `2775` the identity directory has had since 0.4.0.

## The second half

The directory grant is necessary but not sufficient on weekly and monthly. The `RustdMap.cs` on those two hosts was installed by an older revision of *this* role — it is owned by the runtime user at `0644`, and an existing file's own mode governs the overwrite. Without the second task the panel would be able to create plugins but still not replace that one.

Group write rather than `state: absent`, which is what the `RustadminOnline` cleanup right above it does: deleting this one drops map rendering until somebody clicks Install in the panel, and nothing installs the plugin automatically. Making it writable leaves the servers exactly as they are and lets the next panel-driven update land.

The build server needs no such task — its plugins directory is empty, which is how the bug was found.

## Checks

`ansible-lint ansible/roles/rust_game/` passes (production profile). The permission facts above were read off the live hosts; the tasks themselves have not been applied anywhere yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
