### PR TITLE
Remove legacy icmp runner from ubuntu-silverstone

### DIFF
--- a/ansible/runners.yml
+++ b/ansible/runners.yml
@@ -11,11 +11,8 @@
     - vars/deb_arch.yml
     - vars/user.yml
   roles:
-    - role: compscidr.github_runner.github_runner
-      vars:
-        github_runner_name: "icmp"
-        github_runner_repo: "compscidr/icmp"
-        github_runner_adb_port: "5039"
+    # icmp CI moved to the SAIR runner on ubuntu-cube (sair.yml); a plain
+    # self-hosted runner here matches icmp's runs-on and fails sair-acquire.
     - role: compscidr.github_runner.github_runner
       vars:
         github_runner_name: "grape"


### PR DESCRIPTION
icmp CI runs on the SAIR runner on ubuntu-cube (`sair.yml`). The plain runner deployed by the Android Runners play still matched icmp's `runs-on: self-hosted`, grabbed jobs, and failed at `sair-acquire` (no proxy on that host). It also kept coming back after manual removal because deploying the rustd java runner re-runs `runners.yml`, which recreated it.

The grape org runner on ubuntu-silverstone is untouched.

Companion change: compscidr/icmp#398 pins the workflow to `runs-on: [self-hosted, sair-enabled]` so jobs can't land on unlabeled runners regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)