### PR TITLE
Prefer the wired default route so UDP replies leave by the forwarded IP

### DIFF
--- a/ansible/roles/common_cli/files/systemd-networkd/20-wired.network
+++ b/ansible/roles/common_cli/files/systemd-networkd/20-wired.network
@@ -10,3 +10,10 @@ IPv6AcceptRA=yes
 [DHCPv4]
 UseDNS=yes
 UseRoutes=yes
+# systemd-networkd's default, stated explicitly so the wired/wireless ordering is
+# visible in both files rather than only in the one that overrides it. See
+# 25-wireless.network for why the ordering has to be decided at all.
+RouteMetric=1024
+
+[IPv6AcceptRA]
+RouteMetric=1024

--- a/ansible/roles/common_cli/files/systemd-networkd/25-wireless.network
+++ b/ansible/roles/common_cli/files/systemd-networkd/25-wireless.network
@@ -11,6 +11,16 @@ RequiredForOnline=no
 DHCP=yes
 IPv6AcceptRA=yes
 
+# Ignore carrier status - wpa_supplicant will manage the connection.
+#
+# This is a [Network] key. It sat below the [DHCPv4] header until 2026-08-18, where
+# networkd parsed it as a DHCP option and dropped it -- "Unknown key name
+# 'IgnoreCarrierLoss' in section 'DHCPv4', ignoring" on every boot -- so wifi hosts
+# have been running the default (tear down the config on carrier loss) all along.
+# Moving it up here is therefore a real behaviour change, and the intended one: brief
+# wifi flaps no longer drop the addresses and routes for the 3s it takes to come back.
+IgnoreCarrierLoss=3s
+
 [DHCPv4]
 UseDNS=yes
 UseRoutes=yes
@@ -37,9 +47,6 @@ UseRoutes=yes
 # 2048 rather than a wired-side change so wifi-only hosts (the laptops) are untouched:
 # a single default route wins whatever its metric.
 RouteMetric=2048
-
-# Ignore carrier status - wpa_supplicant will manage the connection
-IgnoreCarrierLoss=3s
 
 # Same ordering for the v6 default route, which RA installs separately and which
 # otherwise keeps the 1024 default the DHCPv4 section above no longer uses.

--- a/ansible/roles/common_cli/files/systemd-networkd/25-wireless.network
+++ b/ansible/roles/common_cli/files/systemd-networkd/25-wireless.network
@@ -14,6 +14,34 @@ IPv6AcceptRA=yes
 [DHCPv4]
 UseDNS=yes
 UseRoutes=yes
+# Wired wins; wifi stays as failover.
+#
+# On a host with BOTH links up on the same LAN, DHCP installs two default routes and
+# they used to land on the same metric (1024, the default here and in 20-wired.network),
+# which leaves the kernel free to pick either -- and the choice is not stable across
+# reboots.
+#
+# That is not cosmetic on a host behind a port forward. An inbound packet arrives on
+# the forwarded interface, but a UDP socket bound to 0.0.0.0 takes its REPLY's source
+# address from a route lookup, so the answer can go out as the other interface's IP.
+# The router has no NAT entry for that address and drops it, and a client with a
+# connected socket would discard it anyway. Found on ubuntu-cube 2026-08-18: the
+# bare-metal Rust test server (roles/rust_test_server) answered nobody outside the
+# LAN -- packets reached :30015 on the wired IP and the replies left from the wifi
+# one. TCP was unaffected and looked healthy throughout, because the kernel answers a
+# SYN using the received packet's destination as the source; only unconnected UDP
+# takes the source from routing. The dockerised servers on the same host were fine
+# too: conntrack reverses their DNAT and restores the right source address on the way
+# out, which is exactly what a bare-metal listener has nothing to do for it.
+#
+# 2048 rather than a wired-side change so wifi-only hosts (the laptops) are untouched:
+# a single default route wins whatever its metric.
+RouteMetric=2048
 
 # Ignore carrier status - wpa_supplicant will manage the connection
 IgnoreCarrierLoss=3s
+
+# Same ordering for the v6 default route, which RA installs separately and which
+# otherwise keeps the 1024 default the DHCPv4 section above no longer uses.
+[IPv6AcceptRA]
+RouteMetric=2048


### PR DESCRIPTION
## What was broken

The bare-metal Rust test server on `ubuntu-cube.local` (`roles/rust_test_server`) accepted nobody from outside the LAN. The port forward was correct, the service was healthy, and the dockerised build server on the *same host and same router* was fine.

`ubuntu-cube` has both links up on the same LAN, and DHCP installed two default routes at the same metric:

```
default via 192.168.0.1 dev wlp5s0 proto dhcp src 192.168.0.6 metric 1024
default via 192.168.0.1 dev enp3s0 proto dhcp src 192.168.0.5 metric 1024
```

The router forwards the game ports to `192.168.0.5` (wired). Inbound packets arrived there fine — but `RustDedicated`'s UDP socket is bound to `0.0.0.0`, so the kernel picked the **reply's** source address by route lookup and the tie resolved to `wlp5s0`. The router has no NAT entry for `192.168.0.6:30015`, so every answer was dropped; a client with a connected socket would have discarded it anyway.

Measured from the LAN, before the fix:

```
sent to 192.168.0.5:30016  ->  A2S reply arrived FROM 192.168.0.6:30016
connected socket:              NO REPLY — kernel discarded it (wrong source IP)
```

Since the metrics were tied, which interface won was arbitrary and **not stable across reboots** — so this can appear out of nowhere on a host that was working the day before.

### Why neither neighbour showed it

- **TCP looked healthy the whole time** (`30017` rcon and `30082` app both connected from outside): the kernel answers a SYN using the received packet's destination as the reply's source. Only unconnected UDP takes the source from routing.
- **The dockerised servers were unaffected**: conntrack reverses their DNAT and restores the original destination as the reply's source, regardless of which interface routing prefers. A bare-metal listener has nothing doing that for it — which is precisely what this server exists to be.

## The change

`RouteMetric=2048` on the wireless side, `1024` stated explicitly on the wired side so the ordering is visible in both files. Same for the v6 default route, which RA installs separately.

Set on the **wireless** side rather than lowering the wired one so wifi-only hosts (the laptops) are untouched — a single default route wins whatever its metric. Wifi stays as failover if ethernet drops.

## Verification

Deployed to `ubuntu-cube` with `common.yml --limit ubuntu-cube.local --tags network-tools`:

```
default via 192.168.0.1 dev enp3s0 proto dhcp src 192.168.0.5 metric 1024
default via 192.168.0.1 dev wlp5s0 proto dhcp src 192.168.0.6 metric 2048
159.89.157.125 via 192.168.0.1 dev enp3s0 src 192.168.0.5
```

External A2S probe from a cloud host to the public IP, after:

```
UDP 29016 build query: REPLY 9 bytes    (was: reply)
UDP 30016 test  query: REPLY 9 bytes    (was: no reply — timeout)
```

And confirmed by hand: the test server takes game connections from outside again.

## Also fixed here (review follow-up)

`IgnoreCarrierLoss=3s` sat below the `[DHCPv4]` header in `25-wireless.network`, so networkd parsed it as a DHCP option and discarded it on every boot since the file was written:

```
systemd-networkd[50965]: /etc/systemd/network/25-wireless.network:42:
  Unknown key name 'IgnoreCarrierLoss' in section 'DHCPv4', ignoring.
```

It's a `[Network]` key, and it's now in `[Network]`. Flagged as out of scope in the first draft of this PR, but the `RouteMetric` comment block widened the gap between the header and the stray key, so this branch made the file more misleading — worth fixing here rather than later.

This is a real behaviour change: wifi hosts stop tearing down addresses and routes on a carrier flap shorter than 3s, which is what the original comment intended and never got. It does not interact with the routing fix — wired is preferred at metric 1024 either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
