### PR TITLE
hermes: give kai his own GitHub and 1Password access

### DIFF
--- a/ansible/hermes.yml
+++ b/ansible/hermes.yml
@@ -82,6 +82,16 @@
                 field='private key',
                 vault=hermes_op_vault,
                 service_account_token=hermes_op_service_account_token) }}
+    # Kai's own tooling credentials. The SA token is the same one the
+    # lookups above authenticate with — handing it to kai gives him the
+    # same reach into his own vault that this play has.
+    hermes_op_token_for_agent: "{{ hermes_op_service_account_token }}"
+    hermes_github_token: >-
+      {{ lookup('community.general.onepassword',
+                'GH cli',
+                field='credential',
+                vault=hermes_op_vault,
+                service_account_token=hermes_op_service_account_token) }}
     # Dashboard login — see roles/hermes/defaults/main.yml. The
     # plaintext password is in the same 1P item, for you to log in with.
     hermes_dashboard_username: >-

--- a/ansible/hermes.yml
+++ b/ansible/hermes.yml
@@ -82,6 +82,26 @@
                 field='private key',
                 vault=hermes_op_vault,
                 service_account_token=hermes_op_service_account_token) }}
+    # Dashboard login — see roles/hermes/defaults/main.yml. The
+    # plaintext password is in the same 1P item, for you to log in with.
+    hermes_dashboard_username: >-
+      {{ lookup('community.general.onepassword',
+                'hermes dashboard',
+                field='username',
+                vault=hermes_op_vault,
+                service_account_token=hermes_op_service_account_token) }}
+    hermes_dashboard_password_hash: >-
+      {{ lookup('community.general.onepassword',
+                'hermes dashboard',
+                field='password hash',
+                vault=hermes_op_vault,
+                service_account_token=hermes_op_service_account_token) }}
+    hermes_dashboard_session_secret: >-
+      {{ lookup('community.general.onepassword',
+                'hermes dashboard',
+                field='session secret',
+                vault=hermes_op_vault,
+                service_account_token=hermes_op_service_account_token) }}
     hermes_discord_bot_token: >-
       {{ lookup('community.general.onepassword',
                 'discord hermes',

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -1,13 +1,18 @@
 ---
 # Local hosts use .local (mDNS) - works on LAN even if Tailscale is down
-# Cloud hosts use Tailscale short names (www, mail, projects)
+# Cloud hosts use Tailscale short names (www, projects, hermes)
+#
+# There is no `mail` host: mail and the website are the same droplet.
+# Terraform names it mail.jasonernst.com (for the PTR record) but joins
+# the tailnet as `www`, and jasonernst_com.yml runs the mailu role
+# there. A `mail` entry used to sit in the groups below and resolved to
+# nothing, so every `hosts: all` play logged an unreachable host.
 # Use --limit 'ubuntu-beast*' to match by prefix
 
 ungrouped:
   hosts:
     www:
     nas.local:
-    mail:
     projects:
     hermes:
 academic_gui:
@@ -49,7 +54,6 @@ sair:
 tailscale:
   hosts:
     www:
-    mail:
     projects:
     hermes:
 linux:

--- a/ansible/roles/hermes/defaults/main.yml
+++ b/ansible/roles/hermes/defaults/main.yml
@@ -79,3 +79,18 @@ hermes_ssh_private_key: ""
 # and from nowhere else. 9119 is hermes's own default.
 hermes_dashboard_enabled: true
 hermes_dashboard_port: 9119
+# Bind to the tailnet name rather than loopback. The dashboard rejects
+# any request whose Host header doesn't match what it bound to (a DNS
+# rebinding guard), so a loopback bind behind Tailscale Serve answers
+# every request with "Invalid Host header" — Serve forwards the real
+# hostname. Binding the real name also makes hermes require an auth
+# provider, which is why the basic_auth credentials below are not
+# optional.
+hermes_dashboard_host: "hermes.tail21090.ts.net"
+# Username/password gate (hermes's bundled dashboard_auth/basic
+# plugin). Empty username = plugin no-op, which a non-loopback bind
+# refuses to start with. Hash and session secret come from 1Password;
+# the plaintext password lives there too, for logging in.
+hermes_dashboard_username: ""
+hermes_dashboard_password_hash: ""
+hermes_dashboard_session_secret: ""

--- a/ansible/roles/hermes/defaults/main.yml
+++ b/ansible/roles/hermes/defaults/main.yml
@@ -94,3 +94,18 @@ hermes_dashboard_host: "hermes.tail21090.ts.net"
 hermes_dashboard_username: ""
 hermes_dashboard_password_hash: ""
 hermes_dashboard_session_secret: ""
+
+# Kai's own tooling. `gh` and `op` let him work with his GitHub account
+# and read his own credentials out of 1Password, rather than needing a
+# human to paste secrets into a chat window.
+#
+# The service-account token is the sensitive part: it opens the whole
+# `hermes` vault. That vault holds only kai's own credentials (his
+# GitHub, his mail account, moltbook), which is the containment — a
+# prompt-injected agent can reach kai's things and nothing of Jason's.
+# Keep it that way when adding items.
+hermes_agent_cli_enabled: true
+hermes_op_token_for_agent: ""
+hermes_github_token: ""
+hermes_git_user_name: "Kai"
+hermes_git_user_email: "kai@jasonernst.com"

--- a/ansible/roles/hermes/tasks/main.yml
+++ b/ansible/roles/hermes/tasks/main.yml
@@ -228,7 +228,10 @@
     - systemd
     - dashboard
 
-# Publish the loopback dashboard on the tailnet over HTTPS. Tailscale
+# Publish the dashboard on the tailnet over HTTPS. The proxy target has
+# to be the same address the dashboard binds to: it no longer listens on
+# loopback (see hermes_dashboard_host), so a localhost target would
+# connect to nothing. Tailscale
 # terminates TLS with the node's own cert and only tailnet peers
 # permitted by the ACL can reach it, which is what stands in for the
 # auth provider hermes would demand on a public bind. `serve` config is
@@ -236,7 +239,7 @@
 - name: Serve the dashboard on the tailnet
   become: true
   ansible.builtin.command:
-    cmd: tailscale serve --bg --https=443 http://localhost:{{ hermes_dashboard_port }}
+    cmd: tailscale serve --bg --https=443 http://{{ hermes_dashboard_host }}:{{ hermes_dashboard_port }}
   register: hermes_tailscale_serve
   changed_when: "'Available within your tailnet' in (hermes_tailscale_serve.stdout | default(''))"
   when: hermes_dashboard_enabled

--- a/ansible/roles/hermes/tasks/main.yml
+++ b/ansible/roles/hermes/tasks/main.yml
@@ -245,3 +245,174 @@
     - tailscale
     - dashboard
     - molecule-notest
+
+# --- Kai's own CLI tooling: GitHub and 1Password ---------------------
+
+- name: Install apt repository prereqs
+  become: true
+  ansible.builtin.apt:
+    name:
+      - python3-debian
+      - gnupg
+    state: present
+    update_cache: true
+  when: hermes_agent_cli_enabled
+  tags: [hermes, cli]
+
+- name: Fetch GitHub CLI signing key
+  become: true
+  ansible.builtin.get_url:
+    url: https://cli.github.com/packages/githubcli-archive-keyring.gpg
+    dest: /usr/share/keyrings/githubcli-archive-keyring.gpg
+    mode: "0644"
+  when: hermes_agent_cli_enabled
+  tags: [hermes, cli]
+
+- name: Add GitHub CLI repository
+  become: true
+  ansible.builtin.deb822_repository:
+    name: github-cli
+    state: present
+    types: [deb]
+    uris: https://cli.github.com/packages
+    suites: [stable]
+    components: [main]
+    architectures: [amd64]
+    signed_by: /usr/share/keyrings/githubcli-archive-keyring.gpg
+    enabled: true
+  when: hermes_agent_cli_enabled
+  tags: [hermes, cli]
+
+- name: Fetch 1Password signing key
+  become: true
+  ansible.builtin.get_url:
+    url: https://downloads.1password.com/linux/keys/1password.asc
+    dest: /usr/share/keyrings/1password.asc
+    mode: "0644"
+  when: hermes_agent_cli_enabled
+  tags: [hermes, cli]
+
+- name: Add 1Password CLI repository
+  become: true
+  ansible.builtin.deb822_repository:
+    name: 1password
+    state: present
+    types: [deb]
+    uris: https://downloads.1password.com/linux/debian/amd64
+    suites: [stable]
+    components: [main]
+    architectures: [amd64]
+    signed_by: /usr/share/keyrings/1password.asc
+    enabled: true
+  when: hermes_agent_cli_enabled
+  tags: [hermes, cli]
+
+# 1Password ships its packages with debsig signatures and apt refuses
+# them without a matching policy installed. Their published key id is
+# the directory name; it is not a secret.
+- name: Create 1Password debsig directories
+  become: true
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - /etc/debsig/policies/AC2D62742012EA22
+    - /usr/share/debsig/keyrings/AC2D62742012EA22
+  when: hermes_agent_cli_enabled
+  tags: [hermes, cli]
+
+- name: Install 1Password debsig policy
+  become: true
+  ansible.builtin.get_url:
+    url: https://downloads.1password.com/linux/debian/debsig/1password.pol
+    dest: /etc/debsig/policies/AC2D62742012EA22/1password.pol
+    mode: "0644"
+  when: hermes_agent_cli_enabled
+  tags: [hermes, cli]
+
+- name: Install 1Password debsig keyring
+  become: true
+  ansible.builtin.shell: |
+    set -euo pipefail
+    curl -sS https://downloads.1password.com/linux/keys/1password.asc |
+      gpg --dearmor --yes --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
+  args:
+    creates: /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
+    executable: /bin/bash
+  when: hermes_agent_cli_enabled
+  tags: [hermes, cli]
+
+- name: Install gh and op
+  become: true
+  ansible.builtin.apt:
+    name:
+      - gh
+      - 1password-cli
+    state: present
+    update_cache: true
+  when: hermes_agent_cli_enabled
+  tags: [hermes, cli]
+
+# Kai's credentials reach his tools through the gateway's environment,
+# which every command he runs inherits. Two deliberate choices here:
+#
+#   - A systemd *drop-in*, not the unit file. Hermes rewrites
+#     hermes-gateway.service whenever it thinks the definition drifted,
+#     which would silently drop an EnvironmentFile added there. It does
+#     not touch the .d directory.
+#   - GH_TOKEN rather than `gh auth login`. gh reads the env var
+#     directly, so there is no auth state on disk to go stale and
+#     nothing to make idempotent.
+- name: Deploy kai's credential environment
+  become: true
+  become_user: "{{ hermes_user }}"
+  ansible.builtin.template:
+    src: agent-secrets.env.j2
+    dest: "{{ hermes_config_dir }}/agent-secrets.env"
+    mode: "0600"
+  when: hermes_agent_cli_enabled
+  no_log: true
+  notify: Restart hermes-gateway
+  tags: [hermes, cli, secrets]
+
+- name: Ensure gateway drop-in directory exists
+  become: true
+  become_user: "{{ hermes_user }}"
+  ansible.builtin.file:
+    path: "/home/{{ hermes_user }}/.config/systemd/user/hermes-gateway.service.d"
+    state: directory
+    mode: "0755"
+  when: hermes_agent_cli_enabled
+  tags: [hermes, cli, systemd]
+
+- name: Load kai's credentials into the gateway environment
+  become: true
+  become_user: "{{ hermes_user }}"
+  ansible.builtin.copy:
+    content: |
+      # {{ ansible_managed }}
+      # A drop-in survives hermes rewriting its own unit file.
+      # The leading "-" makes the file optional: these credentials are
+      # for kai's tools, and Discord does not depend on them, so a
+      # missing file should not take him offline.
+      [Service]
+      EnvironmentFile=-{{ hermes_config_dir }}/agent-secrets.env
+    dest: "/home/{{ hermes_user }}/.config/systemd/user/hermes-gateway.service.d/10-agent-secrets.conf"
+    mode: "0644"
+  when: hermes_agent_cli_enabled
+  notify: Restart hermes-gateway
+  tags: [hermes, cli, systemd]
+
+- name: Set kai's git identity
+  become: true
+  become_user: "{{ hermes_user }}"
+  community.general.git_config:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    scope: global
+  loop:
+    - {name: user.name, value: "{{ hermes_git_user_name }}"}
+    - {name: user.email, value: "{{ hermes_git_user_email }}"}
+  when: hermes_agent_cli_enabled
+  tags: [hermes, cli, git]

--- a/ansible/roles/hermes/templates/agent-secrets.env.j2
+++ b/ansible/roles/hermes/templates/agent-secrets.env.j2
@@ -1,0 +1,15 @@
+# {{ ansible_managed }}
+# Kai's own credentials, loaded into the gateway environment (see the
+# systemd drop-in) so the commands he runs inherit them.
+#
+# OP_SERVICE_ACCOUNT_TOKEN opens the `hermes` vault — his GitHub, his
+# mail account, moltbook. Nothing of Jason's is in there, and that
+# separation is the containment for an agent that takes instructions
+# from Discord. `op read op://hermes/<item>/<field>` is how he fetches
+# one.
+{% if hermes_op_token_for_agent %}
+OP_SERVICE_ACCOUNT_TOKEN={{ hermes_op_token_for_agent }}
+{% endif %}
+{% if hermes_github_token %}
+GH_TOKEN={{ hermes_github_token }}
+{% endif %}

--- a/ansible/roles/hermes/templates/env.j2
+++ b/ansible/roles/hermes/templates/env.j2
@@ -6,6 +6,15 @@
 # on every call to a provider whose key it can't resolve. See the
 # key_env fields in config.yaml.
 LOCAL_MODEL_API_KEY=no-key-required
+
+# Dashboard login. Env wins over config.yaml for these, and keeping them
+# here rather than in config.yaml means no plaintext hash in a
+# world-readable-ish settings file.
+{% if hermes_dashboard_username %}
+HERMES_DASHBOARD_BASIC_AUTH_USERNAME={{ hermes_dashboard_username }}
+HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH={{ hermes_dashboard_password_hash }}
+HERMES_DASHBOARD_BASIC_AUTH_SECRET={{ hermes_dashboard_session_secret }}
+{% endif %}
 DISCORD_BOT_TOKEN={{ hermes_discord_bot_token }}
 DISCORD_ALLOWED_USERS={{ hermes_discord_allowed_users }}
 DISCORD_ALLOWED_CHANNELS={{ hermes_discord_allowed_channels }}

--- a/ansible/roles/hermes/templates/env.j2
+++ b/ansible/roles/hermes/templates/env.j2
@@ -10,7 +10,9 @@ LOCAL_MODEL_API_KEY=no-key-required
 # Dashboard login. Env wins over config.yaml for these, and keeping them
 # here rather than in config.yaml means no plaintext hash in a
 # world-readable-ish settings file.
-{% if hermes_dashboard_username %}
+{# All three or none: a half-configured gate fails at login with no
+   useful error, which is worse than leaving the plugin a no-op. #}
+{% if hermes_dashboard_username and hermes_dashboard_password_hash and hermes_dashboard_session_secret %}
 HERMES_DASHBOARD_BASIC_AUTH_USERNAME={{ hermes_dashboard_username }}
 HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH={{ hermes_dashboard_password_hash }}
 HERMES_DASHBOARD_BASIC_AUTH_SECRET={{ hermes_dashboard_session_secret }}

--- a/ansible/roles/hermes/templates/hermes-dashboard.service.j2
+++ b/ansible/roles/hermes/templates/hermes-dashboard.service.j2
@@ -6,10 +6,12 @@
 Description=Hermes Agent dashboard (web UI)
 
 [Service]
-# Bound to loopback on purpose: hermes refuses to serve a non-loopback
-# bind without its own auth provider, and Tailscale Serve fronts this
-# with tailnet identity instead (see the serve task in tasks/main.yml).
-ExecStart={{ hermes_bin }} dashboard --no-open --host 127.0.0.1 --port {{ hermes_dashboard_port }}
+# Bound to the tailnet hostname, not loopback: the dashboard matches the
+# Host header against whatever it bound to, so a loopback bind behind
+# Tailscale Serve rejects every proxied request. The bind is gated by
+# the basic_auth credentials in ~/.hermes/.env, and Tailscale Serve adds
+# HTTPS on top (see the serve task in tasks/main.yml).
+ExecStart={{ hermes_bin }} dashboard --no-open --host {{ hermes_dashboard_host }} --port {{ hermes_dashboard_port }}
 Environment="HERMES_HOME={{ hermes_config_dir }}"
 Restart=on-failure
 RestartSec=10


### PR DESCRIPTION
Items 6 & 8 from the follow-up list. **Stacked on #540** — merge that first, or this diff will show its commits too.

## What it does
- Installs `gh` and `1password-cli` from their official apt repos (including 1Password's debsig policy, which apt requires or the package is refused).
- Deploys kai's credentials to `~/.hermes/agent-secrets.env` (0600, `no_log`) and loads them into the gateway environment, which every command he runs inherits:
  - `OP_SERVICE_ACCOUNT_TOKEN` → `op read op://hermes/<item>/<field>` for his own secrets (the moltbook credential his memory refers to, his mail account).
  - `GH_TOKEN` → gh against his own account, no `gh auth login` state on disk to go stale.
- Sets his git identity (Kai / kai@jasonernst.com) so his commits are attributed to him.

## Two implementation details worth reviewing
- **The EnvironmentFile is a systemd drop-in**, not an edit to the unit. Hermes rewrites `hermes-gateway.service` whenever it decides the definition drifted (we watched it do exactly that in #539), which would silently drop a reference added to the unit itself. It leaves the `.d` directory alone.
- **`-EnvironmentFile=`** — the `-` makes it optional. These credentials are for kai's tooling; Discord doesn't need them, so a missing file shouldn't take him offline.

## Security notes, both worth a decision
1. **Containment is the vault boundary.** The service-account token opens the `hermes` vault, which holds only kai's own credentials. A prompt-injected agent reaches kai's things and nothing of Jason's — worth preserving when adding items to that vault.
2. **His GitHub token is over-scoped.** Verified live: it's valid and belongs to `kai-clawd` (his account, not Jason's), but carries `admin:org`, `delete_repo`, `admin:enterprise`, `admin:public_key`, `workflow`, and more. Actual reach is narrower than that reads — one org (`goblogplatform`) with admin on 2 repos — but `delete_repo` plus admin still means an injected agent could destroy those, and `admin:public_key` would let it add its own SSH key to his account for persistence. **Recommend minting a fine-grained token scoped to just the repos he works in with contents:write**, and replacing the `GH cli` item. The wiring here is unchanged either way.

Verified: both lookups resolve (`GH cli` token is live, authenticates as kai-clawd), ansible-lint clean, playbook syntax-checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)