### PR TITLE
openclaw: manage Discord channel allowlist and session/tool config

### DIFF
--- a/ansible/openclaw.yml
+++ b/ansible/openclaw.yml
@@ -76,6 +76,11 @@
         enabled: true
       dev-alerts:
         enabled: false
+    # Web search on this host: pinned explicitly rather than left to the
+    # role defaults, so search stays on even if the defaults are ever
+    # made opt-in. Needs openclaw_brave_api_key (below).
+    openclaw_web_search_provider: brave
+    openclaw_web_search_enabled: true
     # Claude OAuth blob — Infrastructure vault (default `onepassword_vault`).
     openclaw_claude_credentials: >-
       {{ lookup('community.general.onepassword',

--- a/ansible/openclaw.yml
+++ b/ansible/openclaw.yml
@@ -61,6 +61,21 @@
     # openclaw role vars
     openclaw_workspace_repo: "git@github.com:compscidr/kai-workspace.git"
     openclaw_tailscale_serve: true
+    # Per-channel allowlist for the guild. Keyed by channel *name* (the
+    # resolver matches id -> slug -> name -> parent -> "*"), so no
+    # Discord snowflakes land in this public repo.
+    #
+    # This mirrors the state configured by hand on the host today: the
+    # map is an allowlist, and with no "*" entry every channel except
+    # #openclaw-bot is dropped — including #general. The explicit
+    # dev-alerts entry is redundant under that reading but documents
+    # that it was deliberately muted. If the intent is "everything
+    # except dev-alerts", add `"*": {enabled: true}` here.
+    openclaw_discord_channels:
+      openclaw-bot:
+        enabled: true
+      dev-alerts:
+        enabled: false
     # Claude OAuth blob — Infrastructure vault (default `onepassword_vault`).
     openclaw_claude_credentials: >-
       {{ lookup('community.general.onepassword',

--- a/ansible/roles/openclaw/defaults/main.yml
+++ b/ansible/roles/openclaw/defaults/main.yml
@@ -89,6 +89,52 @@ openclaw_discord_bot_token: ""
 openclaw_discord_guild_id: ""
 openclaw_brave_api_key: ""
 
+# Discord group-message policy for the channel as a whole. `allowlist` is
+# also the runtime fallback when no policy is set, but pinning it here
+# means a fresh provision can't silently drift to `open` if the upstream
+# default ever changes — an open policy would let any member of the
+# guild drive the agent.
+openclaw_discord_group_policy: "allowlist"
+
+# Per-channel enable map, merged into
+# `channels.discord.guilds.<guildId>.channels`.
+#
+# IMPORTANT: this map is an *allowlist*. The moment it holds a single
+# entry, every channel without a matching entry resolves to
+# `allowed: false` and inbound messages are dropped. So a map that only
+# disables one channel silences the entire guild — you need a `"*"`
+# entry alongside it to keep the rest live.
+#
+# Keys are matched in the order: channel ID -> slug -> name -> parent ->
+# `"*"`, so plain channel names work and are preferred here (readable,
+# and no Discord snowflakes committed to a public repo). Name matching
+# is skipped for threads, which fall back to their parent channel's
+# keys.
+#
+# Empty map (the default) leaves the key unset, which means "all
+# channels allowed" — the role only manages this when a host opts in.
+#
+# Example:
+#   openclaw_discord_channels:
+#     "*": {enabled: true}
+#     noisy-channel: {enabled: false}
+openclaw_discord_channels: {}
+
+# Session scoping for DMs. `per-channel-peer` gives each (channel, peer)
+# pair its own session, so a DM on Discord and a DM on another channel
+# from the same person don't share history.
+openclaw_session_dm_scope: "per-channel-peer"
+
+# Tool profile the agent runs with. `coding` enables the file/exec/patch
+# tool set this host is used for; the stock default is narrower.
+openclaw_tools_profile: "coding"
+
+# Web search wiring. The provider must match an installed plugin
+# (`brave` is installed via openclaw_plugins below and needs
+# openclaw_brave_api_key set). Empty provider disables both tasks.
+openclaw_web_search_provider: "brave"
+openclaw_web_search_enabled: true
+
 # Plugins to install via `openclaw plugins install clawhub:<id>`.
 # 2026.5.7+ moved Discord and Brave out of the bundled set; channels
 # and tools won't work without them.

--- a/ansible/roles/openclaw/defaults/main.yml
+++ b/ansible/roles/openclaw/defaults/main.yml
@@ -100,10 +100,10 @@ openclaw_discord_group_policy: "allowlist"
 # `channels.discord.guilds.<guildId>.channels`.
 #
 # IMPORTANT: this map is an *allowlist*. The moment it holds a single
-# entry, every channel without a matching entry resolves to
-# `allowed: false` and inbound messages are dropped. So a map that only
-# disables one channel silences the entire guild — you need a `"*"`
-# entry alongside it to keep the rest live.
+# entry, every channel without a matching entry is blocked (as if it
+# had `enabled: false`) and its inbound messages are dropped. So a map
+# that only disables one channel silences the entire guild — you need a
+# `"*"` entry alongside it to keep the rest live.
 #
 # Keys are matched in the order: channel ID -> slug -> name -> parent ->
 # `"*"`, so plain channel names work and are preferred here (readable,

--- a/ansible/roles/openclaw/tasks/main.yml
+++ b/ansible/roles/openclaw/tasks/main.yml
@@ -293,15 +293,48 @@
     - config
     - discord
 
+# Discord group policy. `allowlist` is the runtime fallback anyway, but
+# writing it explicitly stops a fresh provision from drifting to `open`
+# (which would let any guild member drive the agent) if the upstream
+# default changes.
+- name: Set Discord group policy
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: >-
+    openclaw config set channels.discord.groupPolicy
+    {{ openclaw_discord_group_policy | quote }}
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  when: openclaw_discord_group_policy | length > 0
+  register: openclaw_discord_policy_set
+  changed_when: "'Updated' in (openclaw_discord_policy_set.stdout | default(''))"
+  notify: Restart openclaw-gateway
+  tags:
+    - openclaw
+    - config
+    - discord
+
 # Discord guild config: requireMention=false so the bot replies to plain
 # channel messages (the 2026.5.7 plugin requires an explicit guild ID;
-# `"*"` wildcard keys are accepted by the schema but no-op at runtime).
-- name: Set Discord guild requireMention
+# `"*"` wildcard keys are accepted by the schema but no-op at runtime),
+# plus the optional per-channel enable map.
+#
+# `openclaw config set ... --strict-json` replaces the value at the path
+# wholesale, so this task writes the *complete* guild object. Anything
+# not represented in these vars is dropped on every run — which is why
+# `channels` has to be folded in here rather than set by a second task.
+# See openclaw_discord_channels in defaults/main.yml for the allowlist
+# semantics of that map.
+- name: Set Discord guild config
   become: true
   become_user: "{{ openclaw_user }}"
   ansible.builtin.command: >-
     openclaw config set channels.discord.guilds
-    {{ {openclaw_discord_guild_id: {'requireMention': false}} | to_json | quote }}
+    {{ {openclaw_discord_guild_id: {'requireMention': false}
+        | combine({'channels': openclaw_discord_channels}
+                  if openclaw_discord_channels else {})}
+       | to_json | quote }}
     --strict-json
   environment:
     PATH: "{{ openclaw_path }}"
@@ -448,6 +481,80 @@
     - openclaw
     - config
     - exo
+
+# DM session scoping. Without this, DMs from the same person across
+# different channels collapse into one session and leak context between
+# surfaces.
+- name: Set session dmScope
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: >-
+    openclaw config set session.dmScope {{ openclaw_session_dm_scope | quote }}
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  when: openclaw_session_dm_scope | length > 0
+  register: openclaw_dm_scope_set
+  changed_when: "'Updated' in (openclaw_dm_scope_set.stdout | default(''))"
+  notify: Restart openclaw-gateway
+  tags:
+    - openclaw
+    - config
+
+# Tool profile. The stock default is narrower than what this host is
+# used for; `coding` turns on the file/exec/patch tool set.
+- name: Set tools profile
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: >-
+    openclaw config set tools.profile {{ openclaw_tools_profile | quote }}
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  when: openclaw_tools_profile | length > 0
+  register: openclaw_tools_profile_set
+  changed_when: "'Updated' in (openclaw_tools_profile_set.stdout | default(''))"
+  notify: Restart openclaw-gateway
+  tags:
+    - openclaw
+    - config
+
+# Web search provider selection. Set as two scalar writes rather than one
+# object write so we don't clobber any other tools.web.search subkeys the
+# runtime adds later. The provider needs its plugin installed and keyed
+# (brave, above) or search calls fail at runtime.
+- name: Set web search provider
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: >-
+    openclaw config set tools.web.search.provider {{ openclaw_web_search_provider | quote }}
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  when: openclaw_web_search_provider | length > 0
+  register: openclaw_web_search_provider_set
+  changed_when: "'Updated' in (openclaw_web_search_provider_set.stdout | default(''))"
+  notify: Restart openclaw-gateway
+  tags:
+    - openclaw
+    - config
+
+- name: Set web search enabled
+  become: true
+  become_user: "{{ openclaw_user }}"
+  ansible.builtin.command: >-
+    openclaw config set tools.web.search.enabled
+    {{ openclaw_web_search_enabled | string | lower }}
+  environment:
+    PATH: "{{ openclaw_path }}"
+    HOME: "/home/{{ openclaw_user }}"
+  when: openclaw_web_search_provider | length > 0
+  register: openclaw_web_search_enabled_set
+  changed_when: "'Updated' in (openclaw_web_search_enabled_set.stdout | default(''))"
+  notify: Restart openclaw-gateway
+  tags:
+    - openclaw
+    - config
 
 # Enable memory-core "dreaming" mode (offline review/consolidation
 # cycle). Bundled plugin, no separate install — just a config flip.


### PR DESCRIPTION
What's in it:
• Fixed the clobber — Set Discord guild config now folds the channel map into the same --strict-json write instead of replacing the guild object with just requireMention
• New openclaw_discord_channels var, keyed by channel name (resolver matches id → slug → name → parent → *) so no snowflakes go in the public repo
• Documented the allowlist trap in the role defaults — the "one entry and everything else goes silent" thing
• Also now managed: groupPolicy, session.dmScope, tools.profile, tools.web.search.{provider,enabled}

I rendered every new task's Jinja against the real values to check the JSON comes out right (had to inline the guild expression — repo doesn't set jinja2_native, so a vars: intermediate would've stringified the dict). Couldn't run ansible-lint locally, no pip on this host — CI will catch it.

One thing I did not decide for you: right now there's no "*" entry, so #general is silenced too, not just #dev-alerts. I encoded that as-is since it's the current live state. If you actually meant "everything except dev-alerts", add "*": {enabled: true} to the map in openclaw.yml — there's a comment there pointing at it.