### PR TITLE
Nightly backup of jasonernst.com goblog posts + uploads to nas

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -51,3 +51,12 @@ rustd_xyz_backup_nas_host: nas # tailnet short name - set via rustd_backup_nas_t
 # this same directory.
 rustd_xyz_backup_nas_path: /volume1/storage/backups/rustd-db
 rustd_xyz_backup_nas_keep: 30
+
+# jasonernst.com nightly goblog backup -> nas: same pipeline shape and same
+# rsync daemon as the rustd.xyz backup above, only the subpath differs. Here
+# for the same reason: the push side (jasonernst_com role, jasonernst_com.yml)
+# and the nas-side prune cron (rustd_backup_nas role, nas.yml) run in
+# separate playbooks with no shared vars_file. Only the db snapshots get
+# pruned - uploads/ is an additive mirror of the live images/files.
+jasonernst_com_backup_nas_path: /volume1/storage/backups/goblog
+jasonernst_com_backup_nas_keep: 30

--- a/ansible/jasonernst_com.yml
+++ b/ansible/jasonernst_com.yml
@@ -16,6 +16,12 @@
     fail2ban_nginx_botscan_enabled: true
     www_redirect_domains:
       - { domain: jasonernst.com, letsencrypt_email: "ernstjason1@gmail.com" }
+    # nas rsync-daemon auth for the nightly goblog backup: jason's actual nas
+    # login password (the daemon's "auth users" password on this appliance IS
+    # the account password) - same `ugnas` item the rustd_xyz pipeline uses;
+    # see roles/rustd_backup_nas/README.md.
+    jasonernst_com_backup_nas_rsync_password: "{{ lookup('community.general.onepassword', 'ugnas', field='password', vault=onepassword_vault,
+      account_id=onepassword_account_id) }}"
   roles:
     # www-redirect must run before jasonernst_com so redirect container
     # handles apex domain before app container stops serving it

--- a/ansible/roles/jasonernst_com/defaults/main.yml
+++ b/ansible/roles/jasonernst_com/defaults/main.yml
@@ -1,0 +1,34 @@
+---
+# jasonernst_com role defaults
+#
+# Nightly goblog (posts db + uploads) -> nas backup. Same pipeline shape as
+# rustd_xyz's pg_dump backup: push to the nas' BUILT-IN RSYNC DAEMON (UGOS's
+# own service, port 873) over the tailnet - not ssh. See
+# roles/rustd_xyz/templates/rustd-db-backup.sh.j2 and
+# roles/rustd_backup_nas/README.md for why ssh-based receive designs are
+# impossible on this appliance.
+#
+# The nas-side coordinates (jasonernst_com_backup_nas_path/_keep) live in
+# group_vars/all.yml because the rustd_backup_nas role's prune cron
+# (nas.yml, a separate playbook run) also reads them.
+
+jasonernst_com_backup_local_dir: /opt/goblog/backups
+jasonernst_com_backup_local_keep: 7
+
+# rsync-daemon coordinates: identical daemon/module/auth-user as the rustd
+# pipeline (there is one daemon on the nas), only the subpath differs.
+# Tailnet short name - must match rustd_backup_nas_tailnet_hostname
+# (roles/rustd_backup_nas/defaults/main.yml), the name the nas joins under.
+jasonernst_com_backup_nas_host: nas
+jasonernst_com_backup_nas_rsync_user: jason
+jasonernst_com_backup_nas_rsync_port: 873
+jasonernst_com_backup_nas_rsync_module: storage
+# Full remote path is <module>/<subpath> = /volume1/storage/backups/goblog
+# (matches jasonernst_com_backup_nas_path in group_vars/all.yml, which the
+# nas-side prune cron reads directly off disk).
+jasonernst_com_backup_nas_rsync_subpath: backups/goblog
+jasonernst_com_backup_rsync_password_file: /opt/goblog/.rsync-nas-pass
+# Filled from jasonernst_com.yml via a 1Password lookup (`ugnas` item -
+# jason's actual nas login password; the daemon's "auth users" password on
+# this appliance IS the account password). no_log'd wherever consumed.
+jasonernst_com_backup_nas_rsync_password: ""

--- a/ansible/roles/jasonernst_com/tasks/main.yml
+++ b/ansible/roles/jasonernst_com/tasks/main.yml
@@ -313,11 +313,11 @@
       LETSENCRYPT_HOST: "staging.jasonernst.com"
       LETSENCRYPT_EMAIL: "ernstjason1@gmail.com"
 
-- name: Ensure sqlite3 is installed
-  tags: website
+- name: Ensure sqlite3 and rsync are installed
+  tags: [website, backup]
   become: true
   ansible.builtin.apt:
-    name: sqlite3
+    name: [sqlite3, rsync]
     state: present
 
 - name: Set noindex on staging to prevent search engine indexing
@@ -331,3 +331,63 @@
   changed_when: false
 
 # MySQL moved to media_server role (used by Ombi on NAS)
+
+# --- Nightly goblog db + uploads -> nas backup ----------------------------
+#
+# Same pipeline shape as rustd_xyz's pg_dump backup: sqlite snapshot + rsync
+# push to the nas' built-in rsync daemon (port 873, over the tailnet - not
+# ssh; see roles/rustd_backup_nas/README.md). The nas-side prune cron for
+# these snapshots lives in rustd_backup_nas (nas.yml).
+- name: Create goblog backup directory
+  tags: backup
+  become: true
+  ansible.builtin.file:
+    path: "{{ jasonernst_com_backup_local_dir }}"
+    state: directory
+    mode: "700"
+    owner: root
+    group: root
+
+- name: Write the nas rsync-daemon password file
+  tags: backup
+  become: true
+  ansible.builtin.copy:
+    dest: "{{ jasonernst_com_backup_rsync_password_file }}"
+    content: "{{ jasonernst_com_backup_nas_rsync_password }}\n"
+    owner: root
+    group: root
+    mode: "0600"
+  no_log: true
+
+- name: Deploy the backup script
+  tags: backup
+  become: true
+  ansible.builtin.template:
+    src: goblog-backup.sh.j2
+    dest: /opt/goblog/goblog-backup.sh
+    mode: "0700"
+
+- name: Deploy the backup systemd service
+  tags: backup
+  become: true
+  ansible.builtin.template:
+    src: goblog-backup.service.j2
+    dest: /etc/systemd/system/goblog-backup.service
+    mode: "0644"
+
+- name: Deploy the backup systemd timer
+  tags: backup
+  become: true
+  ansible.builtin.template:
+    src: goblog-backup.timer.j2
+    dest: /etc/systemd/system/goblog-backup.timer
+    mode: "0644"
+
+- name: Enable and start the backup timer
+  tags: backup
+  become: true
+  ansible.builtin.systemd_service:
+    name: goblog-backup.timer
+    enabled: true
+    state: started
+    daemon_reload: true

--- a/ansible/roles/jasonernst_com/templates/goblog-backup.service.j2
+++ b/ansible/roles/jasonernst_com/templates/goblog-backup.service.j2
@@ -1,0 +1,6 @@
+[Unit]
+Description=jasonernst.com nightly goblog db + uploads backup, shipped to the nas
+
+[Service]
+Type=oneshot
+ExecStart=/opt/goblog/goblog-backup.sh

--- a/ansible/roles/jasonernst_com/templates/goblog-backup.sh.j2
+++ b/ansible/roles/jasonernst_com/templates/goblog-backup.sh.j2
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Managed by ansible (jasonernst_com role) - do not edit by hand.
+#
+# Nightly jasonernst.com backup: snapshot the prod goblog sqlite db (the
+# posts), prune local snapshots beyond {{ jasonernst_com_backup_local_keep }},
+# then push the snapshots AND the prod uploads directory (images/files) to
+# the nas over its built-in rsync daemon (UGOS's vendor-supported service,
+# port 873 - NOT ssh; see roles/rustd_backup_nas/README.md for why ssh-based
+# receive designs can't work on that appliance).
+#
+# Pushes are additive (no --delete): the nas keeps a longer retention window
+# for db snapshots ({{ jasonernst_com_backup_nas_keep }} days, pruned by a
+# root cron in the rustd_backup_nas role), and deleted uploads should
+# survive on the nas rather than be mirrored away. This script never deletes
+# anything remote.
+set -euo pipefail
+
+STAMP="$(date +%F)"
+OUT="{{ jasonernst_com_backup_local_dir }}/goblog-${STAMP}.db"
+TMP="${OUT}.tmp"
+
+# Belt-and-braces: a leftover .tmp from a previous killed/failed run must
+# not be mistaken for a valid snapshot.
+rm -f "${TMP}"
+
+# sqlite3 .backup takes a consistent snapshot even while the goblog
+# container is writing (a plain cp of a live sqlite file can be corrupt).
+# Snapshot to a temp name and only rename into place on success, so a run
+# that dies partway never leaves a truncated file at the final name for the
+# next night's push to ship as if it were a good backup.
+sqlite3 /opt/goblog/prod/database.db ".backup '${TMP}'"
+mv "${TMP}" "${OUT}"
+
+# Keep the newest {{ jasonernst_com_backup_local_keep }} local snapshots.
+# Glob scoped to *.db (not *.db.tmp) so an in-progress snapshot is never
+# pruned out from under itself.
+ls -1t {{ jasonernst_com_backup_local_dir }}/goblog-*.db | tail -n +{{ jasonernst_com_backup_local_keep | int + 1 }} | xargs -r rm --
+
+# --contimeout caps the initial connect (dead daemon / down tailnet) and
+# --timeout aborts stalled mid-transfer I/O, so a oneshot run can't hang
+# indefinitely; set -e turns either into a clean unit failure.
+RSYNC_OPTS=(-a --mkpath --contimeout=30 --timeout=300
+  --password-file={{ jasonernst_com_backup_rsync_password_file }})
+DEST="rsync://{{ jasonernst_com_backup_nas_rsync_user }}@{{ jasonernst_com_backup_nas_host }}:{{ jasonernst_com_backup_nas_rsync_port }}/{{ jasonernst_com_backup_nas_rsync_module }}/{{ jasonernst_com_backup_nas_rsync_subpath }}"
+
+# Posts (db snapshots), then images/files (uploads) - both additive.
+rsync "${RSYNC_OPTS[@]}" {{ jasonernst_com_backup_local_dir }}/ "${DEST}/db/"
+rsync "${RSYNC_OPTS[@]}" /opt/goblog/prod/uploads/ "${DEST}/uploads/"

--- a/ansible/roles/jasonernst_com/templates/goblog-backup.sh.j2
+++ b/ansible/roles/jasonernst_com/templates/goblog-backup.sh.j2
@@ -19,9 +19,11 @@ STAMP="$(date +%F)"
 OUT="{{ jasonernst_com_backup_local_dir }}/goblog-${STAMP}.db"
 TMP="${OUT}.tmp"
 
-# Belt-and-braces: a leftover .tmp from a previous killed/failed run must
-# not be mistaken for a valid snapshot.
-rm -f "${TMP}"
+# Belt-and-braces: leftover .tmp files from previous killed/failed runs
+# (any day's, not just today's) must not be mistaken for valid snapshots,
+# accumulate locally, or get pushed to the nas. Safe to sweep them all -
+# runs never overlap (systemd oneshot).
+rm -f {{ jasonernst_com_backup_local_dir }}/goblog-*.db.tmp
 
 # sqlite3 .backup takes a consistent snapshot even while the goblog
 # container is writing (a plain cp of a live sqlite file can be corrupt).
@@ -44,5 +46,9 @@ RSYNC_OPTS=(-a --mkpath --contimeout=30 --timeout=300
 DEST="rsync://{{ jasonernst_com_backup_nas_rsync_user }}@{{ jasonernst_com_backup_nas_host }}:{{ jasonernst_com_backup_nas_rsync_port }}/{{ jasonernst_com_backup_nas_rsync_module }}/{{ jasonernst_com_backup_nas_rsync_subpath }}"
 
 # Posts (db snapshots), then images/files (uploads) - both additive.
-rsync "${RSYNC_OPTS[@]}" {{ jasonernst_com_backup_local_dir }}/ "${DEST}/db/"
+# --exclude on the db push only: no in-progress .tmp can normally exist by
+# this point (swept above, renamed after snapshot), but the nas prune only
+# ever deletes goblog-*.db, so anything else that slips in would sit there
+# forever. Uploads are pushed as-is - a user file named *.tmp is still data.
+rsync "${RSYNC_OPTS[@]}" --exclude='*.tmp' {{ jasonernst_com_backup_local_dir }}/ "${DEST}/db/"
 rsync "${RSYNC_OPTS[@]}" /opt/goblog/prod/uploads/ "${DEST}/uploads/"

--- a/ansible/roles/jasonernst_com/templates/goblog-backup.timer.j2
+++ b/ansible/roles/jasonernst_com/templates/goblog-backup.timer.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Nightly jasonernst.com goblog db + uploads backup, shipped to the nas
+
+[Timer]
+OnCalendar=*-*-* 04:00:00
+Persistent=true
+RandomizedDelaySec=15m
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/rustd_backup_nas/README.md
+++ b/ansible/roles/rustd_backup_nas/README.md
@@ -15,6 +15,11 @@ That's it.
   job — the nas is the **sole owner** of nas-side retention. The push script
   (`rustd-db-backup.sh.j2`, in `rustd_xyz`) never deletes anything remote; it only prunes
   its own local copy. There is exactly one place backups on the nas get deleted from.
+- Same-shaped prune for the jasonernst.com goblog pipeline (push side: `jasonernst_com`
+  role, `jasonernst_com.yml`): db snapshots older than `jasonernst_com_backup_nas_keep`
+  under `jasonernst_com_backup_nas_path`/db. The sibling `uploads/` mirror is never
+  pruned. This role now serves two pipelines despite its rustd-specific name; rename to
+  `backup_nas` if a third lands.
 
 That's the whole role. It does **not** create a receiver user, a target directory, an
 SSH key, or any receive-side script — see "Field reality" below for why: the actual

--- a/ansible/roles/rustd_backup_nas/tasks/main.yml
+++ b/ansible/roles/rustd_backup_nas/tasks/main.yml
@@ -114,3 +114,19 @@
     job: >-
       find {{ rustd_xyz_backup_nas_path }} -maxdepth 1 -type f -name 'rustd-*.dump'
       -mtime +{{ rustd_xyz_backup_nas_keep }} -delete
+
+# Same-shaped prune for the jasonernst.com goblog pipeline (push side:
+# jasonernst_com role, jasonernst_com.yml). Only the db/ snapshots are
+# pruned - the sibling uploads/ directory is an additive mirror of the live
+# images/files and must never be aged out.
+# ponytail: this role now serves two pipelines; rename to backup_nas if a
+# third one lands.
+- name: Prune jasonernst.com backups older than the retention window
+  become: true
+  ansible.builtin.cron:
+    name: "prune jasonernst.com goblog db backups"
+    minute: "35"
+    hour: "5"
+    job: >-
+      find {{ jasonernst_com_backup_nas_path }}/db -maxdepth 1 -type f -name 'goblog-*.db'
+      -mtime +{{ jasonernst_com_backup_nas_keep }} -delete

--- a/ansible/roles/rustd_backup_nas/tasks/main.yml
+++ b/ansible/roles/rustd_backup_nas/tasks/main.yml
@@ -127,6 +127,10 @@
     name: "prune jasonernst.com goblog db backups"
     minute: "35"
     hour: "5"
+    # Directory-exists guard: the db/ dir only appears once the first push
+    # from the www droplet lands, and find on a missing path errors - which
+    # cron turns into nightly mail/log noise. Silent no-op until then.
     job: >-
+      [ -d {{ jasonernst_com_backup_nas_path }}/db ] &&
       find {{ jasonernst_com_backup_nas_path }}/db -maxdepth 1 -type f -name 'goblog-*.db'
       -mtime +{{ jasonernst_com_backup_nas_keep }} -delete


### PR DESCRIPTION
Part of #479 — the jasonernst.com www slice (posts db + images/files). Mail (`/opt/mailu`) backup is a follow-up.

## What

Mirrors the proven rustd.xyz backup pipeline end to end:

**Push side (`jasonernst_com` role, www droplet):**
- Nightly systemd timer (`goblog-backup.timer`, 04:00 + 15m jitter, `Persistent=true`).
- Script snapshots `/opt/goblog/prod/database.db` with `sqlite3 .backup` (consistent even while the container is writing — a plain `cp` of a live sqlite file can be corrupt), via tmp-name + rename so a half-written snapshot never gets shipped.
- Keeps 7 local snapshots, then rsyncs snapshots → `nas:/volume1/storage/backups/goblog/db/` and `/opt/goblog/prod/uploads/` → `.../goblog/uploads/`, over the nas' built-in rsync daemon (port 873, tailnet) — same transport, module, and 1Password `ugnas` credential as the rustd pipeline. Pushes are additive; the script never deletes anything remote.

**Receive side (`rustd_backup_nas` role, nas):**
- New root prune cron: db snapshots older than 30 days under `backups/goblog/db`. The `uploads/` mirror is never aged out. (Role now serves two pipelines despite its rustd name — noted in its README, rename when a third lands.)

Deliberately not backed up: `.env` (regenerated from 1Password by ansible), `profiles.json`/`articles.json` (scholar caches), staging (copied from prod on every play).

## Deploy

```
ansible-playbook jasonernst_com.yml --tags backup   # www droplet
ansible-playbook nas.yml --tags rustd-backup        # nas prune cron
```

Then a one-off `systemctl start goblog-backup.service` on www to prove the first push lands.

## Failure visibility

A failed run shows as a failed oneshot unit (`systemctl --failed`). No alerting yet — same posture as the rustd pipeline; worth doing once for both under #479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)