### PR TITLE
Put the test server's seed.env where the panel writes it

### DIFF
--- a/ansible/roles/rust_test_server/defaults/main.yml
+++ b/ansible/roles/rust_test_server/defaults/main.yml
@@ -14,6 +14,17 @@ rust_test_server_steamcmd_dir: /opt/steamcmd
 # above rather than rust_test_server_root.
 rust_test_server_home: "/home/{{ rust_test_server_user }}"
 rust_test_server_identity: test
+
+# The identity (save) directory inside the install root, and — matching the collection
+# role's `rust_gameserver_data_dir` — where seed.env belongs.
+#
+# rustd.xyz derives the seed.env it rewrites from the server's DATA path, so a seed.env
+# anywhere else is one the panel cannot write. It kept this file at the install root
+# until 2026-08-19, one level above where the panel looks: every wipe with a chosen seed
+# came back on the old map, because the write correctly refused a path that did not
+# exist (the panel never creates these files — compscidr/rustd.xyz#407) and the wipe had
+# already run its countdown by then.
+rust_test_server_data_dir: "{{ rust_test_server_root }}/server/{{ rust_test_server_identity }}"
 rust_test_server_name: "rustd.xyz test server"
 rust_test_server_description: "Test server for rustd.xyz. Wipes frequently."
 

--- a/ansible/roles/rust_test_server/tasks/main.yml
+++ b/ansible/roles/rust_test_server/tasks/main.yml
@@ -113,15 +113,43 @@
     force: true
     follow: false
 
+# Rust creates this itself on first boot, but seed.env has to be in it BEFORE that boot
+# — start.sh refuses to launch without one — so the role cannot wait for the game.
+- name: Create the save directory
+  tags: rust-test
+  become: true
+  ansible.builtin.file:
+    path: "{{ rust_test_server_data_dir }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ rust_test_server_user }}"
+    group: "{{ rust_test_server_user }}"
+
+# Moved, not recreated: this file holds the seed of the map the server is CURRENTLY
+# running, and writing a fresh one would silently change the map at the next restart.
+#
+# Ordered before the create below so that create's `force: false` sees the migrated file
+# and leaves it alone. `creates`/`removes` make this a no-op once done, and on a host
+# that never had the old layout.
+- name: Move a seed.env left at the install root by the pre-2026-08-19 layout
+  tags: rust-test
+  become: true
+  ansible.builtin.command:
+    cmd: mv {{ rust_test_server_root }}/seed.env {{ rust_test_server_data_dir }}/seed.env
+    creates: "{{ rust_test_server_data_dir }}/seed.env"
+    removes: "{{ rust_test_server_root }}/seed.env"
+
 # The seed lives in its own file so a wipe can rotate it without rewriting the launch
-# script — the same split the containerised servers use, so rustd.xyz's `sed -i` on
-# seed.env works identically against both.
+# script, and it lives in the SAVE directory because that is the path rustd.xyz derives
+# the file it rewrites from — the same place compscidr.rust_gameserver keeps it
+# (`rust_gameserver_data_dir`). Anywhere else and the panel's wipes cannot change the
+# seed at all; see rust_test_server_data_dir for what that looked like.
 - name: Create seed.env (never overwritten — wipes rotate it at runtime)
   tags: rust-test
   become: true
   ansible.builtin.copy:
     content: "RUST_SERVER_SEED={{ rust_test_server_seed }}\n"
-    dest: "{{ rust_test_server_root }}/seed.env"
+    dest: "{{ rust_test_server_data_dir }}/seed.env"
     mode: '0644'
     owner: "{{ rust_test_server_user }}"
     group: "{{ rust_test_server_user }}"

--- a/ansible/roles/rust_test_server/tasks/main.yml
+++ b/ansible/roles/rust_test_server/tasks/main.yml
@@ -135,7 +135,13 @@
   tags: rust-test
   become: true
   ansible.builtin.command:
-    cmd: mv {{ rust_test_server_root }}/seed.env {{ rust_test_server_data_dir }}/seed.env
+    # argv, not a cmd string: a path carrying whitespace — from an override, or a
+    # rust_test_server_identity someone gives a space — would otherwise split into extra
+    # arguments and mv would move the wrong thing or fail.
+    argv:
+      - mv
+      - "{{ rust_test_server_root }}/seed.env"
+      - "{{ rust_test_server_data_dir }}/seed.env"
     creates: "{{ rust_test_server_data_dir }}/seed.env"
     removes: "{{ rust_test_server_root }}/seed.env"
 

--- a/ansible/roles/rust_test_server/templates/start.sh.j2
+++ b/ansible/roles/rust_test_server/templates/start.sh.j2
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-SEED_FILE="{{ rust_test_server_root }}/seed.env"
+SEED_FILE="{{ rust_test_server_data_dir }}/seed.env"
 
 # Fail loudly rather than booting with an empty seed. Rust picks its own seed when
 # +server.seed is empty, so the running map would silently stop matching what


### PR DESCRIPTION
## Why

Every rustd.xyz wipe that chose a seed on `ubuntu-cube`'s test server came back on the **old map**. Traced on the host:

```
$ ls /opt/rust-test/server/test/seed.env   → No such file or directory   (where the panel writes)
$ cat /opt/rust-test/seed.env              → RUST_SERVER_SEED=1337       (where start.sh reads; mtime Aug 7)
journal 08:02  +server.seed "1337"  →  Generating procedural map of size 1000 with seed 1337
```

The panel derives the seed.env it rewrites from the server's **data** path. This role kept the file one level up, at the install root. The write hit a path that did not exist and was refused correctly — the panel never creates these files (compscidr/rustd.xyz#407) — but by then the wipe's countdown had run: players warned, server down, same map back.

The old task's comment claimed this matched *"the same split the containerised servers use, so rustd.xyz's seed.env rewrite works identically against both."* It didn't — `compscidr.rust_gameserver` puts seed.env in `rust_gameserver_data_dir` = `<install>/server/<identity>`, which is exactly what the panel looks at. This puts the test server on the same convention, making that claim true.

## What changes

- New `rust_test_server_data_dir` (`<root>/server/<identity>`), mirroring `rust_gameserver_data_dir`
- `seed.env` and `SEED_FILE` in `start.sh.j2` both move there
- The save directory is created by the role — the game does not make it until first boot, which is too late for a file `start.sh` reads *before* launching
- An existing `seed.env` is **moved**, not recreated: it holds the seed of the map the server is currently running, and a fresh one would silently change the map at the next restart. `creates`/`removes` make it a no-op afterwards and on a host that never had the old layout — verified on the host that a first run moves the file with its contents intact and a second run skips.

`ansible-lint` passes at the production profile.

## Deploy note

Moving the file does not disturb the running server — it read its seed at boot — and nothing here restarts the unit, so `start.sh`'s new path takes effect at the next restart.

## Not fixed here

The test server still has no `rust.env`; `start.sh.j2` templates `+server.worldsize` in directly, so a panel **size** change has nowhere to land either. With compscidr/rustd.xyz#492 that is now a clean refusal instead of a silent no-op. Worth a follow-up if the panel's size control should work against this server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)