### PR TITLE
Nightly backup of mailu dkim/db/mailboxes/config to nas

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -60,3 +60,11 @@ rustd_xyz_backup_nas_keep: 30
 # pruned - uploads/ is an additive mirror of the live images/files.
 jasonernst_com_backup_nas_path: /volume1/storage/backups/goblog
 jasonernst_com_backup_nas_keep: 30
+
+# mailu nightly backup -> nas (issue #479): dkim keys, admin db snapshots,
+# mailboxes, mailu.env from the www droplet. Same pipeline shape and daemon
+# as the two above; here for the same split-playbook reason. Only the db/
+# snapshots get pruned - dkim/, data/, mail/, and mailu.env are additive
+# mirrors that must never be aged out.
+mailu_backup_nas_path: /volume1/storage/backups/mailu
+mailu_backup_nas_keep: 30

--- a/ansible/jasonernst_com.yml
+++ b/ansible/jasonernst_com.yml
@@ -22,6 +22,9 @@
     # see roles/rustd_backup_nas/README.md.
     jasonernst_com_backup_nas_rsync_password: "{{ lookup('community.general.onepassword', 'ugnas', field='password', vault=onepassword_vault,
       account_id=onepassword_account_id) }}"
+    # Same credential for the mailu backup pipeline (one daemon on the nas).
+    mailu_backup_nas_rsync_password: "{{ lookup('community.general.onepassword', 'ugnas', field='password', vault=onepassword_vault,
+      account_id=onepassword_account_id) }}"
   roles:
     # www-redirect must run before jasonernst_com so redirect container
     # handles apex domain before app container stops serving it

--- a/ansible/roles/mailu/defaults/main.yml
+++ b/ansible/roles/mailu/defaults/main.yml
@@ -146,3 +146,26 @@ mailu_images:
   fetchmail:
     image: ghcr.io/mailu/fetchmail
     digest: "sha256:f9f1385196f5b5c4bda9fcf21e0d089392cdeec7435c1c664001494900684427"
+
+# --- Nightly mailu -> nas backup (issue #479) ------------------------------
+#
+# Same pipeline shape as the goblog and rustd.xyz backups: push to the nas'
+# BUILT-IN RSYNC DAEMON (port 873) over the tailnet - not ssh. See
+# roles/rustd_backup_nas/README.md. The nas-side coordinates
+# (mailu_backup_nas_path/_keep) live in group_vars/all.yml because the
+# rustd_backup_nas role's prune cron (nas.yml, a separate playbook run) also
+# reads them.
+mailu_backup_local_dir: "{{ mailu_install_path }}/backups"
+mailu_backup_local_keep: 7
+mailu_backup_nas_host: nas # must match rustd_backup_nas_tailnet_hostname
+mailu_backup_nas_rsync_user: jason
+mailu_backup_nas_rsync_port: 873
+mailu_backup_nas_rsync_module: storage
+# Full remote path is <module>/<subpath> = /volume1/storage/backups/mailu
+# (matches mailu_backup_nas_path in group_vars/all.yml).
+mailu_backup_nas_rsync_subpath: backups/mailu
+mailu_backup_rsync_password_file: "{{ mailu_install_path }}/.rsync-nas-pass"
+# Filled from jasonernst_com.yml via a 1Password lookup (`ugnas` item -
+# jason's actual nas login password; the daemon's "auth users" password on
+# this appliance IS the account password). no_log'd wherever consumed.
+mailu_backup_nas_rsync_password: ""

--- a/ansible/roles/mailu/tasks/main.yml
+++ b/ansible/roles/mailu/tasks/main.yml
@@ -259,3 +259,71 @@
   loop_control:
     label: "{{ item.item }}"
   when: item.stdout | default('') | trim | length == 0
+
+# --- Nightly mailu -> nas backup (issue #479) ------------------------------
+#
+# dkim keys, admin sqlite db, mailboxes, and mailu.env - the parts the April
+# server wipe permanently lost. Same pipeline shape as goblog-backup
+# (jasonernst_com role): sqlite snapshot + additive rsync to the nas' rsync
+# daemon over the tailnet. The nas-side prune cron for the db snapshots
+# lives in rustd_backup_nas (nas.yml).
+- name: Ensure sqlite3 and rsync are installed
+  tags: backup
+  become: true
+  ansible.builtin.apt:
+    name: [sqlite3, rsync]
+    state: present
+
+- name: Create mailu backup directory
+  tags: backup
+  become: true
+  ansible.builtin.file:
+    path: "{{ mailu_backup_local_dir }}"
+    state: directory
+    mode: "700"
+    owner: root
+    group: root
+
+- name: Write the nas rsync-daemon password file
+  tags: backup
+  become: true
+  ansible.builtin.copy:
+    dest: "{{ mailu_backup_rsync_password_file }}"
+    content: "{{ mailu_backup_nas_rsync_password }}\n"
+    owner: root
+    group: root
+    mode: "0600"
+  no_log: true
+
+- name: Deploy the backup script
+  tags: backup
+  become: true
+  ansible.builtin.template:
+    src: mailu-backup.sh.j2
+    dest: "{{ mailu_install_path }}/mailu-backup.sh"
+    mode: "0700"
+
+- name: Deploy the backup systemd service
+  tags: backup
+  become: true
+  ansible.builtin.template:
+    src: mailu-backup.service.j2
+    dest: /etc/systemd/system/mailu-backup.service
+    mode: "0644"
+
+- name: Deploy the backup systemd timer
+  tags: backup
+  become: true
+  ansible.builtin.template:
+    src: mailu-backup.timer.j2
+    dest: /etc/systemd/system/mailu-backup.timer
+    mode: "0644"
+
+- name: Enable and start the backup timer
+  tags: backup
+  become: true
+  ansible.builtin.systemd_service:
+    name: mailu-backup.timer
+    enabled: true
+    state: started
+    daemon_reload: true

--- a/ansible/roles/mailu/templates/mailu-backup.service.j2
+++ b/ansible/roles/mailu/templates/mailu-backup.service.j2
@@ -1,0 +1,6 @@
+[Unit]
+Description=mailu nightly dkim/db/mailboxes/config backup, shipped to the nas
+
+[Service]
+Type=oneshot
+ExecStart={{ mailu_install_path }}/mailu-backup.sh

--- a/ansible/roles/mailu/templates/mailu-backup.sh.j2
+++ b/ansible/roles/mailu/templates/mailu-backup.sh.j2
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Managed by ansible (mailu role) - do not edit by hand.
+#
+# Nightly mailu backup (issue #479): the parts of /opt/mailu that are NOT
+# reproducible from IaC, pushed to the nas over its built-in rsync daemon
+# (port 873, over the tailnet - NOT ssh; see roles/rustd_backup_nas/README.md
+# for why ssh-based receive designs can't work on that appliance):
+#
+#   dkim/     - signing keys (tiny, critical: losing these silently breaks
+#               outbound mail - the April wipe proved it)
+#   data/     - admin sqlite db (accounts, domains, aliases) + instance files
+#   mail/     - mailboxes (dovecot maildir - per-file crash-safe, so an
+#               rsync while dovecot runs is a usable backup; indexes rebuild)
+#   mailu.env - config (templated by ansible, but tiny and the issue asks
+#               for it - a restore shouldn't depend on a working controller)
+#
+# NOT backed up: redis/ (transient queue/rate-limit state), mailqueue/,
+# filter/, webmail/, overrides/ (empty/templated - all recreated by the
+# role).
+#
+# Pushes are additive (no --delete): db snapshots keep a longer window on
+# the nas ({{ mailu_backup_nas_keep }} days, pruned by a root cron in the
+# rustd_backup_nas role), and deleted mail should survive on the nas rather
+# than be mirrored away. This script never deletes anything remote.
+set -euo pipefail
+
+STAMP="$(date +%F)"
+OUT="{{ mailu_backup_local_dir }}/mailu-${STAMP}.db"
+TMP="${OUT}.tmp"
+
+# Sweep leftover .tmp files from previous killed/failed runs (any day's) so
+# they can't be mistaken for valid snapshots or accumulate. Safe - runs
+# never overlap (systemd oneshot).
+rm -f {{ mailu_backup_local_dir }}/mailu-*.db.tmp
+
+# sqlite3 .backup takes a consistent snapshot even while the admin container
+# is writing (a plain cp of a live sqlite file can be corrupt). Temp name +
+# rename so a run that dies partway never leaves a truncated file at the
+# final name for the next night's push to ship as a good backup.
+sqlite3 /opt/mailu/data/main.db ".backup '${TMP}'"
+mv "${TMP}" "${OUT}"
+
+# Keep the newest {{ mailu_backup_local_keep }} local snapshots. Glob scoped
+# to *.db (not *.db.tmp) so an in-progress snapshot is never pruned out from
+# under itself.
+ls -1t {{ mailu_backup_local_dir }}/mailu-*.db | tail -n +{{ mailu_backup_local_keep | int + 1 }} | xargs -r rm --
+
+# --contimeout caps the initial connect (dead daemon / down tailnet) and
+# --timeout aborts stalled mid-transfer I/O, so a oneshot run can't hang
+# indefinitely; set -e turns either into a clean unit failure.
+RSYNC_OPTS=(-a --mkpath --contimeout=30 --timeout=300
+  --password-file={{ mailu_backup_rsync_password_file }})
+DEST="rsync://{{ mailu_backup_nas_rsync_user }}@{{ mailu_backup_nas_host }}:{{ mailu_backup_nas_rsync_port }}/{{ mailu_backup_nas_rsync_module }}/{{ mailu_backup_nas_rsync_subpath }}"
+
+# db snapshots: --exclude '*.tmp' as belt-and-braces (swept above, but the
+# nas prune only ever deletes mailu-*.db, so anything else would sit there
+# forever).
+rsync "${RSYNC_OPTS[@]}" --exclude='*.tmp' {{ mailu_backup_local_dir }}/ "${DEST}/db/"
+
+# data/ mirror: the live main.db (and its -wal/-shm journals) is excluded -
+# a raw copy of it mid-write can be corrupt, and the consistent snapshot
+# above already covers it. The rest (instance keys, fetchmail state, ...)
+# copies fine as plain files.
+rsync "${RSYNC_OPTS[@]}" --exclude='main.db' --exclude='main.db-*' /opt/mailu/data/ "${DEST}/data/"
+
+rsync "${RSYNC_OPTS[@]}" /opt/mailu/dkim/ "${DEST}/dkim/"
+rsync "${RSYNC_OPTS[@]}" /opt/mailu/mail/ "${DEST}/mail/"
+rsync "${RSYNC_OPTS[@]}" /opt/mailu/mailu.env "${DEST}/"

--- a/ansible/roles/mailu/templates/mailu-backup.sh.j2
+++ b/ansible/roles/mailu/templates/mailu-backup.sh.j2
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Managed by ansible (mailu role) - do not edit by hand.
 #
-# Nightly mailu backup (issue #479): the parts of /opt/mailu that are NOT
+# Nightly mailu backup (issue #479): the parts of {{ mailu_install_path }} that are NOT
 # reproducible from IaC, pushed to the nas over its built-in rsync daemon
 # (port 873, over the tailnet - NOT ssh; see roles/rustd_backup_nas/README.md
 # for why ssh-based receive designs can't work on that appliance):
@@ -37,7 +37,7 @@ rm -f {{ mailu_backup_local_dir }}/mailu-*.db.tmp
 # is writing (a plain cp of a live sqlite file can be corrupt). Temp name +
 # rename so a run that dies partway never leaves a truncated file at the
 # final name for the next night's push to ship as a good backup.
-sqlite3 /opt/mailu/data/main.db ".backup '${TMP}'"
+sqlite3 {{ mailu_install_path }}/data/main.db ".backup '${TMP}'"
 mv "${TMP}" "${OUT}"
 
 # Keep the newest {{ mailu_backup_local_keep }} local snapshots. Glob scoped
@@ -61,8 +61,8 @@ rsync "${RSYNC_OPTS[@]}" --exclude='*.tmp' {{ mailu_backup_local_dir }}/ "${DEST
 # a raw copy of it mid-write can be corrupt, and the consistent snapshot
 # above already covers it. The rest (instance keys, fetchmail state, ...)
 # copies fine as plain files.
-rsync "${RSYNC_OPTS[@]}" --exclude='main.db' --exclude='main.db-*' /opt/mailu/data/ "${DEST}/data/"
+rsync "${RSYNC_OPTS[@]}" --exclude='main.db' --exclude='main.db-*' {{ mailu_install_path }}/data/ "${DEST}/data/"
 
-rsync "${RSYNC_OPTS[@]}" /opt/mailu/dkim/ "${DEST}/dkim/"
-rsync "${RSYNC_OPTS[@]}" /opt/mailu/mail/ "${DEST}/mail/"
-rsync "${RSYNC_OPTS[@]}" /opt/mailu/mailu.env "${DEST}/"
+rsync "${RSYNC_OPTS[@]}" {{ mailu_install_path }}/dkim/ "${DEST}/dkim/"
+rsync "${RSYNC_OPTS[@]}" {{ mailu_install_path }}/mail/ "${DEST}/mail/"
+rsync "${RSYNC_OPTS[@]}" {{ mailu_install_path }}/mailu.env "${DEST}/"

--- a/ansible/roles/mailu/templates/mailu-backup.timer.j2
+++ b/ansible/roles/mailu/templates/mailu-backup.timer.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Nightly mailu dkim/db/mailboxes/config backup, shipped to the nas
+
+[Timer]
+# 04:45 keeps it clear of goblog-backup (04:00 + 15m jitter) on the same
+# host, so the two pushes don't contend for the nas daemon or the uplink.
+OnCalendar=*-*-* 04:45:00
+Persistent=true
+RandomizedDelaySec=15m
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/rustd_backup_nas/README.md
+++ b/ansible/roles/rustd_backup_nas/README.md
@@ -15,11 +15,14 @@ That's it.
   job — the nas is the **sole owner** of nas-side retention. The push script
   (`rustd-db-backup.sh.j2`, in `rustd_xyz`) never deletes anything remote; it only prunes
   its own local copy. There is exactly one place backups on the nas get deleted from.
-- Same-shaped prune for the jasonernst.com goblog pipeline (push side: `jasonernst_com`
-  role, `jasonernst_com.yml`): db snapshots older than `jasonernst_com_backup_nas_keep`
-  under `jasonernst_com_backup_nas_path`/db. The sibling `uploads/` mirror is never
-  pruned. This role now serves two pipelines despite its rustd-specific name; rename to
-  `backup_nas` if a third lands.
+- Same-shaped prunes for the jasonernst.com goblog and mailu pipelines (push sides:
+  `jasonernst_com` and `mailu` roles, both in `jasonernst_com.yml`): db snapshots older
+  than `jasonernst_com_backup_nas_keep` / `mailu_backup_nas_keep` under each pipeline's
+  `db/` directory. The sibling mirrors (goblog `uploads/`; mailu `dkim/`, `data/`,
+  `mail/`, `mailu.env`) are never pruned. This role now serves three pipelines despite
+  its rustd-specific name — the rename to `backup_nas` was considered and deferred: it
+  touches runbook tags (`--tags rustd-backup`) and a dozen prose references for zero
+  function.
 
 That's the whole role. It does **not** create a receiver user, a target directory, an
 SSH key, or any receive-side script — see "Field reality" below for why: the actual

--- a/ansible/roles/rustd_backup_nas/tasks/main.yml
+++ b/ansible/roles/rustd_backup_nas/tasks/main.yml
@@ -119,8 +119,10 @@
 # jasonernst_com role, jasonernst_com.yml). Only the db/ snapshots are
 # pruned - the sibling uploads/ directory is an additive mirror of the live
 # images/files and must never be aged out.
-# ponytail: this role now serves two pipelines; rename to backup_nas if a
-# third one lands.
+# ponytail: the third pipeline (mailu) landed and the role kept its rustd
+# name anyway - the rename touches runbook tags (`--tags rustd-backup`) and
+# a dozen prose references for zero function. Rename only if the tag/docs
+# churn ever becomes worth it.
 - name: Prune jasonernst.com backups older than the retention window
   become: true
   ansible.builtin.cron:
@@ -134,3 +136,18 @@
       [ -d {{ jasonernst_com_backup_nas_path }}/db ] &&
       find {{ jasonernst_com_backup_nas_path }}/db -maxdepth 1 -type f -name 'goblog-*.db'
       -mtime +{{ jasonernst_com_backup_nas_keep }} -delete
+
+# Same-shaped prune for the mailu pipeline (push side: mailu role,
+# jasonernst_com.yml). Only the db/ snapshots are pruned - dkim/, data/,
+# mail/, and mailu.env are additive mirrors that must never be aged out.
+# Directory-exists guard for the same first-push reason as above.
+- name: Prune mailu backups older than the retention window
+  become: true
+  ansible.builtin.cron:
+    name: "prune mailu db backups"
+    minute: "40"
+    hour: "5"
+    job: >-
+      [ -d {{ mailu_backup_nas_path }}/db ] &&
+      find {{ mailu_backup_nas_path }}/db -maxdepth 1 -type f -name 'mailu-*.db'
+      -mtime +{{ mailu_backup_nas_keep }} -delete


### PR DESCRIPTION
Completes the www-droplet half of #479 (mail slice — the goblog slice landed in #530). Backs up exactly what the April wipe permanently lost.

## What

Same pipeline as #530, third instance of the pattern:

**Push side (`mailu` role, www droplet):**
- Nightly systemd timer (`mailu-backup.timer`, 04:45 + 15m jitter, `Persistent=true` — offset from the 04:00 goblog push on the same host).
- Snapshots the admin sqlite DB (`data/main.db` — accounts, domains, aliases) with `sqlite3 .backup` (tmp + rename, stale-tmp sweep, same hardening as #530).
- Pushes to `nas:/volume1/storage/backups/mailu/`: db snapshots → `db/`, plus additive mirrors of `dkim/` (the keys whose silent loss caused the 3-month DKIM outage), `data/` (live db + journals excluded — the snapshot covers it), `mail/` (dovecot maildir — per-file crash-safe, rsync while running is a usable backup), and `mailu.env`. Never deletes anything remote.
- Skipped as reproducible or transient: `redis/`, `mailqueue/`, `filter/`, `webmail/`, `overrides/`.

**Receive side (`rustd_backup_nas` role, nas):**
- Prune cron for db snapshots >30 days, directory-guarded until the first push lands. Mirrors are never aged out.
- The marker promising a rename to `backup_nas` on a third pipeline: considered and deferred — it touches runbook tags (`--tags rustd-backup`) and a dozen prose references for zero function. Marker and README updated to say so.

## Deploy

```
ansible-playbook jasonernst_com.yml --tags backup   # www droplet (goblog tasks re-run, no-op)
ansible-playbook nas.yml --tags rustd-backup        # nas prune cron
```

Then a one-off `systemctl start mailu-backup.service` on www; first run moves the full mailboxes so it'll take a while, nights after are incremental. Verify `dkim/*.dkim.key` files landed on the nas — they're the crown jewels here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)