### PR TITLE
Backup freshness alerting to discord #dev-alerts

### DIFF
--- a/ansible/nas.yml
+++ b/ansible/nas.yml
@@ -32,7 +32,13 @@
         - monthly
     # - cs2_game
     - dyndns
-    - { role: rustd_backup_nas, tags: [rustd, rustd-backup] }
+    - role: rustd_backup_nas
+      tags: [rustd, rustd-backup]
+      # Discord #dev-alerts channel webhook for the backup freshness check
+      # (a plain webhook URL - no bot). Item must exist before this play
+      # runs - a onepassword lookup for a missing item is a hard failure.
+      rustd_backup_nas_discord_webhook: "{{ lookup('community.general.onepassword', 'discord-dev-alerts', field='credential', vault=onepassword_vault,
+        account_id=onepassword_account_id) }}"
     # Real sshd on :2222 (the UGOS counterpart of sshd_alt_port): the vendor sshd's
     # SFTP is chrooted to the share view, which broke the rustd.xyz panel's file
     # reads for the servers above — see the role README and rustd.xyz#456.

--- a/ansible/roles/jasonernst_com/templates/goblog-backup.sh.j2
+++ b/ansible/roles/jasonernst_com/templates/goblog-backup.sh.j2
@@ -45,10 +45,14 @@ RSYNC_OPTS=(-a --mkpath --contimeout=30 --timeout=300
   --password-file={{ jasonernst_com_backup_rsync_password_file }})
 DEST="rsync://{{ jasonernst_com_backup_nas_rsync_user }}@{{ jasonernst_com_backup_nas_host }}:{{ jasonernst_com_backup_nas_rsync_port }}/{{ jasonernst_com_backup_nas_rsync_module }}/{{ jasonernst_com_backup_nas_rsync_subpath }}"
 
-# Posts (db snapshots), then images/files (uploads) - both additive.
+# Images/files (uploads) first, posts (db snapshots) LAST - both additive.
+# Order matters: the nas-side freshness check (rustd_backup_nas role) uses
+# the newest db snapshot as the "this run succeeded" marker, so it must be
+# the final transfer - a fresh marker then implies the uploads push
+# succeeded too.
 # --exclude on the db push only: no in-progress .tmp can normally exist by
 # this point (swept above, renamed after snapshot), but the nas prune only
 # ever deletes goblog-*.db, so anything else that slips in would sit there
 # forever. Uploads are pushed as-is - a user file named *.tmp is still data.
-rsync "${RSYNC_OPTS[@]}" --exclude='*.tmp' {{ jasonernst_com_backup_local_dir }}/ "${DEST}/db/"
 rsync "${RSYNC_OPTS[@]}" /opt/goblog/prod/uploads/ "${DEST}/uploads/"
+rsync "${RSYNC_OPTS[@]}" --exclude='*.tmp' {{ jasonernst_com_backup_local_dir }}/ "${DEST}/db/"

--- a/ansible/roles/mailu/templates/mailu-backup.sh.j2
+++ b/ansible/roles/mailu/templates/mailu-backup.sh.j2
@@ -52,11 +52,11 @@ RSYNC_OPTS=(-a --mkpath --contimeout=30 --timeout=300
   --password-file={{ mailu_backup_rsync_password_file }})
 DEST="rsync://{{ mailu_backup_nas_rsync_user }}@{{ mailu_backup_nas_host }}:{{ mailu_backup_nas_rsync_port }}/{{ mailu_backup_nas_rsync_module }}/{{ mailu_backup_nas_rsync_subpath }}"
 
-# db snapshots: --exclude '*.tmp' as belt-and-braces (swept above, but the
-# nas prune only ever deletes mailu-*.db, so anything else would sit there
-# forever).
-rsync "${RSYNC_OPTS[@]}" --exclude='*.tmp' {{ mailu_backup_local_dir }}/ "${DEST}/db/"
-
+# Mirrors first, db snapshots LAST. Order matters: the nas-side freshness
+# check (rustd_backup_nas role) uses the newest db snapshot as the "this
+# run succeeded" marker, so it must be the final transfer - a fresh marker
+# then implies every mirror push succeeded too.
+#
 # data/ mirror: the live main.db (and its -wal/-shm journals) is excluded -
 # a raw copy of it mid-write can be corrupt, and the consistent snapshot
 # above already covers it. The rest (instance keys, fetchmail state, ...)
@@ -66,3 +66,8 @@ rsync "${RSYNC_OPTS[@]}" --exclude='main.db' --exclude='main.db-*' {{ mailu_inst
 rsync "${RSYNC_OPTS[@]}" {{ mailu_install_path }}/dkim/ "${DEST}/dkim/"
 rsync "${RSYNC_OPTS[@]}" {{ mailu_install_path }}/mail/ "${DEST}/mail/"
 rsync "${RSYNC_OPTS[@]}" {{ mailu_install_path }}/mailu.env "${DEST}/"
+
+# db snapshots: --exclude '*.tmp' as belt-and-braces (swept above, but the
+# nas prune only ever deletes mailu-*.db, so anything else would sit there
+# forever).
+rsync "${RSYNC_OPTS[@]}" --exclude='*.tmp' {{ mailu_backup_local_dir }}/ "${DEST}/db/"

--- a/ansible/roles/rustd_backup_nas/README.md
+++ b/ansible/roles/rustd_backup_nas/README.md
@@ -24,6 +24,16 @@ That's it.
   touches runbook tags (`--tags rustd-backup`) and a dozen prose references for zero
   function.
 
+- Daily backup freshness check (08:00 cron) — a dead-man's switch for **all three**
+  pipelines: if a pipeline's newest db snapshot on the nas is older than
+  `rustd_backup_nas_freshness_max_age_hours` (26h — catches a single missed night on the
+  first morning), it posts to discord #dev-alerts via a channel webhook (1Password item
+  `discord-dev-alerts`, no bot). Checking arrival here rather than hooking run failures
+  on the droplets covers every silent-stop mode with one mechanism — failed run, dead
+  timer, dead droplet, broken tailnet, broken rsync auth. The push scripts send their db
+  snapshot **last**, so a fresh marker means that night's whole run (mirrors included)
+  succeeded. Silent when everything is fresh.
+
 That's the whole role. It does **not** create a receiver user, a target directory, an
 SSH key, or any receive-side script — see "Field reality" below for why: the actual
 receive path is the nas' own rsync daemon, which owns all of that itself.

--- a/ansible/roles/rustd_backup_nas/defaults/main.yml
+++ b/ansible/roles/rustd_backup_nas/defaults/main.yml
@@ -25,3 +25,24 @@
 # tailnet. Set explicitly rather than left to default to the appliance's
 # own hostname (DXP8800PLUS-3F06), which must never become the tailnet name.
 rustd_backup_nas_tailnet_hostname: nas
+
+# --- Backup freshness alerting (issue #479) --------------------------------
+#
+# Daily dead-man's switch: alert to discord #dev-alerts when a pipeline's
+# newest db snapshot on the nas is older than the threshold. One check per
+# pipeline; the dirs/globs come from the shared coordinates in
+# group_vars/all.yml. The db snapshot is each push script's LAST transfer,
+# so a fresh one means that night's whole run succeeded.
+rustd_backup_nas_freshness_checks:
+  - { name: rustd-db, dir: "{{ rustd_xyz_backup_nas_path }}", glob: "rustd-*.dump" }
+  - { name: goblog, dir: "{{ jasonernst_com_backup_nas_path }}/db", glob: "goblog-*.db" }
+  - { name: mailu, dir: "{{ mailu_backup_nas_path }}/db", glob: "mailu-*.db" }
+# Pushes run nightly ~04:00-05:00, the check at 08:00: a normal night shows
+# ~3-4h, a single missed night ~28h. 26 catches one missed night on the
+# first morning after.
+rustd_backup_nas_freshness_max_age_hours: 26
+# Discord channel webhook URL (a plain URL - no bot). 0600 root file;
+# filled from nas.yml via a 1Password lookup (`discord-dev-alerts` item,
+# Infrastructure vault, `credential` field). no_log'd wherever consumed.
+rustd_backup_nas_webhook_file: /root/.backup-alert-webhook
+rustd_backup_nas_discord_webhook: ""

--- a/ansible/roles/rustd_backup_nas/tasks/main.yml
+++ b/ansible/roles/rustd_backup_nas/tasks/main.yml
@@ -151,3 +151,38 @@
       [ -d {{ mailu_backup_nas_path }}/db ] &&
       find {{ mailu_backup_nas_path }}/db -maxdepth 1 -type f -name 'mailu-*.db'
       -mtime +{{ mailu_backup_nas_keep }} -delete
+
+# --- Backup freshness alerting (issue #479) --------------------------------
+#
+# See backup-freshness-check.py.j2's header for the design: a nas-side
+# dead-man's switch beats per-unit OnFailure hooks on the droplets because
+# it also catches the timer/host/tailnet dying - the silent-stop modes that
+# motivated #479 in the first place.
+- name: Write the discord webhook file
+  become: true
+  ansible.builtin.copy:
+    dest: "{{ rustd_backup_nas_webhook_file }}"
+    content: "{{ rustd_backup_nas_discord_webhook }}\n"
+    owner: root
+    group: root
+    mode: "0600"
+  no_log: true
+
+- name: Deploy the backup freshness check script
+  become: true
+  ansible.builtin.template:
+    src: backup-freshness-check.py.j2
+    dest: /usr/local/bin/backup-freshness-check.py
+    owner: root
+    group: root
+    mode: "0700"
+
+# 08:00, after every pipeline's nightly push window (~04:00-05:00) and this
+# role's own prune crons (05:30-05:40).
+- name: Check backup freshness daily and alert to discord
+  become: true
+  ansible.builtin.cron:
+    name: "backup freshness check -> discord"
+    minute: "0"
+    hour: "8"
+    job: /usr/local/bin/backup-freshness-check.py

--- a/ansible/roles/rustd_backup_nas/tasks/main.yml
+++ b/ansible/roles/rustd_backup_nas/tasks/main.yml
@@ -158,6 +158,18 @@
 # dead-man's switch beats per-unit OnFailure hooks on the droplets because
 # it also catches the timer/host/tailnet dying - the silent-stop modes that
 # motivated #479 in the first place.
+# Fast-fail guard: the role's default is an empty string (the real value is
+# injected in nas.yml from 1Password), and deploying that would mean a blank
+# webhook file and a cron that errors every morning - the exact silent-ish
+# failure this feature exists to prevent.
+- name: Ensure the discord webhook is configured
+  ansible.builtin.assert:
+    that: rustd_backup_nas_discord_webhook | length > 0
+    fail_msg: >-
+      rustd_backup_nas_discord_webhook is empty - set it from the 1Password
+      `discord-dev-alerts` item (see nas.yml) before deploying the freshness check.
+    quiet: true
+
 - name: Write the discord webhook file
   become: true
   ansible.builtin.copy:

--- a/ansible/roles/rustd_backup_nas/templates/backup-freshness-check.py.j2
+++ b/ansible/roles/rustd_backup_nas/templates/backup-freshness-check.py.j2
@@ -52,4 +52,5 @@ if stale:
         data=json.dumps({"content": content[:2000]}).encode(),
         headers={"Content-Type": "application/json", "User-Agent": "backup-freshness-check"},
     )
-    urllib.request.urlopen(req, timeout=30)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        resp.read()

--- a/ansible/roles/rustd_backup_nas/templates/backup-freshness-check.py.j2
+++ b/ansible/roles/rustd_backup_nas/templates/backup-freshness-check.py.j2
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Managed by ansible (rustd_backup_nas role) - do not edit by hand.
+#
+# Daily dead-man's switch for every backup pipeline landing on this nas
+# (issue #479): if the newest freshness marker in a pipeline's directory is
+# older than the threshold, post to discord (#dev-alerts, via a channel
+# webhook - no bot involved). Checking arrival on the nas rather than
+# hooking run failures on the droplets covers every silent-stop mode with
+# one mechanism: failed run, dead timer, dead droplet, broken tailnet,
+# broken rsync auth. "A backup that silently stops is how we got here."
+#
+# The markers are the db snapshots, which the push scripts deliberately
+# send LAST - a fresh marker therefore means the whole run (mirrors
+# included) succeeded that night.
+#
+# Silent when everything is fresh. If this script itself dies (webhook
+# revoked, discord down), cron mails/logs the traceback - the watcher
+# failing is at least not silent either.
+import glob
+import json
+import os
+import time
+import urllib.request
+
+CHECKS = [
+{% for c in rustd_backup_nas_freshness_checks %}
+    ("{{ c.name }}", "{{ c.dir }}", "{{ c.glob }}"),
+{% endfor %}
+]
+MAX_AGE_HOURS = {{ rustd_backup_nas_freshness_max_age_hours }}
+
+stale = []
+now = time.time()
+for name, directory, pattern in CHECKS:
+    files = glob.glob(os.path.join(directory, pattern))
+    if not files:
+        stale.append(f"**{name}**: no `{pattern}` files in `{directory}` at all")
+        continue
+    age_h = (now - max(os.path.getmtime(f) for f in files)) / 3600
+    if age_h > MAX_AGE_HOURS:
+        stale.append(f"**{name}**: newest backup is {age_h:.0f}h old (expected < {MAX_AGE_HOURS}h)")
+
+if stale:
+    content = (
+        "\N{WARNING SIGN} **backups have stopped landing on the nas:**\n"
+        + "\n".join(f"- {s}" for s in stale)
+    )
+    with open("{{ rustd_backup_nas_webhook_file }}") as f:
+        webhook = f.read().strip()
+    req = urllib.request.Request(
+        webhook,
+        data=json.dumps({"content": content[:2000]}).encode(),
+        headers={"Content-Type": "application/json", "User-Agent": "backup-freshness-check"},
+    )
+    urllib.request.urlopen(req, timeout=30)


### PR DESCRIPTION
The alerting/visibility piece of #479 — "a backup that silently stops is how we got here."

## Design: dead-man's switch on the nas, not OnFailure hooks on the droplets

One mechanism, checked where the truth lives: a daily 08:00 root cron on the nas verifies each pipeline's newest db snapshot (`rustd-db`, `goblog`, `mailu`) is under 26h old, and posts to discord #dev-alerts when one is stale or missing entirely. This catches every silent-stop mode — failed run, dead timer, dead droplet, broken tailnet, broken rsync auth — where per-unit `OnFailure=` hooks only catch a run that fires *and* fails. Threshold math: pushes land ~04:00–05:00, so a normal morning shows ~3–4h and a single missed night shows ~28h — 26h alerts on the first morning after one miss.

To make the marker meaningful, the goblog and mailu push scripts now send their db snapshot **last**: a fresh snapshot implies every mirror push (uploads / dkim / data / mail / mailu.env) succeeded that night. (rustd's script only pushes dumps, already fine.)

The checker is stdlib-python3, posts via `urllib` to a discord **channel webhook** (no bot, no library), is silent when everything is fresh, and if the checker itself dies the cron logs the traceback — the watcher failing is at least not silent either. Rendered and functionally tested against a local HTTP server: stale + missing pipelines alert in one message, all-fresh posts nothing.

## Manual prerequisite (before deploying)

1. Discord: **#dev-alerts → Edit Channel → Integrations → Webhooks → New Webhook** (name it e.g. `iac-backups`), copy the URL.
2. 1Password: Infrastructure vault, new item **`discord-dev-alerts`**, URL in the **`credential`** field.

The lookup hard-fails if the item is missing, so do this first.

## Deploy

```
ansible-playbook nas.yml --tags rustd-backup          # webhook file + checker + cron
ansible-playbook jasonernst_com.yml --tags backup     # reordered push scripts
```

To see a real post in #dev-alerts once: on the nas, temporarily lower the bar and run it —
`sudo sed -i 's/^MAX_AGE_HOURS = .*/MAX_AGE_HOURS = 0/' /usr/local/bin/backup-freshness-check.py && sudo /usr/local/bin/backup-freshness-check.py` — then re-run `nas.yml --tags rustd-backup` to restore the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)